### PR TITLE
feat(setup): definir estrutura de pastas do serviço

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ npm run test
 npm run sls:print:dev
 npm run sls:package:dev
 ```
+
+## Estrutura de pastas
+
+```text
+src/
+  handlers/    # Entradas Lambda
+  domain/      # Casos de uso e regras de negócio
+  infra/       # Adaptadores de infraestrutura
+  shared/      # Utilitários compartilhados
+tests/         # Testes automatizados
+```
+
+Detalhes e convenções estão em `src/README.md`.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,22 @@
+# Estrutura de pastas do código-fonte
+
+## Princípios
+
+- `handlers` expõem entrypoints Lambda e coordenam fluxo.
+- `domain` centraliza regras de negócio sem dependência de AWS.
+- `infra` implementa acesso a serviços externos e persistência.
+- `shared` concentra utilitários reutilizáveis entre módulos.
+
+## Fluxo recomendado
+
+`handler -> domain -> infra` e `shared` pode ser usado por qualquer camada.
+
+## Árvore atual
+
+```text
+src/
+  handlers/
+  domain/
+  infra/
+  shared/
+```

--- a/src/domain/scheduler/list-eligible-sources.js
+++ b/src/domain/scheduler/list-eligible-sources.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Domain use-case for loading source IDs that can run in the current tick.
+ * Infrastructure details are hidden behind the repository contract.
+ */
+async function listEligibleSources({ sourceRepository, now }) {
+  return sourceRepository.listEligibleSourceIds({ now });
+}
+
+module.exports = {
+  listEligibleSources
+};

--- a/src/handlers/scheduler.js
+++ b/src/handlers/scheduler.js
@@ -1,8 +1,20 @@
 'use strict';
 
-module.exports.handler = async () => {
+const { listEligibleSources } = require('../domain/scheduler/list-eligible-sources');
+const {
+  createInMemorySourceRepository
+} = require('../infra/sources/in-memory-source-repository');
+const { nowIso } = require('../shared/time/now-iso');
+
+module.exports.handler = async (event = {}) => {
+  const sourceRepository = createInMemorySourceRepository();
+  const sourceIds = await listEligibleSources({
+    sourceRepository,
+    now: event.now
+  });
+
   return {
-    sourceIds: [],
-    generatedAt: new Date().toISOString()
+    sourceIds,
+    generatedAt: nowIso()
   };
 };

--- a/src/infra/sources/in-memory-source-repository.js
+++ b/src/infra/sources/in-memory-source-repository.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function createInMemorySourceRepository(seed = []) {
+  return {
+    async listEligibleSourceIds() {
+      return seed.map((source) => source.sourceId);
+    }
+  };
+}
+
+module.exports = {
+  createInMemorySourceRepository
+};

--- a/src/shared/time/now-iso.js
+++ b/src/shared/time/now-iso.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function nowIso(clock = () => new Date()) {
+  return clock().toISOString();
+}
+
+module.exports = {
+  nowIso
+};

--- a/tests/unit/handlers/scheduler.test.js
+++ b/tests/unit/handlers/scheduler.test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { handler } = require('../../../src/handlers/scheduler');
+
+test('scheduler handler returns expected payload', async () => {
+  const result = await handler();
+
+  assert.deepEqual(result.sourceIds, []);
+  assert.equal(typeof result.generatedAt, 'string');
+  assert.equal(Number.isNaN(Date.parse(result.generatedAt)), false);
+});


### PR DESCRIPTION
Closes #18

---

## 🎯 Objetivo

Definir uma estrutura base de pastas para o serviço (`handlers`, `domain`, `infra`, `shared`, `tests`), com documentação e exemplo funcional aplicado no `scheduler`.

---

## 🧠 Decisão Técnica

Separação em camadas com fluxo `handler -> domain -> infra`, mantendo utilitários transversais em `shared`.
Refatorado o `scheduler` para consumir um caso de uso de domínio e adaptador de infraestrutura, reduzindo lógica inline no handler.

---

## 🧪 BDD Validado

Dado que o scheduler é executado
Quando o handler processa uma execução padrão
Então ele retorna `sourceIds` e `generatedAt` válidos sem regressão funcional.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
