### PR TITLE
feat(step-functions): configurar catch por fonte no map

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
   - Retry específico para `States.Timeout`:
     - `IntervalSeconds: 5`, `MaxAttempts: 2`, `BackoffRate: 2`.
   - Guardrail de resiliência: número máximo de tentativas explícito para evitar loop infinito.
+- Catch por item no `Map State` para tolerância a falha parcial:
+  - `InvokeCollector` trata `States.ALL` no escopo da fonte.
+  - Falhas de uma fonte não interrompem o processamento das demais.
+  - Resultado final inclui status por item (`SUCCEEDED` ou `FAILED`) com rastreabilidade de erro (`error` e `cause`).
 - Policy mínima nas filas de integração (`IntegrationQueuesPolicy`) permitindo apenas:
   - `Principal: sns.amazonaws.com`
   - `Action: sqs:SendMessage`

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -50,6 +50,10 @@ Payload esperado na execução:
 - Entrada: `scheduler.sourceIds` e `scheduler.maxConcurrency`.
 - Ação: itera cada `sourceId` e invoca `CollectorLambdaFunction`.
 - Retry com backoff exponencial na task `InvokeCollector` com os mesmos limites do `Scheduler`.
+- Catch por item no `InvokeCollector` (`States.ALL`) para registrar falha da fonte sem interromper o `Map`.
+- Contrato por item em `collectorResults`:
+  - sucesso: `sourceId`, `status=SUCCEEDED`, `processedAt`, `recordsSent`;
+  - falha: `sourceId`, `status=FAILED`, `error`, `cause`.
 - Controle de paralelismo:
   - `MaxConcurrencyPath = $.scheduler.maxConcurrency`.
   - Valor configurado por stage via `MAP_MAX_CONCURRENCY`.
@@ -60,7 +64,9 @@ Payload esperado na execução:
 - Saída final:
   - `meta`
   - `sources` (`schedulerResult.sourceIds`)
+  - `results` (lista de itens com sucesso/falha por `sourceId`)
   - `summary.eligibleSources` (tamanho de `sources`)
+  - `summary.processedSources` (tamanho de `results`)
   - `summary.generatedAt`
   - `summary.maxConcurrency` (limite aplicado no Map)
 

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -270,6 +270,35 @@ const staticFallback = () => {
     process.exit(1);
   }
 
+  const invokeCollectorCatch =
+    states.ProcessEligibleSources?.Iterator?.States?.InvokeCollector?.Catch;
+  const hasCollectorCatch =
+    Array.isArray(invokeCollectorCatch) &&
+    invokeCollectorCatch.some(
+      (entry) =>
+        JSON.stringify(entry?.ErrorEquals ?? []) === JSON.stringify(['States.ALL']) &&
+        entry?.ResultPath === '$.collectorError' &&
+        entry?.Next === 'BuildItemFailureResult',
+    );
+  if (!hasCollectorCatch) {
+    console.error('Falha no fallback estático: InvokeCollector sem Catch por item esperado.');
+    process.exit(1);
+  }
+
+  const buildItemFailureResult =
+    states.ProcessEligibleSources?.Iterator?.States?.BuildItemFailureResult ?? {};
+  if (
+    buildItemFailureResult?.Type !== 'Pass' ||
+    buildItemFailureResult?.Parameters?.status !== 'FAILED' ||
+    buildItemFailureResult?.Parameters?.['error.$'] !== '$.collectorError.Error' ||
+    buildItemFailureResult?.Parameters?.['cause.$'] !== '$.collectorError.Cause'
+  ) {
+    console.error(
+      'Falha no fallback estático: BuildItemFailureResult sem contrato esperado de erro.',
+    );
+    process.exit(1);
+  }
+
   console.warn(
     '\nAviso: renderização multi-stage indisponível por rede. Fallback estático no serverless.yml concluído.',
   );

--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -111,16 +111,33 @@
                 "BackoffRate": 2
               }
             ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.collectorError",
+                "Next": "BuildItemFailureResult"
+              }
+            ],
             "ResultPath": "$.collectorResult",
-            "Next": "BuildItemResult"
+            "Next": "BuildItemSuccessResult"
           },
-          "BuildItemResult": {
+          "BuildItemSuccessResult": {
             "Type": "Pass",
             "Parameters": {
               "sourceId.$": "$.sourceId",
               "status": "SUCCEEDED",
               "processedAt.$": "$.collectorResult.processedAt",
               "recordsSent.$": "$.collectorResult.recordsSent"
+            },
+            "End": true
+          },
+          "BuildItemFailureResult": {
+            "Type": "Pass",
+            "Parameters": {
+              "sourceId.$": "$.sourceId",
+              "status": "FAILED",
+              "error.$": "$.collectorError.Error",
+              "cause.$": "$.collectorError.Cause"
             },
             "End": true
           }

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -105,11 +105,12 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(iterator.StartAt).toBe('InvokeCollector');
     const iteratorStates = asObject(iterator.States);
     const invokeCollector = asObject(iteratorStates.InvokeCollector);
-    const buildItemResult = asObject(iteratorStates.BuildItemResult);
+    const buildItemSuccessResult = asObject(iteratorStates.BuildItemSuccessResult);
+    const buildItemFailureResult = asObject(iteratorStates.BuildItemFailureResult);
 
     expect(invokeCollector.Type).toBe('Task');
     expect(invokeCollector.ResultPath).toBe('$.collectorResult');
-    expect(invokeCollector.Next).toBe('BuildItemResult');
+    expect(invokeCollector.Next).toBe('BuildItemSuccessResult');
     const invokeCollectorResource = asObject(invokeCollector.Resource);
     expect(invokeCollectorResource['Fn::GetAtt']).toEqual(['CollectorLambdaFunction', 'Arn']);
     const invokeCollectorParameters = asObject(invokeCollector.Parameters);
@@ -133,14 +134,29 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(collectorTimeoutRetry.IntervalSeconds).toBe(5);
     expect(collectorTimeoutRetry.MaxAttempts).toBe(2);
     expect(collectorTimeoutRetry.BackoffRate).toBe(2);
+    const invokeCollectorCatch = invokeCollector.Catch as unknown[];
+    expect(Array.isArray(invokeCollectorCatch)).toBe(true);
+    expect(invokeCollectorCatch).toHaveLength(1);
+    const collectorCatchEntry = asObject(invokeCollectorCatch[0]);
+    expect(collectorCatchEntry.ErrorEquals).toEqual(['States.ALL']);
+    expect(collectorCatchEntry.ResultPath).toBe('$.collectorError');
+    expect(collectorCatchEntry.Next).toBe('BuildItemFailureResult');
 
-    expect(buildItemResult.Type).toBe('Pass');
-    expect(buildItemResult.End).toBe(true);
-    const buildItemResultParameters = asObject(buildItemResult.Parameters);
-    expect(buildItemResultParameters['sourceId.$']).toBe('$.sourceId');
-    expect(buildItemResultParameters.status).toBe('SUCCEEDED');
-    expect(buildItemResultParameters['processedAt.$']).toBe('$.collectorResult.processedAt');
-    expect(buildItemResultParameters['recordsSent.$']).toBe('$.collectorResult.recordsSent');
+    expect(buildItemSuccessResult.Type).toBe('Pass');
+    expect(buildItemSuccessResult.End).toBe(true);
+    const buildItemSuccessParameters = asObject(buildItemSuccessResult.Parameters);
+    expect(buildItemSuccessParameters['sourceId.$']).toBe('$.sourceId');
+    expect(buildItemSuccessParameters.status).toBe('SUCCEEDED');
+    expect(buildItemSuccessParameters['processedAt.$']).toBe('$.collectorResult.processedAt');
+    expect(buildItemSuccessParameters['recordsSent.$']).toBe('$.collectorResult.recordsSent');
+
+    expect(buildItemFailureResult.Type).toBe('Pass');
+    expect(buildItemFailureResult.End).toBe(true);
+    const buildItemFailureParameters = asObject(buildItemFailureResult.Parameters);
+    expect(buildItemFailureParameters['sourceId.$']).toBe('$.sourceId');
+    expect(buildItemFailureParameters.status).toBe('FAILED');
+    expect(buildItemFailureParameters['error.$']).toBe('$.collectorError.Error');
+    expect(buildItemFailureParameters['cause.$']).toBe('$.collectorError.Cause');
 
     expect(buildExecutionOutput.Type).toBe('Pass');
     expect(buildExecutionOutput.ResultPath).toBe('$');


### PR DESCRIPTION
Closes #36

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Adicionar tratamento de falha por item no `Map State` da orquestração principal para que erro de uma fonte não interrompa o processamento das demais.

---

## 🧠 Decisão Técnica

Aplicado `Catch` em `InvokeCollector` (escopo do item) com `ResultPath` para `collectorError` e saída padronizada:
- `BuildItemSuccessResult` (`SUCCEEDED`)
- `BuildItemFailureResult` (`FAILED`, `error`, `cause`)

Isso preserva continuidade do `Map` e rastreabilidade de erro por `sourceId`.

---

## 🧪 BDD Validado

Dado que o `Map State` processa múltiplas fontes
Quando uma iteração falha no `InvokeCollector`
Então a falha é capturada no item, as demais fontes continuam e a execução finaliza com saída consolidada.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
