### PR TITLE
feat(step-functions): configurar max concurrency por stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
   - Stage `stg`: `cron(0/15 * * * ? *)`
   - Stage `prod`: `cron(0/5 * * * ? *)`
   - Payload padrão enviado para execução: `trigger`, `source`, `stage`, `service`.
+- Controle de paralelismo do `Map State` por stage:
+  - Variável de ambiente: `MAP_MAX_CONCURRENCY`.
+  - Stage `dev`: `2`
+  - Stage `stg`: `5`
+  - Stage `prod`: `10`
+  - Limites aceitos em runtime: inteiro entre `1` e `40`.
+  - Fallback no scheduler quando ausente: `5`.
 - Definição da state machine principal versionada em `state-machines/main-orchestration-v1.asl.json`.
 - Contratos de entrada/saída por estado documentados em `docs/step-functions/main-orchestration-v1.md`.
 - Policy mínima nas filas de integração (`IntegrationQueuesPolicy`) permitindo apenas:

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -34,6 +34,15 @@ Payload esperado na execução:
 - Saída esperada em `schedulerResult`:
   - `sourceIds` (array de string)
   - `generatedAt` (string ISO)
+  - `maxConcurrency` (number, inteiro entre 1 e 40)
+
+### ProcessEligibleSources (Map)
+
+- Entrada: `scheduler.sourceIds` e `scheduler.maxConcurrency`.
+- Ação: itera cada `sourceId` e invoca `CollectorLambdaFunction`.
+- Controle de paralelismo:
+  - `MaxConcurrencyPath = $.scheduler.maxConcurrency`.
+  - Valor configurado por stage via `MAP_MAX_CONCURRENCY`.
 
 ### BuildExecutionOutput (Pass)
 
@@ -43,6 +52,7 @@ Payload esperado na execução:
   - `sources` (`schedulerResult.sourceIds`)
   - `summary.eligibleSources` (tamanho de `sources`)
   - `summary.generatedAt`
+  - `summary.maxConcurrency` (limite aplicado no Map)
 
 ### Done (Succeed)
 

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -30,6 +30,7 @@ const staticFallback = () => {
     'lambda: ${self:custom.stages.${self:provider.stage}.tracing}',
     'SOURCES_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.sourcesTableName}',
     'CURSORS_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.cursorsTableName}',
+    'MAP_MAX_CONCURRENCY: ${self:custom.stages.${self:provider.stage}.mapMaxConcurrency}',
     'CLIENT_EVENTS_TOPIC_ARN:',
     'SALESFORCE_INTEGRATION_QUEUE_URL:',
     'SALESFORCE_INTEGRATION_QUEUE_ARN:',
@@ -92,6 +93,9 @@ const staticFallback = () => {
     'integrationDlqMessageRetentionSeconds: 1209600',
     'salesforceQueueMaxReceiveCount: 5',
     'hubspotQueueMaxReceiveCount: 5',
+    'mapMaxConcurrency: 2',
+    'mapMaxConcurrency: 5',
+    'mapMaxConcurrency: 10',
     'SourcesTable:',
     'CursorsTable:',
     'ClientEventsTopic:',
@@ -187,6 +191,26 @@ const staticFallback = () => {
     for (const stateName of missingStates) {
       console.error(`- Estado ausente: ${stateName}`);
     }
+    process.exit(1);
+  }
+
+  const normalizeSchedulerOutput = states.NormalizeSchedulerOutput ?? {};
+  const schedulerParams = normalizeSchedulerOutput.Parameters?.scheduler ?? {};
+  if (schedulerParams['maxConcurrency.$'] !== '$.schedulerResult.maxConcurrency') {
+    console.error('Falha no fallback estático: NormalizeSchedulerOutput sem maxConcurrency.');
+    process.exit(1);
+  }
+
+  const processEligibleSources = states.ProcessEligibleSources ?? {};
+  if (processEligibleSources.MaxConcurrencyPath !== '$.scheduler.maxConcurrency') {
+    console.error('Falha no fallback estático: Map sem MaxConcurrencyPath esperado.');
+    process.exit(1);
+  }
+
+  const buildExecutionOutput = states.BuildExecutionOutput ?? {};
+  const summaryParams = buildExecutionOutput.Parameters?.summary ?? {};
+  if (summaryParams['maxConcurrency.$'] !== '$.scheduler.maxConcurrency') {
+    console.error('Falha no fallback estático: summary sem maxConcurrency.');
     process.exit(1);
   }
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,6 +14,7 @@ provider:
     SERVICE_NAME: ${self:service}
     SOURCES_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.sourcesTableName}
     CURSORS_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.cursorsTableName}
+    MAP_MAX_CONCURRENCY: ${self:custom.stages.${self:provider.stage}.mapMaxConcurrency}
     CLIENT_EVENTS_TOPIC_ARN:
       Ref: ClientEventsTopic
     SALESFORCE_INTEGRATION_QUEUE_URL:
@@ -72,6 +73,7 @@ custom:
       integrationDlqMessageRetentionSeconds: 1209600
       salesforceQueueMaxReceiveCount: 5
       hubspotQueueMaxReceiveCount: 5
+      mapMaxConcurrency: 2
       orchestrationScheduleExpression: cron(0/30 * * * ? *)
     stg:
       region: us-east-1
@@ -88,6 +90,7 @@ custom:
       integrationDlqMessageRetentionSeconds: 1209600
       salesforceQueueMaxReceiveCount: 5
       hubspotQueueMaxReceiveCount: 5
+      mapMaxConcurrency: 5
       orchestrationScheduleExpression: cron(0/15 * * * ? *)
     prod:
       region: us-east-1
@@ -104,6 +107,7 @@ custom:
       integrationDlqMessageRetentionSeconds: 1209600
       salesforceQueueMaxReceiveCount: 5
       hubspotQueueMaxReceiveCount: 5
+      mapMaxConcurrency: 10
       orchestrationScheduleExpression: cron(0/5 * * * ? *)
 
 plugins:

--- a/src/handlers/scheduler.ts
+++ b/src/handlers/scheduler.ts
@@ -2,6 +2,10 @@ import { listEligibleSources } from '../domain/scheduler/list-eligible-sources';
 import { createInMemorySourceRepository } from '../infra/sources/in-memory-source-repository';
 import { nowIso } from '../shared/time/now-iso';
 
+const MAP_MAX_CONCURRENCY_DEFAULT = 5;
+const MAP_MAX_CONCURRENCY_MIN = 1;
+const MAP_MAX_CONCURRENCY_MAX = 40;
+
 export interface SchedulerEvent {
   now?: string;
 }
@@ -9,7 +13,26 @@ export interface SchedulerEvent {
 export interface SchedulerResult {
   sourceIds: string[];
   generatedAt: string;
+  maxConcurrency: number;
 }
+
+const resolveMapMaxConcurrency = (rawValue: string | undefined): number => {
+  if (!rawValue) {
+    return MAP_MAX_CONCURRENCY_DEFAULT;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  const isValidInteger = Number.isInteger(parsed);
+  const isInRange = parsed >= MAP_MAX_CONCURRENCY_MIN && parsed <= MAP_MAX_CONCURRENCY_MAX;
+
+  if (!isValidInteger || !isInRange) {
+    throw new Error(
+      `Invalid MAP_MAX_CONCURRENCY="${rawValue}". Expected integer between ${MAP_MAX_CONCURRENCY_MIN} and ${MAP_MAX_CONCURRENCY_MAX}.`,
+    );
+  }
+
+  return parsed;
+};
 
 export async function handler(event: SchedulerEvent = {}): Promise<SchedulerResult> {
   const sourceRepository = createInMemorySourceRepository();
@@ -17,9 +40,11 @@ export async function handler(event: SchedulerEvent = {}): Promise<SchedulerResu
     sourceRepository,
     now: event.now,
   });
+  const maxConcurrency = resolveMapMaxConcurrency(process.env.MAP_MAX_CONCURRENCY);
 
   return {
     sourceIds,
     generatedAt: nowIso(),
+    maxConcurrency,
   };
 }

--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -46,6 +46,7 @@
         "scheduler": {
           "sourceIds.$": "$.schedulerResult.sourceIds",
           "generatedAt.$": "$.schedulerResult.generatedAt",
+          "maxConcurrency.$": "$.schedulerResult.maxConcurrency",
           "eligibleSources.$": "States.ArrayLength($.schedulerResult.sourceIds)"
         }
       },
@@ -55,6 +56,7 @@
     "ProcessEligibleSources": {
       "Type": "Map",
       "ItemsPath": "$.scheduler.sourceIds",
+      "MaxConcurrencyPath": "$.scheduler.maxConcurrency",
       "Parameters": {
         "sourceId.$": "$$.Map.Item.Value",
         "meta.$": "$.meta"
@@ -99,6 +101,7 @@
           "processedSources.$": "States.ArrayLength($.collectorResults)",
           "eligibleSources.$": "$.scheduler.eligibleSources",
           "generatedAt.$": "$.scheduler.generatedAt",
+          "maxConcurrency.$": "$.scheduler.maxConcurrency",
           "schedulerStatus": "SUCCEEDED"
         }
       },

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -1,13 +1,42 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it } from '@jest/globals';
 
 import { handler } from '../../../src/handlers/scheduler';
 
+const ORIGINAL_MAP_MAX_CONCURRENCY = process.env.MAP_MAX_CONCURRENCY;
+
+afterEach(() => {
+  if (ORIGINAL_MAP_MAX_CONCURRENCY === undefined) {
+    delete process.env.MAP_MAX_CONCURRENCY;
+    return;
+  }
+
+  process.env.MAP_MAX_CONCURRENCY = ORIGINAL_MAP_MAX_CONCURRENCY;
+});
+
 describe('scheduler handler', () => {
-  it('returns expected payload', async () => {
+  it('returns expected payload with default max concurrency', async () => {
+    delete process.env.MAP_MAX_CONCURRENCY;
     const result = await handler();
 
     expect(result.sourceIds).toEqual([]);
     expect(typeof result.generatedAt).toBe('string');
     expect(Number.isNaN(Date.parse(result.generatedAt))).toBe(false);
+    expect(result.maxConcurrency).toBe(5);
+  });
+
+  it('returns configured max concurrency from environment', async () => {
+    process.env.MAP_MAX_CONCURRENCY = '12';
+
+    const result = await handler();
+
+    expect(result.maxConcurrency).toBe(12);
+  });
+
+  it('throws on invalid MAP_MAX_CONCURRENCY', async () => {
+    process.env.MAP_MAX_CONCURRENCY = '0';
+
+    await expect(handler()).rejects.toThrow(
+      'Invalid MAP_MAX_CONCURRENCY="0". Expected integer between 1 and 40.',
+    );
   });
 });

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -70,12 +70,14 @@ describe('main-orchestration-v1.asl.json', () => {
     const schedulerPayload = asObject(normalizeSchedulerParameters.scheduler);
     expect(schedulerPayload['sourceIds.$']).toBe('$.schedulerResult.sourceIds');
     expect(schedulerPayload['generatedAt.$']).toBe('$.schedulerResult.generatedAt');
+    expect(schedulerPayload['maxConcurrency.$']).toBe('$.schedulerResult.maxConcurrency');
     expect(schedulerPayload['eligibleSources.$']).toBe(
       'States.ArrayLength($.schedulerResult.sourceIds)',
     );
 
     expect(processEligibleSources.Type).toBe('Map');
     expect(processEligibleSources.ItemsPath).toBe('$.scheduler.sourceIds');
+    expect(processEligibleSources.MaxConcurrencyPath).toBe('$.scheduler.maxConcurrency');
     expect(processEligibleSources.ResultPath).toBe('$.collectorResults');
     expect(processEligibleSources.Next).toBe('BuildExecutionOutput');
     const processEligibleSourcesParameters = asObject(processEligibleSources.Parameters);
@@ -115,6 +117,7 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(summary['processedSources.$']).toBe('States.ArrayLength($.collectorResults)');
     expect(summary['eligibleSources.$']).toBe('$.scheduler.eligibleSources');
     expect(summary['generatedAt.$']).toBe('$.scheduler.generatedAt');
+    expect(summary['maxConcurrency.$']).toBe('$.scheduler.maxConcurrency');
     expect(summary.schedulerStatus).toBe('SUCCEEDED');
 
     expect(buildSchedulerFailureOutput.Type).toBe('Pass');


### PR DESCRIPTION
Closes #34

---

## 🎯 Objetivo

Configurar controle de paralelismo no `Map State` da orquestração principal com valor por stage, para reduzir saturação de fontes e permitir ajuste operacional via configuração.

---

## 🧠 Decisão Técnica

- Adicionado `mapMaxConcurrency` em `custom.stages` (`dev=2`, `stg=5`, `prod=10`).
- Exposto `MAP_MAX_CONCURRENCY` no ambiente da Scheduler.
- Scheduler agora retorna `maxConcurrency` com validação de intervalo (`1..40`) e fallback (`5`).
- `ProcessEligibleSources` passou a usar `MaxConcurrencyPath: $.scheduler.maxConcurrency`.
- `summary.maxConcurrency` incluído no output final da execução.
- Atualizados testes, documentação e fallback de validação estática.

---

## 🧪 BDD Validado

Dado que cada stage possui um limite de concorrência configurado
Quando a state machine entra no estado `ProcessEligibleSources`
Então o `Map State` aplica `MaxConcurrencyPath` com o valor retornado pela Scheduler.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
