### PR TITLE
feat(step-functions): implementar Step Scheduler com tratamento inicial de falha

### DIFF
--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -30,20 +30,61 @@
         "now.$": "$.schedulerInput.now"
       },
       "ResultPath": "$.schedulerResult",
+      "Next": "NormalizeSchedulerOutput",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.schedulerError",
+          "Next": "BuildSchedulerFailureOutput"
+        }
+      ]
+    },
+    "NormalizeSchedulerOutput": {
+      "Type": "Pass",
+      "Parameters": {
+        "meta.$": "$.meta",
+        "scheduler": {
+          "sourceIds.$": "$.schedulerResult.sourceIds",
+          "generatedAt.$": "$.schedulerResult.generatedAt",
+          "eligibleSources.$": "States.ArrayLength($.schedulerResult.sourceIds)"
+        }
+      },
+      "ResultPath": "$",
       "Next": "BuildExecutionOutput"
     },
     "BuildExecutionOutput": {
       "Type": "Pass",
       "Parameters": {
         "meta.$": "$.meta",
-        "sources.$": "$.schedulerResult.sourceIds",
+        "sources.$": "$.scheduler.sourceIds",
         "summary": {
-          "eligibleSources.$": "States.ArrayLength($.schedulerResult.sourceIds)",
-          "generatedAt.$": "$.schedulerResult.generatedAt"
+          "eligibleSources.$": "$.scheduler.eligibleSources",
+          "generatedAt.$": "$.scheduler.generatedAt",
+          "schedulerStatus": "SUCCEEDED"
         }
       },
       "ResultPath": "$",
       "Next": "Done"
+    },
+    "BuildSchedulerFailureOutput": {
+      "Type": "Pass",
+      "Parameters": {
+        "meta.$": "$.meta",
+        "sources": [],
+        "summary": {
+          "eligibleSources": 0,
+          "schedulerStatus": "FAILED",
+          "error.$": "$.schedulerError.Error",
+          "cause.$": "$.schedulerError.Cause"
+        }
+      },
+      "ResultPath": "$",
+      "Next": "SchedulerFailed"
+    },
+    "SchedulerFailed": {
+      "Type": "Fail",
+      "Error": "SchedulerStepFailed",
+      "Cause": "Scheduler task failed before Map state execution."
     },
     "Done": {
       "Type": "Succeed"

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -25,7 +25,10 @@ describe('main-orchestration-v1.asl.json', () => {
     const states = asObject(definition.States);
     const normalizeInput = asObject(states.NormalizeInput);
     const scheduler = asObject(states.Scheduler);
+    const normalizeSchedulerOutput = asObject(states.NormalizeSchedulerOutput);
     const buildExecutionOutput = asObject(states.BuildExecutionOutput);
+    const buildSchedulerFailureOutput = asObject(states.BuildSchedulerFailureOutput);
+    const schedulerFailed = asObject(states.SchedulerFailed);
     const done = asObject(states.Done);
 
     expect(normalizeInput.Type).toBe('Pass');
@@ -45,21 +48,57 @@ describe('main-orchestration-v1.asl.json', () => {
 
     expect(scheduler.Type).toBe('Task');
     expect(scheduler.ResultPath).toBe('$.schedulerResult');
-    expect(scheduler.Next).toBe('BuildExecutionOutput');
+    expect(scheduler.Next).toBe('NormalizeSchedulerOutput');
     const schedulerParameters = asObject(scheduler.Parameters);
     expect(schedulerParameters['now.$']).toBe('$.schedulerInput.now');
     const schedulerResource = asObject(scheduler.Resource);
     expect(schedulerResource['Fn::GetAtt']).toEqual(['SchedulerLambdaFunction', 'Arn']);
+    const schedulerCatch = scheduler.Catch as unknown[];
+    expect(Array.isArray(schedulerCatch)).toBe(true);
+    expect(schedulerCatch).toHaveLength(1);
+    const schedulerCatchEntry = asObject(schedulerCatch[0]);
+    expect(schedulerCatchEntry.ErrorEquals).toEqual(['States.ALL']);
+    expect(schedulerCatchEntry.ResultPath).toBe('$.schedulerError');
+    expect(schedulerCatchEntry.Next).toBe('BuildSchedulerFailureOutput');
+
+    expect(normalizeSchedulerOutput.Type).toBe('Pass');
+    expect(normalizeSchedulerOutput.ResultPath).toBe('$');
+    expect(normalizeSchedulerOutput.Next).toBe('BuildExecutionOutput');
+    const normalizeSchedulerParameters = asObject(normalizeSchedulerOutput.Parameters);
+    expect(normalizeSchedulerParameters['meta.$']).toBe('$.meta');
+    const schedulerPayload = asObject(normalizeSchedulerParameters.scheduler);
+    expect(schedulerPayload['sourceIds.$']).toBe('$.schedulerResult.sourceIds');
+    expect(schedulerPayload['generatedAt.$']).toBe('$.schedulerResult.generatedAt');
+    expect(schedulerPayload['eligibleSources.$']).toBe(
+      'States.ArrayLength($.schedulerResult.sourceIds)',
+    );
 
     expect(buildExecutionOutput.Type).toBe('Pass');
     expect(buildExecutionOutput.ResultPath).toBe('$');
     expect(buildExecutionOutput.Next).toBe('Done');
     const outputParameters = asObject(buildExecutionOutput.Parameters);
     expect(outputParameters['meta.$']).toBe('$.meta');
-    expect(outputParameters['sources.$']).toBe('$.schedulerResult.sourceIds');
+    expect(outputParameters['sources.$']).toBe('$.scheduler.sourceIds');
     const summary = asObject(outputParameters.summary);
-    expect(summary['eligibleSources.$']).toBe('States.ArrayLength($.schedulerResult.sourceIds)');
-    expect(summary['generatedAt.$']).toBe('$.schedulerResult.generatedAt');
+    expect(summary['eligibleSources.$']).toBe('$.scheduler.eligibleSources');
+    expect(summary['generatedAt.$']).toBe('$.scheduler.generatedAt');
+    expect(summary.schedulerStatus).toBe('SUCCEEDED');
+
+    expect(buildSchedulerFailureOutput.Type).toBe('Pass');
+    expect(buildSchedulerFailureOutput.ResultPath).toBe('$');
+    expect(buildSchedulerFailureOutput.Next).toBe('SchedulerFailed');
+    const buildSchedulerFailureParameters = asObject(buildSchedulerFailureOutput.Parameters);
+    expect(buildSchedulerFailureParameters['meta.$']).toBe('$.meta');
+    expect(buildSchedulerFailureParameters.sources).toEqual([]);
+    const failureSummary = asObject(buildSchedulerFailureParameters.summary);
+    expect(failureSummary.eligibleSources).toBe(0);
+    expect(failureSummary.schedulerStatus).toBe('FAILED');
+    expect(failureSummary['error.$']).toBe('$.schedulerError.Error');
+    expect(failureSummary['cause.$']).toBe('$.schedulerError.Cause');
+
+    expect(schedulerFailed.Type).toBe('Fail');
+    expect(schedulerFailed.Error).toBe('SchedulerStepFailed');
+    expect(schedulerFailed.Cause).toBe('Scheduler task failed before Map state execution.');
 
     expect(done.Type).toBe('Succeed');
   });


### PR DESCRIPTION
Closes #32

---

## 🎯 Objetivo

Implementar o Step `Scheduler` da state machine principal com tratamento inicial de falha e payload normalizado para consumo das próximas etapas de orquestração.

---

## 🧠 Decisão Técnica

Foi mantida a invocação da Lambda Scheduler como estado `Task` com contrato mínimo (`now`).
Foi adicionado `Catch` global (`States.ALL`) para tratar falhas iniciais do scheduler e encaminhar para rota explícita de erro.
Também foi introduzido um estado de normalização (`NormalizeSchedulerOutput`) para estabilizar o contrato do payload (`sourceIds`, `generatedAt`, `eligibleSources`) antes do output da execução.

---

## 🧪 BDD Validado

Dado que a execução da state machine inicia com `NormalizeInput`
Quando o estado `Scheduler` retorna com sucesso
Então o payload final contém `sources`, resumo com metadados e status `SUCCEEDED`.

Dado que o estado `Scheduler` falha
Quando o `Catch` captura o erro
Então a execução segue para `BuildSchedulerFailureOutput` e encerra em `SchedulerFailed` com falha explícita.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
