### PR TITLE
feat(step-functions): configurar retry com backoff exponencial

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
   - Fallback no scheduler quando ausente: `5`.
 - Definição da state machine principal versionada em `state-machines/main-orchestration-v1.asl.json`.
 - Contratos de entrada/saída por estado documentados em `docs/step-functions/main-orchestration-v1.md`.
+- Retry com backoff exponencial configurado na state machine para tasks críticas:
+  - `Scheduler` e `InvokeCollector` com tentativa para erros transitórios de Lambda:
+    - `IntervalSeconds: 2`, `MaxAttempts: 3`, `BackoffRate: 2`.
+  - Retry específico para `States.Timeout`:
+    - `IntervalSeconds: 5`, `MaxAttempts: 2`, `BackoffRate: 2`.
+  - Guardrail de resiliência: número máximo de tentativas explícito para evitar loop infinito.
 - Policy mínima nas filas de integração (`IntegrationQueuesPolicy`) permitindo apenas:
   - `Principal: sns.amazonaws.com`
   - `Action: sqs:SendMessage`

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -31,6 +31,15 @@ Payload esperado na execução:
 
 - Entrada: `schedulerInput.now`.
 - Ação: invoca `SchedulerLambdaFunction`.
+- Retry com backoff exponencial para falhas transitórias:
+  - Erros Lambda transitórios (`ServiceException`, `AWSLambdaException`, `SdkClientException`, `TooManyRequestsException`):
+    - `IntervalSeconds: 2`
+    - `MaxAttempts: 3`
+    - `BackoffRate: 2`
+  - `States.Timeout`:
+    - `IntervalSeconds: 5`
+    - `MaxAttempts: 2`
+    - `BackoffRate: 2`
 - Saída esperada em `schedulerResult`:
   - `sourceIds` (array de string)
   - `generatedAt` (string ISO)
@@ -40,6 +49,7 @@ Payload esperado na execução:
 
 - Entrada: `scheduler.sourceIds` e `scheduler.maxConcurrency`.
 - Ação: itera cada `sourceId` e invoca `CollectorLambdaFunction`.
+- Retry com backoff exponencial na task `InvokeCollector` com os mesmos limites do `Scheduler`.
 - Controle de paralelismo:
   - `MaxConcurrencyPath = $.scheduler.maxConcurrency`.
   - Valor configurado por stage via `MAP_MAX_CONCURRENCY`.

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -175,6 +175,18 @@ const staticFallback = () => {
   }
 
   const states = definition?.States ?? {};
+  const hasExpectedRetryPolicy = (retryBlock, expectedErrors, intervalSeconds, maxAttempts) =>
+    Array.isArray(retryBlock) &&
+    retryBlock.some((entry) => {
+      const errors = Array.isArray(entry?.ErrorEquals) ? entry.ErrorEquals : [];
+      return (
+        JSON.stringify(errors) === JSON.stringify(expectedErrors) &&
+        entry?.IntervalSeconds === intervalSeconds &&
+        entry?.MaxAttempts === maxAttempts &&
+        entry?.BackoffRate === 2
+      );
+    });
+
   const requiredStates = [
     'NormalizeInput',
     'Scheduler',
@@ -211,6 +223,50 @@ const staticFallback = () => {
   const summaryParams = buildExecutionOutput.Parameters?.summary ?? {};
   if (summaryParams['maxConcurrency.$'] !== '$.scheduler.maxConcurrency') {
     console.error('Falha no fallback estático: summary sem maxConcurrency.');
+    process.exit(1);
+  }
+
+  const schedulerRetry = states.Scheduler?.Retry;
+  const hasSchedulerLambdaRetry = hasExpectedRetryPolicy(
+    schedulerRetry,
+    [
+      'Lambda.ServiceException',
+      'Lambda.AWSLambdaException',
+      'Lambda.SdkClientException',
+      'Lambda.TooManyRequestsException',
+    ],
+    2,
+    3,
+  );
+  const hasSchedulerTimeoutRetry = hasExpectedRetryPolicy(schedulerRetry, ['States.Timeout'], 5, 2);
+  if (!hasSchedulerLambdaRetry || !hasSchedulerTimeoutRetry) {
+    console.error('Falha no fallback estático: Scheduler sem política de retry/backoff esperada.');
+    process.exit(1);
+  }
+
+  const invokeCollectorRetry =
+    states.ProcessEligibleSources?.Iterator?.States?.InvokeCollector?.Retry;
+  const hasCollectorLambdaRetry = hasExpectedRetryPolicy(
+    invokeCollectorRetry,
+    [
+      'Lambda.ServiceException',
+      'Lambda.AWSLambdaException',
+      'Lambda.SdkClientException',
+      'Lambda.TooManyRequestsException',
+    ],
+    2,
+    3,
+  );
+  const hasCollectorTimeoutRetry = hasExpectedRetryPolicy(
+    invokeCollectorRetry,
+    ['States.Timeout'],
+    5,
+    2,
+  );
+  if (!hasCollectorLambdaRetry || !hasCollectorTimeoutRetry) {
+    console.error(
+      'Falha no fallback estático: InvokeCollector sem política de retry/backoff esperada.',
+    );
     process.exit(1);
   }
 

--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -29,6 +29,25 @@
       "Parameters": {
         "now.$": "$.schedulerInput.now"
       },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        },
+        {
+          "ErrorEquals": ["States.Timeout"],
+          "IntervalSeconds": 5,
+          "MaxAttempts": 2,
+          "BackoffRate": 2
+        }
+      ],
       "ResultPath": "$.schedulerResult",
       "Next": "NormalizeSchedulerOutput",
       "Catch": [
@@ -73,6 +92,25 @@
               "sourceId.$": "$.sourceId",
               "meta.$": "$.meta"
             },
+            "Retry": [
+              {
+                "ErrorEquals": [
+                  "Lambda.ServiceException",
+                  "Lambda.AWSLambdaException",
+                  "Lambda.SdkClientException",
+                  "Lambda.TooManyRequestsException"
+                ],
+                "IntervalSeconds": 2,
+                "MaxAttempts": 3,
+                "BackoffRate": 2
+              },
+              {
+                "ErrorEquals": ["States.Timeout"],
+                "IntervalSeconds": 5,
+                "MaxAttempts": 2,
+                "BackoffRate": 2
+              }
+            ],
             "ResultPath": "$.collectorResult",
             "Next": "BuildItemResult"
           },

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -52,6 +52,24 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(scheduler.Next).toBe('NormalizeSchedulerOutput');
     const schedulerParameters = asObject(scheduler.Parameters);
     expect(schedulerParameters['now.$']).toBe('$.schedulerInput.now');
+    const schedulerRetry = scheduler.Retry as unknown[];
+    expect(Array.isArray(schedulerRetry)).toBe(true);
+    expect(schedulerRetry).toHaveLength(2);
+    const schedulerLambdaRetry = asObject(schedulerRetry[0]);
+    expect(schedulerLambdaRetry.ErrorEquals).toEqual([
+      'Lambda.ServiceException',
+      'Lambda.AWSLambdaException',
+      'Lambda.SdkClientException',
+      'Lambda.TooManyRequestsException',
+    ]);
+    expect(schedulerLambdaRetry.IntervalSeconds).toBe(2);
+    expect(schedulerLambdaRetry.MaxAttempts).toBe(3);
+    expect(schedulerLambdaRetry.BackoffRate).toBe(2);
+    const schedulerTimeoutRetry = asObject(schedulerRetry[1]);
+    expect(schedulerTimeoutRetry.ErrorEquals).toEqual(['States.Timeout']);
+    expect(schedulerTimeoutRetry.IntervalSeconds).toBe(5);
+    expect(schedulerTimeoutRetry.MaxAttempts).toBe(2);
+    expect(schedulerTimeoutRetry.BackoffRate).toBe(2);
     const schedulerResource = asObject(scheduler.Resource);
     expect(schedulerResource['Fn::GetAtt']).toEqual(['SchedulerLambdaFunction', 'Arn']);
     const schedulerCatch = scheduler.Catch as unknown[];
@@ -97,6 +115,24 @@ describe('main-orchestration-v1.asl.json', () => {
     const invokeCollectorParameters = asObject(invokeCollector.Parameters);
     expect(invokeCollectorParameters['sourceId.$']).toBe('$.sourceId');
     expect(invokeCollectorParameters['meta.$']).toBe('$.meta');
+    const invokeCollectorRetry = invokeCollector.Retry as unknown[];
+    expect(Array.isArray(invokeCollectorRetry)).toBe(true);
+    expect(invokeCollectorRetry).toHaveLength(2);
+    const collectorLambdaRetry = asObject(invokeCollectorRetry[0]);
+    expect(collectorLambdaRetry.ErrorEquals).toEqual([
+      'Lambda.ServiceException',
+      'Lambda.AWSLambdaException',
+      'Lambda.SdkClientException',
+      'Lambda.TooManyRequestsException',
+    ]);
+    expect(collectorLambdaRetry.IntervalSeconds).toBe(2);
+    expect(collectorLambdaRetry.MaxAttempts).toBe(3);
+    expect(collectorLambdaRetry.BackoffRate).toBe(2);
+    const collectorTimeoutRetry = asObject(invokeCollectorRetry[1]);
+    expect(collectorTimeoutRetry.ErrorEquals).toEqual(['States.Timeout']);
+    expect(collectorTimeoutRetry.IntervalSeconds).toBe(5);
+    expect(collectorTimeoutRetry.MaxAttempts).toBe(2);
+    expect(collectorTimeoutRetry.BackoffRate).toBe(2);
 
     expect(buildItemResult.Type).toBe('Pass');
     expect(buildItemResult.End).toBe(true);


### PR DESCRIPTION
Closes #35

---

## 🎯 Objetivo

Configurar política de retry com backoff exponencial na orquestração principal para tratar falhas transitórias nas tasks `Scheduler` e `InvokeCollector`, com limite explícito de tentativas.

---

## 🧠 Decisão Técnica

- Adicionado `Retry` em `Scheduler` e `InvokeCollector` com duas políticas:
  - Erros transitórios de Lambda (`ServiceException`, `AWSLambdaException`, `SdkClientException`, `TooManyRequestsException`): `IntervalSeconds: 2`, `MaxAttempts: 3`, `BackoffRate: 2`.
  - `States.Timeout`: `IntervalSeconds: 5`, `MaxAttempts: 2`, `BackoffRate: 2`.
- Mantido sem `Catch` por item no `Map` nesta issue para não antecipar escopo da #36.
- Atualizados testes e documentação para garantir contrato explícito e evitar regressão.

---

## 🧪 BDD Validado

Dado que a state machine executa tasks Lambda sujeitas a falhas transitórias
Quando ocorrer erro transitório ou timeout nas tasks `Scheduler` ou `InvokeCollector`
Então a execução aplica retry com backoff exponencial respeitando `MaxAttempts` e sem loop infinito

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
