### PR TITLE
feat(ci): adicionar workflow de auto-tag e release

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,51 @@
+name: Auto Tag
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-tag-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Create Semantic Tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute and create next tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+          default_bump: false
+          fetch_all_tags: true
+          create_annotated_tag: true
+          tag_prefix: v
+
+      - name: Job summary
+        run: |
+          echo "previous_tag=${{ steps.tag_version.outputs.previous_tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "new_tag=${{ steps.tag_version.outputs.new_tag }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "release_type=${{ steps.tag_version.outputs.release_type }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create GitHub release
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+          generateReleaseNotes: false


### PR DESCRIPTION
Closes #1

---

## 🎯 Objetivo

Adicionar o workflow de auto-tag semântica e criação de release no GitHub para `main`.

---

## 🧠 Decisão Técnica

Foi adotado `mathieudutour/github-tag-action` para cálculo/versionamento semântico e `ncipollo/release-action` para publicação da release com changelog do próprio cálculo.

---

## 🧪 BDD Validado

Dado que há push em `main` com commits convencionais
Quando o workflow `Auto Tag` executa
Então uma nova tag semântica e release correspondente são geradas.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [ ] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [ ] PATCH
- [x] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
