### PR TITLE
feat(step-functions): definir state machine principal v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
   - Stage `stg`: `cron(0/15 * * * ? *)`
   - Stage `prod`: `cron(0/5 * * * ? *)`
   - Payload padrão enviado para execução: `trigger`, `source`, `stage`, `service`.
+- Definição da state machine principal versionada em `state-machines/main-orchestration-v1.asl.json`.
+- Contratos de entrada/saída por estado documentados em `docs/step-functions/main-orchestration-v1.md`.
 - Policy mínima nas filas de integração (`IntegrationQueuesPolicy`) permitindo apenas:
   - `Principal: sns.amazonaws.com`
   - `Action: sqs:SendMessage`

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -1,0 +1,54 @@
+# Main Orchestration v1
+
+Definição versionada em `state-machines/main-orchestration-v1.asl.json`.
+
+## Contrato de entrada do fluxo
+
+Payload esperado na execução:
+
+- `trigger` (string): origem do disparo (`scheduled` no EventBridge).
+- `source` (string): origem técnica do evento (`eventbridge`).
+- `stage` (string): ambiente (`dev`, `stg`, `prod`).
+- `service` (string): nome do serviço.
+- `now` (string, opcional): timestamp ISO para forçar relógio na execução.
+
+## Estados e contratos
+
+### NormalizeInput (Pass)
+
+- Entrada: payload bruto da execução + contexto `$$`.
+- Saída:
+  - `meta.executionId`
+  - `meta.stateMachineId`
+  - `meta.startedAt`
+  - `meta.trigger`
+  - `meta.source`
+  - `meta.stage`
+  - `meta.service`
+  - `schedulerInput.now`
+
+### Scheduler (Task)
+
+- Entrada: `schedulerInput.now`.
+- Ação: invoca `SchedulerLambdaFunction`.
+- Saída esperada em `schedulerResult`:
+  - `sourceIds` (array de string)
+  - `generatedAt` (string ISO)
+
+### BuildExecutionOutput (Pass)
+
+- Entrada: `meta` + `schedulerResult`.
+- Saída final:
+  - `meta`
+  - `sources` (`schedulerResult.sourceIds`)
+  - `summary.eligibleSources` (tamanho de `sources`)
+  - `summary.generatedAt`
+
+### Done (Succeed)
+
+- Finaliza execução com saída padronizada da versão v1.
+
+## Versionamento
+
+- Versão atual: `v1`.
+- Evoluções incompatíveis devem criar novo arquivo (ex.: `main-orchestration-v2.asl.json`) e manter histórico.

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -18,6 +18,10 @@ const printCapturedOutput = (error) => {
 
 const staticFallback = () => {
   const serverless = readFileSync(new URL('../serverless.yml', import.meta.url), 'utf8');
+  const stateMachineFile = new URL(
+    '../state-machines/main-orchestration-v1.asl.json',
+    import.meta.url,
+  );
   const checks = [
     "stage: ${opt:stage, 'dev'}",
     'prefix: ${self:service}-${self:provider.stage}',
@@ -45,13 +49,11 @@ const staticFallback = () => {
     'hubspotConsumerRoleName: ${self:custom.naming.prefix}-hubspot-consumer-role',
     'name: ${self:custom.naming.orchestrationStateMachineName}',
     'name: ${self:custom.naming.orchestrationScheduleRuleName}',
+    'definition: ${file(./state-machines/main-orchestration-v1.asl.json)}',
     'description: Disparo global da orquestracao principal via EventBridge.',
     'rate: ${self:custom.stages.${self:provider.stage}.orchestrationScheduleExpression}',
     'trigger: scheduled',
     'source: eventbridge',
-    'StartAt: Scheduler',
-    'Type: Task',
-    'Fn::GetAtt: [SchedulerLambdaFunction, Arn]',
     'Service: states.amazonaws.com',
     'Sid: InvokeSchedulerLambda',
     'name: ${self:custom.naming.schedulerFunctionName}',
@@ -153,6 +155,29 @@ const staticFallback = () => {
     console.error('Falha no fallback estático de stage render:');
     for (const check of missing) {
       console.error(`- Ausente: ${check}`);
+    }
+    process.exit(1);
+  }
+
+  let definition;
+  try {
+    definition = JSON.parse(readFileSync(stateMachineFile, 'utf8'));
+  } catch (error) {
+    console.error('Falha no fallback estático: arquivo ASL inválido.');
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  const states = definition?.States ?? {};
+  const requiredStates = ['NormalizeInput', 'Scheduler', 'BuildExecutionOutput', 'Done'];
+  const missingStates = requiredStates.filter((stateName) => !(stateName in states));
+  if (definition?.StartAt !== 'NormalizeInput' || missingStates.length > 0) {
+    console.error('Falha no fallback estático: definição ASL principal incompleta.');
+    if (definition?.StartAt !== 'NormalizeInput') {
+      console.error('- StartAt deve ser NormalizeInput');
+    }
+    for (const stateName of missingStates) {
+      console.error(`- Estado ausente: ${stateName}`);
     }
     process.exit(1);
   }

--- a/serverless.yml
+++ b/serverless.yml
@@ -140,15 +140,7 @@ stepFunctions:
         Fn::GetAtt:
           - MainStateMachineExecutionRole
           - Arn
-      definition:
-        Comment: Orquestrador base da plataforma de ingestao.
-        StartAt: Scheduler
-        States:
-          Scheduler:
-            Type: Task
-            Resource:
-              Fn::GetAtt: [SchedulerLambdaFunction, Arn]
-            End: true
+      definition: ${file(./state-machines/main-orchestration-v1.asl.json)}
 
 resources:
   Resources:

--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -1,0 +1,52 @@
+{
+  "Comment": "Orquestrador principal v1 da plataforma de ingestao.",
+  "StartAt": "NormalizeInput",
+  "States": {
+    "NormalizeInput": {
+      "Type": "Pass",
+      "Parameters": {
+        "meta": {
+          "executionId.$": "$$.Execution.Id",
+          "stateMachineId.$": "$$.StateMachine.Id",
+          "startedAt.$": "$$.Execution.StartTime",
+          "trigger.$": "$.trigger",
+          "source.$": "$.source",
+          "stage.$": "$.stage",
+          "service.$": "$.service"
+        },
+        "schedulerInput": {
+          "now.$": "$.now"
+        }
+      },
+      "ResultPath": "$",
+      "Next": "Scheduler"
+    },
+    "Scheduler": {
+      "Type": "Task",
+      "Resource": {
+        "Fn::GetAtt": ["SchedulerLambdaFunction", "Arn"]
+      },
+      "Parameters": {
+        "now.$": "$.schedulerInput.now"
+      },
+      "ResultPath": "$.schedulerResult",
+      "Next": "BuildExecutionOutput"
+    },
+    "BuildExecutionOutput": {
+      "Type": "Pass",
+      "Parameters": {
+        "meta.$": "$.meta",
+        "sources.$": "$.schedulerResult.sourceIds",
+        "summary": {
+          "eligibleSources.$": "States.ArrayLength($.schedulerResult.sourceIds)",
+          "generatedAt.$": "$.schedulerResult.generatedAt"
+        }
+      },
+      "ResultPath": "$",
+      "Next": "Done"
+    },
+    "Done": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+
+type JsonObject = Record<string, unknown>;
+
+const asObject = (value: unknown): JsonObject => {
+  expect(value).toBeDefined();
+  expect(value).toBeTruthy();
+  expect(typeof value).toBe('object');
+  return value as JsonObject;
+};
+
+const loadDefinition = (): JsonObject => {
+  const filePath = resolve(process.cwd(), 'state-machines/main-orchestration-v1.asl.json');
+  return JSON.parse(readFileSync(filePath, 'utf8')) as JsonObject;
+};
+
+describe('main-orchestration-v1.asl.json', () => {
+  it('define fluxo principal com contratos explícitos por estado', () => {
+    const definition = loadDefinition();
+    expect(definition.Comment).toBe('Orquestrador principal v1 da plataforma de ingestao.');
+    expect(definition.StartAt).toBe('NormalizeInput');
+
+    const states = asObject(definition.States);
+    const normalizeInput = asObject(states.NormalizeInput);
+    const scheduler = asObject(states.Scheduler);
+    const buildExecutionOutput = asObject(states.BuildExecutionOutput);
+    const done = asObject(states.Done);
+
+    expect(normalizeInput.Type).toBe('Pass');
+    expect(normalizeInput.ResultPath).toBe('$');
+    expect(normalizeInput.Next).toBe('Scheduler');
+    const normalizeParameters = asObject(normalizeInput.Parameters);
+    const meta = asObject(normalizeParameters.meta);
+    const schedulerInput = asObject(normalizeParameters.schedulerInput);
+    expect(meta['executionId.$']).toBe('$$.Execution.Id');
+    expect(meta['stateMachineId.$']).toBe('$$.StateMachine.Id');
+    expect(meta['startedAt.$']).toBe('$$.Execution.StartTime');
+    expect(meta['trigger.$']).toBe('$.trigger');
+    expect(meta['source.$']).toBe('$.source');
+    expect(meta['stage.$']).toBe('$.stage');
+    expect(meta['service.$']).toBe('$.service');
+    expect(schedulerInput['now.$']).toBe('$.now');
+
+    expect(scheduler.Type).toBe('Task');
+    expect(scheduler.ResultPath).toBe('$.schedulerResult');
+    expect(scheduler.Next).toBe('BuildExecutionOutput');
+    const schedulerParameters = asObject(scheduler.Parameters);
+    expect(schedulerParameters['now.$']).toBe('$.schedulerInput.now');
+    const schedulerResource = asObject(scheduler.Resource);
+    expect(schedulerResource['Fn::GetAtt']).toEqual(['SchedulerLambdaFunction', 'Arn']);
+
+    expect(buildExecutionOutput.Type).toBe('Pass');
+    expect(buildExecutionOutput.ResultPath).toBe('$');
+    expect(buildExecutionOutput.Next).toBe('Done');
+    const outputParameters = asObject(buildExecutionOutput.Parameters);
+    expect(outputParameters['meta.$']).toBe('$.meta');
+    expect(outputParameters['sources.$']).toBe('$.schedulerResult.sourceIds');
+    const summary = asObject(outputParameters.summary);
+    expect(summary['eligibleSources.$']).toBe('States.ArrayLength($.schedulerResult.sourceIds)');
+    expect(summary['generatedAt.$']).toBe('$.schedulerResult.generatedAt');
+
+    expect(done.Type).toBe('Succeed');
+  });
+});


### PR DESCRIPTION
Closes #31

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Definir a state machine principal em arquivo ASL versionado (`v1`), com contratos explícitos de entrada/saída entre estados e validação automatizada da definição.

---

## 🧠 Decisão Técnica

- A definição foi extraída para `state-machines/main-orchestration-v1.asl.json` e referenciada no `serverless.yml`.
- O fluxo v1 explicita contratos por estado (`NormalizeInput`, `Scheduler`, `BuildExecutionOutput`, `Done`).
- O contrato da orquestração foi documentado em `docs/step-functions/main-orchestration-v1.md`.
- A validação local foi reforçada com:
  - teste unitário da ASL (`tests/unit/state-machines/main-orchestration-v1.test.ts`),
  - validação no fallback de `validate-stage-render` para garantir estrutura mínima da ASL.

---

## 🧪 BDD Validado

Dado que a orquestração principal é renderizada via `serverless print` por stage
Quando a definição da state machine é carregada do arquivo versionado v1
Então o fluxo contém estados e contratos explícitos para entrada normalizada, execução do scheduler e saída padronizada.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
