### PR TITLE
feat(infra): criar DynamoDB sources com GSI e TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
 - Prefixo de recursos: `${service}-${stage}`.
 - Configurações por ambiente ficam em `custom.stages.dev|stg|prod`.
 
+### Recursos base de dados (DynamoDB)
+
+- Tabela `sources` provisionada por IaC com nome `${service}-${stage}-sources`.
+- Chave primária: `sourceId` (HASH).
+- GSI operacional: `active-nextRunAt-index` (`active` + `nextRunAt`) para consultas do scheduler.
+- TTL habilitado em `expiresAt`.
+- Billing mode: `PAY_PER_REQUEST`.
+
 ### Validação por stage
 
 Renderização do template por stage:

--- a/scripts/validate-stage-package.mjs
+++ b/scripts/validate-stage-package.mjs
@@ -32,7 +32,7 @@ try {
   }
 
   console.warn(
-    '\nAviso: empacotamento multi-stage indisponível no ambiente atual (credenciais/rede). Executando fallback com build local.'
+    '\nAviso: empacotamento multi-stage indisponível no ambiente atual (credenciais/rede). Executando fallback com build local.',
   );
   execSync('npm run build', { stdio: 'inherit', env: process.env });
 }

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -24,7 +24,15 @@ const staticFallback = () => {
     'region: ${self:custom.stages.${self:provider.stage}.region}',
     'logRetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}',
     'lambda: ${self:custom.stages.${self:provider.stage}.tracing}',
+    'SOURCES_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.sourcesTableName}',
     'name: ${self:custom.naming.prefix}-orchestration',
+    'sourcesTableName: ${self:service}-dev-sources',
+    'sourcesTableName: ${self:service}-stg-sources',
+    'sourcesTableName: ${self:service}-prod-sources',
+    'SourcesTable:',
+    'BillingMode: PAY_PER_REQUEST',
+    'IndexName: active-nextRunAt-index',
+    'AttributeName: expiresAt',
     'dev:',
     'stg:',
     'prod:',
@@ -40,7 +48,7 @@ const staticFallback = () => {
   }
 
   console.warn(
-    '\nAviso: renderização multi-stage indisponível por rede. Fallback estático no serverless.yml concluído.'
+    '\nAviso: renderização multi-stage indisponível por rede. Fallback estático no serverless.yml concluído.',
   );
 };
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,7 @@ provider:
   environment:
     STAGE: ${self:provider.stage}
     SERVICE_NAME: ${self:service}
+    SOURCES_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.sourcesTableName}
   stackTags:
     Service: ${self:service}
     Stage: ${self:provider.stage}
@@ -25,14 +26,17 @@ custom:
       region: us-east-1
       logRetentionInDays: 7
       tracing: false
+      sourcesTableName: ${self:service}-dev-sources
     stg:
       region: us-east-1
       logRetentionInDays: 14
       tracing: true
+      sourcesTableName: ${self:service}-stg-sources
     prod:
       region: us-east-1
       logRetentionInDays: 30
       tracing: true
+      sourcesTableName: ${self:service}-prod-sources
 
 plugins:
   - serverless-step-functions
@@ -57,3 +61,33 @@ stepFunctions:
             Resource:
               Fn::GetAtt: [SchedulerLambdaFunction, Arn]
             End: true
+
+resources:
+  Resources:
+    SourcesTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.stages.${self:provider.stage}.sourcesTableName}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: sourceId
+            AttributeType: S
+          - AttributeName: active
+            AttributeType: S
+          - AttributeName: nextRunAt
+            AttributeType: S
+        KeySchema:
+          - AttributeName: sourceId
+            KeyType: HASH
+        GlobalSecondaryIndexes:
+          - IndexName: active-nextRunAt-index
+            KeySchema:
+              - AttributeName: active
+                KeyType: HASH
+              - AttributeName: nextRunAt
+                KeyType: RANGE
+            Projection:
+              ProjectionType: ALL
+        TimeToLiveSpecification:
+          AttributeName: expiresAt
+          Enabled: true


### PR DESCRIPTION
Closes #22

---

## 🎯 Objetivo

Provisionar a tabela DynamoDB `sources` via Serverless Framework v4, com suporte operacional para consulta de fontes ativas por `nextRunAt`, habilitando a base do scheduler incremental.

---

## 🧠 Decisão Técnica

- Definição de `SourcesTable` em `serverless.yml` com `BillingMode: PAY_PER_REQUEST`.
- Chave primária: `sourceId` (HASH).
- GSI: `active-nextRunAt-index` (`active` HASH + `nextRunAt` RANGE) para consultas `active=true` e janela temporal.
- TTL habilitado em `expiresAt`.
- Nome por stage (`dev/stg/prod`) e injeção em `SOURCES_TABLE_NAME`.
- Ajuste da validação de stage para verificar presença dos elementos de DynamoDB no fallback estático.

---

## 🧪 BDD Validado

Dado que a plataforma roda com stages `dev/stg/prod`
Quando renderizamos o `serverless.yml` para cada stage
Então existe uma tabela `sources` por ambiente com PK, GSI, TTL e billing mode configurados.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
