### PR TITLE
feat(step-functions): adicionar logging e metricas na orquestracao

### DIFF
--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -51,6 +51,9 @@ Payload esperado na execução:
 - Ação: itera cada `sourceId` e invoca `CollectorLambdaFunction`.
 - Retry com backoff exponencial na task `InvokeCollector` com os mesmos limites do `Scheduler`.
 - Catch por item no `InvokeCollector` (`States.ALL`) para registrar falha da fonte sem interromper o `Map`.
+- Publica métricas customizadas por item usando `cloudwatch:PutMetricData` (não bloqueante):
+  - `SourceProcessed` / `SourceFailed` (dimensão `Stage`);
+  - `SourceProcessedBySource` / `SourceFailedBySource` (dimensões `Stage`, `ExecutionId`, `SourceId`).
 - Contrato por item em `collectorResults`:
   - sucesso: `sourceId`, `status=SUCCEEDED`, `processedAt`, `recordsSent`;
   - falha: `sourceId`, `status=FAILED`, `error`, `cause`.
@@ -73,6 +76,25 @@ Payload esperado na execução:
 ### Done (Succeed)
 
 - Finaliza execução com saída padronizada da versão v1.
+
+## Observabilidade da orquestração
+
+- **Logging da SFN**:
+  - `loggingConfig.level = ALL`
+  - `includeExecutionData = true`
+  - Log group dedicado: `${service}-${stage}-orchestration` em `/aws/vendedlogs/states/...`
+- **Tracing da SFN**:
+  - `tracingConfig.enabled` por stage (reuso da flag `tracing` já definida em `custom.stages`).
+- **Métricas de execução (custom namespace)**:
+  - Namespace: `AlertOrchestrationService/Orchestration`
+  - `ExecutionSucceeded`, `ExecutionFailed` (dimensão `Stage`)
+  - `ExecutionSucceededByExecution`, `ExecutionFailedByExecution` (dimensões `Stage`, `ExecutionId`)
+  - `ProcessedSources`, `EligibleSources` (dimensão `Stage`)
+- **Métrica de duração**:
+  - Métrica nativa `AWS/States::ExecutionTime` exposta no dashboard de observabilidade da orquestração.
+- **Rastreabilidade por correlação**:
+  - `meta.executionId` é propagado entre estados e utilizado nas dimensões customizadas.
+  - `sourceId` é mantido por item no `Map` e nas métricas por fonte.
 
 ## Cobertura de teste de falha parcial
 

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -43,6 +43,8 @@ const staticFallback = () => {
     'schedulerFunctionName: ${self:custom.naming.prefix}-scheduler',
     'orchestrationStateMachineName: ${self:custom.naming.prefix}-orchestration',
     'orchestrationScheduleRuleName: ${self:custom.naming.prefix}-orchestration-schedule',
+    'orchestrationLogGroupName: /aws/vendedlogs/states/${self:custom.naming.orchestrationStateMachineName}',
+    'orchestrationDashboardName: ${self:custom.naming.prefix}-orchestration-observability',
     'schedulerRoleName: ${self:custom.naming.prefix}-scheduler-role',
     'stateMachineRoleName: ${self:custom.naming.prefix}-state-machine-role',
     'collectorRoleName: ${self:custom.naming.prefix}-collector-role',
@@ -50,6 +52,12 @@ const staticFallback = () => {
     'hubspotConsumerRoleName: ${self:custom.naming.prefix}-hubspot-consumer-role',
     'name: ${self:custom.naming.orchestrationStateMachineName}',
     'name: ${self:custom.naming.orchestrationScheduleRuleName}',
+    'tracingConfig:',
+    'enabled: ${self:custom.stages.${self:provider.stage}.tracing}',
+    'loggingConfig:',
+    'level: ALL',
+    'includeExecutionData: true',
+    'Fn::Sub: ${MainOrchestrationStateMachineLogGroup.Arn}:*',
     'definition: ${file(./state-machines/main-orchestration-v1.asl.json)}',
     'description: Disparo global da orquestracao principal via EventBridge.',
     'rate: ${self:custom.stages.${self:provider.stage}.orchestrationScheduleExpression}',
@@ -63,6 +71,20 @@ const staticFallback = () => {
     'MainStateMachineExecutionRole',
     'SchedulerExecutionRole',
     'CollectorExecutionRole',
+    'MainOrchestrationStateMachineLogGroup:',
+    'LogGroupName: ${self:custom.naming.orchestrationLogGroupName}',
+    'Sid: DeliverStepFunctionsExecutionLogs',
+    'logs:CreateLogDelivery',
+    'logs:GetLogDelivery',
+    'logs:UpdateLogDelivery',
+    'logs:DeleteLogDelivery',
+    'logs:ListLogDeliveries',
+    'logs:PutResourcePolicy',
+    'logs:DescribeResourcePolicies',
+    'logs:DescribeLogGroups',
+    'Sid: PublishOrchestrationMetrics',
+    'cloudwatch:PutMetricData',
+    'cloudwatch:namespace: AlertOrchestrationService/Orchestration',
     'SalesforceConsumerExecutionRole',
     'HubspotConsumerExecutionRole',
     'sourcesTableName: ${self:service}-dev-sources',
@@ -107,6 +129,11 @@ const staticFallback = () => {
     'IntegrationQueuesPolicy:',
     'SalesforceIntegrationSubscription:',
     'HubspotIntegrationSubscription:',
+    'MainOrchestrationObservabilityDashboard:',
+    'Type: AWS::CloudWatch::Dashboard',
+    'DashboardName: ${self:custom.naming.orchestrationDashboardName}',
+    'ExecutionTime',
+    'AlertOrchestrationService/Orchestration',
     'SchedulerExecutionRoleArn:',
     'MainStateMachineExecutionRoleArn:',
     'CollectorExecutionRoleArn:',
@@ -124,6 +151,8 @@ const staticFallback = () => {
     'HubspotIntegrationDlqArn:',
     'SalesforceIntegrationSubscriptionArn:',
     'HubspotIntegrationSubscriptionArn:',
+    'MainOrchestrationStateMachineLogGroupName:',
+    'MainOrchestrationObservabilityDashboardName:',
     'MainStateMachineName:',
     'MainStateMachineArn:',
     'Name: ${self:custom.naming.prefix}-main-state-machine-name',
@@ -192,6 +221,8 @@ const staticFallback = () => {
     'Scheduler',
     'ProcessEligibleSources',
     'BuildExecutionOutput',
+    'PublishExecutionSuccessMetric',
+    'PublishExecutionFailureMetric',
     'Done',
   ];
   const missingStates = requiredStates.filter((stateName) => !(stateName in states));
@@ -223,6 +254,31 @@ const staticFallback = () => {
   const summaryParams = buildExecutionOutput.Parameters?.summary ?? {};
   if (summaryParams['maxConcurrency.$'] !== '$.scheduler.maxConcurrency') {
     console.error('Falha no fallback estático: summary sem maxConcurrency.');
+    process.exit(1);
+  }
+  if (buildExecutionOutput.Next !== 'PublishExecutionSuccessMetric') {
+    console.error(
+      'Falha no fallback estático: BuildExecutionOutput deve encadear PublishExecutionSuccessMetric.',
+    );
+    process.exit(1);
+  }
+
+  const buildSchedulerFailureOutput = states.BuildSchedulerFailureOutput ?? {};
+  if (buildSchedulerFailureOutput.Next !== 'PublishExecutionFailureMetric') {
+    console.error(
+      'Falha no fallback estático: BuildSchedulerFailureOutput deve encadear PublishExecutionFailureMetric.',
+    );
+    process.exit(1);
+  }
+
+  const hasPutMetricDataResource = (state) =>
+    state?.Type === 'Task' &&
+    state?.Resource === 'arn:aws:states:::aws-sdk:cloudwatch:putMetricData';
+  if (
+    !hasPutMetricDataResource(states.PublishExecutionSuccessMetric) ||
+    !hasPutMetricDataResource(states.PublishExecutionFailureMetric)
+  ) {
+    console.error('Falha no fallback estático: tasks de métrica de execução ausentes no ASL.');
     process.exit(1);
   }
 
@@ -287,11 +343,23 @@ const staticFallback = () => {
 
   const buildItemFailureResult =
     states.ProcessEligibleSources?.Iterator?.States?.BuildItemFailureResult ?? {};
+  const publishItemSuccessMetric =
+    states.ProcessEligibleSources?.Iterator?.States?.PublishItemSuccessMetric ?? {};
+  const publishItemFailureMetric =
+    states.ProcessEligibleSources?.Iterator?.States?.PublishItemFailureMetric ?? {};
+  if (
+    !hasPutMetricDataResource(publishItemSuccessMetric) ||
+    !hasPutMetricDataResource(publishItemFailureMetric)
+  ) {
+    console.error('Falha no fallback estático: tasks de métrica por item ausentes no Map.');
+    process.exit(1);
+  }
+
   if (
     buildItemFailureResult?.Type !== 'Pass' ||
-    buildItemFailureResult?.Parameters?.status !== 'FAILED' ||
-    buildItemFailureResult?.Parameters?.['error.$'] !== '$.collectorError.Error' ||
-    buildItemFailureResult?.Parameters?.['cause.$'] !== '$.collectorError.Cause'
+    buildItemFailureResult?.Parameters?.result?.status !== 'FAILED' ||
+    buildItemFailureResult?.Parameters?.result?.['error.$'] !== '$.collectorError.Error' ||
+    buildItemFailureResult?.Parameters?.result?.['cause.$'] !== '$.collectorError.Cause'
   ) {
     console.error(
       'Falha no fallback estático: BuildItemFailureResult sem contrato esperado de erro.',

--- a/serverless.yml
+++ b/serverless.yml
@@ -52,6 +52,8 @@ custom:
     schedulerFunctionName: ${self:custom.naming.prefix}-scheduler
     orchestrationStateMachineName: ${self:custom.naming.prefix}-orchestration
     orchestrationScheduleRuleName: ${self:custom.naming.prefix}-orchestration-schedule
+    orchestrationLogGroupName: /aws/vendedlogs/states/${self:custom.naming.orchestrationStateMachineName}
+    orchestrationDashboardName: ${self:custom.naming.prefix}-orchestration-observability
     schedulerRoleName: ${self:custom.naming.prefix}-scheduler-role
     stateMachineRoleName: ${self:custom.naming.prefix}-state-machine-role
     collectorRoleName: ${self:custom.naming.prefix}-collector-role
@@ -154,6 +156,13 @@ stepFunctions:
         Fn::GetAtt:
           - MainStateMachineExecutionRole
           - Arn
+      tracingConfig:
+        enabled: ${self:custom.stages.${self:provider.stage}.tracing}
+      loggingConfig:
+        level: ALL
+        includeExecutionData: true
+        destinations:
+          - Fn::Sub: ${MainOrchestrationStateMachineLogGroup.Arn}:*
       definition: ${file(./state-machines/main-orchestration-v1.asl.json)}
 
 resources:
@@ -162,6 +171,11 @@ resources:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: /aws/lambda/${self:custom.naming.schedulerFunctionName}
+        RetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
+    MainOrchestrationStateMachineLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: ${self:custom.naming.orchestrationLogGroupName}
         RetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
     SchedulerExecutionRole:
       Type: AWS::IAM::Role
@@ -241,6 +255,26 @@ resources:
                         - CollectorLambdaFunction
                         - Arn
                     - Fn::Sub: ${CollectorLambdaFunction.Arn}:*
+                - Sid: DeliverStepFunctionsExecutionLogs
+                  Effect: Allow
+                  Action:
+                    - logs:CreateLogDelivery
+                    - logs:GetLogDelivery
+                    - logs:UpdateLogDelivery
+                    - logs:DeleteLogDelivery
+                    - logs:ListLogDeliveries
+                    - logs:PutResourcePolicy
+                    - logs:DescribeResourcePolicies
+                    - logs:DescribeLogGroups
+                  Resource: '*'
+                - Sid: PublishOrchestrationMetrics
+                  Effect: Allow
+                  Action:
+                    - cloudwatch:PutMetricData
+                  Resource: '*'
+                  Condition:
+                    StringEquals:
+                      cloudwatch:namespace: AlertOrchestrationService/Orchestration
     CollectorExecutionRole:
       Type: AWS::IAM::Role
       Properties:
@@ -526,6 +560,72 @@ resources:
             - HubspotIntegrationQueue
             - Arn
         RawMessageDelivery: true
+    MainOrchestrationObservabilityDashboard:
+      Type: AWS::CloudWatch::Dashboard
+      Properties:
+        DashboardName: ${self:custom.naming.orchestrationDashboardName}
+        DashboardBody:
+          Fn::Sub: |
+            {
+              "widgets": [
+                {
+                  "type": "metric",
+                  "x": 0,
+                  "y": 0,
+                  "width": 24,
+                  "height": 6,
+                  "properties": {
+                    "title": "State Machine executions (success x failure)",
+                    "view": "timeSeries",
+                    "stacked": false,
+                    "region": "${AWS::Region}",
+                    "period": 300,
+                    "metrics": [
+                      ["AWS/States", "ExecutionsSucceeded", "StateMachineArn", "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${self:custom.naming.orchestrationStateMachineName}", {"stat": "Sum", "label": "Succeeded"}],
+                      [".", "ExecutionsFailed", ".", ".", {"stat": "Sum", "label": "Failed"}]
+                    ]
+                  }
+                },
+                {
+                  "type": "metric",
+                  "x": 0,
+                  "y": 6,
+                  "width": 24,
+                  "height": 6,
+                  "properties": {
+                    "title": "State Machine duration (ExecutionTime)",
+                    "view": "timeSeries",
+                    "stacked": false,
+                    "region": "${AWS::Region}",
+                    "period": 300,
+                    "metrics": [
+                      ["AWS/States", "ExecutionTime", "StateMachineArn", "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${self:custom.naming.orchestrationStateMachineName}", {"stat": "Average", "label": "Avg duration (ms)"}],
+                      [".", "ExecutionTime", ".", ".", {"stat": "p95", "label": "p95 duration (ms)"}]
+                    ]
+                  }
+                },
+                {
+                  "type": "metric",
+                  "x": 0,
+                  "y": 12,
+                  "width": 24,
+                  "height": 6,
+                  "properties": {
+                    "title": "Orchestration custom metrics",
+                    "view": "timeSeries",
+                    "stacked": false,
+                    "region": "${AWS::Region}",
+                    "period": 300,
+                    "metrics": [
+                      ["AlertOrchestrationService/Orchestration", "ExecutionSucceeded", "Stage", "${self:provider.stage}", {"stat": "Sum"}],
+                      [".", "ExecutionFailed", "Stage", "${self:provider.stage}", {"stat": "Sum"}],
+                      [".", "SourceProcessed", "Stage", "${self:provider.stage}", {"stat": "Sum"}],
+                      [".", "SourceFailed", "Stage", "${self:provider.stage}", {"stat": "Sum"}]
+                    ]
+                  }
+                }
+              ]
+            }
   Outputs:
     MainStateMachineName:
       Description: Nome da state machine principal.
@@ -658,3 +758,13 @@ resources:
         Ref: HubspotIntegrationSubscription
       Export:
         Name: ${self:custom.naming.prefix}-hubspot-integration-subscription-arn
+    MainOrchestrationStateMachineLogGroupName:
+      Description: Nome do log group da state machine principal.
+      Value: ${self:custom.naming.orchestrationLogGroupName}
+      Export:
+        Name: ${self:custom.naming.prefix}-main-state-machine-log-group-name
+    MainOrchestrationObservabilityDashboardName:
+      Description: Nome do dashboard de observabilidade da orquestracao.
+      Value: ${self:custom.naming.orchestrationDashboardName}
+      Export:
+        Name: ${self:custom.naming.prefix}-orchestration-observability-dashboard-name

--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -124,20 +124,148 @@
           "BuildItemSuccessResult": {
             "Type": "Pass",
             "Parameters": {
-              "sourceId.$": "$.sourceId",
-              "status": "SUCCEEDED",
-              "processedAt.$": "$.collectorResult.processedAt",
-              "recordsSent.$": "$.collectorResult.recordsSent"
+              "result": {
+                "sourceId.$": "$.sourceId",
+                "status": "SUCCEEDED",
+                "processedAt.$": "$.collectorResult.processedAt",
+                "recordsSent.$": "$.collectorResult.recordsSent"
+              },
+              "metric": {
+                "stage.$": "$.meta.stage",
+                "executionId.$": "$.meta.executionId",
+                "sourceId.$": "$.sourceId"
+              }
+            },
+            "Next": "PublishItemSuccessMetric"
+          },
+          "PublishItemSuccessMetric": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::aws-sdk:cloudwatch:putMetricData",
+            "Parameters": {
+              "Namespace": "AlertOrchestrationService/Orchestration",
+              "MetricData": [
+                {
+                  "MetricName": "SourceProcessed",
+                  "Dimensions": [
+                    {
+                      "Name": "Stage",
+                      "Value.$": "$.metric.stage"
+                    }
+                  ],
+                  "Unit": "Count",
+                  "Value": 1
+                },
+                {
+                  "MetricName": "SourceProcessedBySource",
+                  "Dimensions": [
+                    {
+                      "Name": "Stage",
+                      "Value.$": "$.metric.stage"
+                    },
+                    {
+                      "Name": "ExecutionId",
+                      "Value.$": "$.metric.executionId"
+                    },
+                    {
+                      "Name": "SourceId",
+                      "Value.$": "$.metric.sourceId"
+                    }
+                  ],
+                  "Unit": "Count",
+                  "Value": 1
+                }
+              ]
+            },
+            "Next": "ReturnItemSuccessResult",
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.metricPublishError",
+                "Next": "ReturnItemSuccessResult"
+              }
+            ]
+          },
+          "ReturnItemSuccessResult": {
+            "Type": "Pass",
+            "Parameters": {
+              "sourceId.$": "$.result.sourceId",
+              "status.$": "$.result.status",
+              "processedAt.$": "$.result.processedAt",
+              "recordsSent.$": "$.result.recordsSent"
             },
             "End": true
           },
           "BuildItemFailureResult": {
             "Type": "Pass",
             "Parameters": {
-              "sourceId.$": "$.sourceId",
-              "status": "FAILED",
-              "error.$": "$.collectorError.Error",
-              "cause.$": "$.collectorError.Cause"
+              "result": {
+                "sourceId.$": "$.sourceId",
+                "status": "FAILED",
+                "error.$": "$.collectorError.Error",
+                "cause.$": "$.collectorError.Cause"
+              },
+              "metric": {
+                "stage.$": "$.meta.stage",
+                "executionId.$": "$.meta.executionId",
+                "sourceId.$": "$.sourceId"
+              }
+            },
+            "Next": "PublishItemFailureMetric"
+          },
+          "PublishItemFailureMetric": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::aws-sdk:cloudwatch:putMetricData",
+            "Parameters": {
+              "Namespace": "AlertOrchestrationService/Orchestration",
+              "MetricData": [
+                {
+                  "MetricName": "SourceFailed",
+                  "Dimensions": [
+                    {
+                      "Name": "Stage",
+                      "Value.$": "$.metric.stage"
+                    }
+                  ],
+                  "Unit": "Count",
+                  "Value": 1
+                },
+                {
+                  "MetricName": "SourceFailedBySource",
+                  "Dimensions": [
+                    {
+                      "Name": "Stage",
+                      "Value.$": "$.metric.stage"
+                    },
+                    {
+                      "Name": "ExecutionId",
+                      "Value.$": "$.metric.executionId"
+                    },
+                    {
+                      "Name": "SourceId",
+                      "Value.$": "$.metric.sourceId"
+                    }
+                  ],
+                  "Unit": "Count",
+                  "Value": 1
+                }
+              ]
+            },
+            "Next": "ReturnItemFailureResult",
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.metricPublishError",
+                "Next": "ReturnItemFailureResult"
+              }
+            ]
+          },
+          "ReturnItemFailureResult": {
+            "Type": "Pass",
+            "Parameters": {
+              "sourceId.$": "$.result.sourceId",
+              "status.$": "$.result.status",
+              "error.$": "$.result.error",
+              "cause.$": "$.result.cause"
             },
             "End": true
           }
@@ -161,7 +289,72 @@
         }
       },
       "ResultPath": "$",
-      "Next": "Done"
+      "Next": "PublishExecutionSuccessMetric"
+    },
+    "PublishExecutionSuccessMetric": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:cloudwatch:putMetricData",
+      "Parameters": {
+        "Namespace": "AlertOrchestrationService/Orchestration",
+        "MetricData": [
+          {
+            "MetricName": "ExecutionSucceeded",
+            "Dimensions": [
+              {
+                "Name": "Stage",
+                "Value.$": "$.meta.stage"
+              }
+            ],
+            "Unit": "Count",
+            "Value": 1
+          },
+          {
+            "MetricName": "ExecutionSucceededByExecution",
+            "Dimensions": [
+              {
+                "Name": "Stage",
+                "Value.$": "$.meta.stage"
+              },
+              {
+                "Name": "ExecutionId",
+                "Value.$": "$.meta.executionId"
+              }
+            ],
+            "Unit": "Count",
+            "Value": 1
+          },
+          {
+            "MetricName": "ProcessedSources",
+            "Dimensions": [
+              {
+                "Name": "Stage",
+                "Value.$": "$.meta.stage"
+              }
+            ],
+            "Unit": "Count",
+            "Value.$": "$.summary.processedSources"
+          },
+          {
+            "MetricName": "EligibleSources",
+            "Dimensions": [
+              {
+                "Name": "Stage",
+                "Value.$": "$.meta.stage"
+              }
+            ],
+            "Unit": "Count",
+            "Value.$": "$.summary.eligibleSources"
+          }
+        ]
+      },
+      "Next": "Done",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.metricPublishError",
+          "Next": "Done"
+        }
+      ]
     },
     "BuildSchedulerFailureOutput": {
       "Type": "Pass",
@@ -178,7 +371,50 @@
         }
       },
       "ResultPath": "$",
-      "Next": "SchedulerFailed"
+      "Next": "PublishExecutionFailureMetric"
+    },
+    "PublishExecutionFailureMetric": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::aws-sdk:cloudwatch:putMetricData",
+      "Parameters": {
+        "Namespace": "AlertOrchestrationService/Orchestration",
+        "MetricData": [
+          {
+            "MetricName": "ExecutionFailed",
+            "Dimensions": [
+              {
+                "Name": "Stage",
+                "Value.$": "$.meta.stage"
+              }
+            ],
+            "Unit": "Count",
+            "Value": 1
+          },
+          {
+            "MetricName": "ExecutionFailedByExecution",
+            "Dimensions": [
+              {
+                "Name": "Stage",
+                "Value.$": "$.meta.stage"
+              },
+              {
+                "Name": "ExecutionId",
+                "Value.$": "$.meta.executionId"
+              }
+            ],
+            "Unit": "Count",
+            "Value": 1
+          }
+        ]
+      },
+      "Next": "SchedulerFailed",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.metricPublishError",
+          "Next": "SchedulerFailed"
+        }
+      ]
     },
     "SchedulerFailed": {
       "Type": "Fail",

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -83,7 +83,9 @@ describe('main-orchestration-v1.asl.json', () => {
     const normalizeSchedulerOutput = asObject(states.NormalizeSchedulerOutput);
     const processEligibleSources = asObject(states.ProcessEligibleSources);
     const buildExecutionOutput = asObject(states.BuildExecutionOutput);
+    const publishExecutionSuccessMetric = asObject(states.PublishExecutionSuccessMetric);
     const buildSchedulerFailureOutput = asObject(states.BuildSchedulerFailureOutput);
+    const publishExecutionFailureMetric = asObject(states.PublishExecutionFailureMetric);
     const schedulerFailed = asObject(states.SchedulerFailed);
     const done = asObject(states.Done);
 
@@ -161,7 +163,11 @@ describe('main-orchestration-v1.asl.json', () => {
     const iteratorStates = asObject(iterator.States);
     const invokeCollector = asObject(iteratorStates.InvokeCollector);
     const buildItemSuccessResult = asObject(iteratorStates.BuildItemSuccessResult);
+    const publishItemSuccessMetric = asObject(iteratorStates.PublishItemSuccessMetric);
+    const returnItemSuccessResult = asObject(iteratorStates.ReturnItemSuccessResult);
     const buildItemFailureResult = asObject(iteratorStates.BuildItemFailureResult);
+    const publishItemFailureMetric = asObject(iteratorStates.PublishItemFailureMetric);
+    const returnItemFailureResult = asObject(iteratorStates.ReturnItemFailureResult);
 
     expect(invokeCollector.Type).toBe('Task');
     expect(invokeCollector.ResultPath).toBe('$.collectorResult');
@@ -198,24 +204,82 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(collectorCatchEntry.Next).toBe('BuildItemFailureResult');
 
     expect(buildItemSuccessResult.Type).toBe('Pass');
-    expect(buildItemSuccessResult.End).toBe(true);
+    expect(buildItemSuccessResult.Next).toBe('PublishItemSuccessMetric');
     const buildItemSuccessParameters = asObject(buildItemSuccessResult.Parameters);
-    expect(buildItemSuccessParameters['sourceId.$']).toBe('$.sourceId');
-    expect(buildItemSuccessParameters.status).toBe('SUCCEEDED');
-    expect(buildItemSuccessParameters['processedAt.$']).toBe('$.collectorResult.processedAt');
-    expect(buildItemSuccessParameters['recordsSent.$']).toBe('$.collectorResult.recordsSent');
+    const buildItemSuccessPayload = asObject(buildItemSuccessParameters.result);
+    expect(buildItemSuccessPayload['sourceId.$']).toBe('$.sourceId');
+    expect(buildItemSuccessPayload.status).toBe('SUCCEEDED');
+    expect(buildItemSuccessPayload['processedAt.$']).toBe('$.collectorResult.processedAt');
+    expect(buildItemSuccessPayload['recordsSent.$']).toBe('$.collectorResult.recordsSent');
+    const buildItemSuccessMetric = asObject(buildItemSuccessParameters.metric);
+    expect(buildItemSuccessMetric['stage.$']).toBe('$.meta.stage');
+    expect(buildItemSuccessMetric['executionId.$']).toBe('$.meta.executionId');
+    expect(buildItemSuccessMetric['sourceId.$']).toBe('$.sourceId');
+
+    expect(publishItemSuccessMetric.Type).toBe('Task');
+    expect(publishItemSuccessMetric.Resource).toBe(
+      'arn:aws:states:::aws-sdk:cloudwatch:putMetricData',
+    );
+    expect(publishItemSuccessMetric.Next).toBe('ReturnItemSuccessResult');
+    const publishItemSuccessParams = asObject(publishItemSuccessMetric.Parameters);
+    expect(publishItemSuccessParams.Namespace).toBe('AlertOrchestrationService/Orchestration');
+    const publishItemSuccessMetricData = asArray(publishItemSuccessParams.MetricData);
+    expect(publishItemSuccessMetricData).toHaveLength(2);
+    const publishItemSuccessCatch = asArray(publishItemSuccessMetric.Catch);
+    expect(publishItemSuccessCatch).toHaveLength(1);
+    const publishItemSuccessCatchEntry = asObject(publishItemSuccessCatch[0]);
+    expect(publishItemSuccessCatchEntry.ErrorEquals).toEqual(['States.ALL']);
+    expect(publishItemSuccessCatchEntry.ResultPath).toBe('$.metricPublishError');
+    expect(publishItemSuccessCatchEntry.Next).toBe('ReturnItemSuccessResult');
+
+    expect(returnItemSuccessResult.Type).toBe('Pass');
+    expect(returnItemSuccessResult.End).toBe(true);
+    const returnItemSuccessParameters = asObject(returnItemSuccessResult.Parameters);
+    expect(returnItemSuccessParameters['sourceId.$']).toBe('$.result.sourceId');
+    expect(returnItemSuccessParameters['status.$']).toBe('$.result.status');
+    expect(returnItemSuccessParameters['processedAt.$']).toBe('$.result.processedAt');
+    expect(returnItemSuccessParameters['recordsSent.$']).toBe('$.result.recordsSent');
 
     expect(buildItemFailureResult.Type).toBe('Pass');
-    expect(buildItemFailureResult.End).toBe(true);
+    expect(buildItemFailureResult.Next).toBe('PublishItemFailureMetric');
     const buildItemFailureParameters = asObject(buildItemFailureResult.Parameters);
-    expect(buildItemFailureParameters['sourceId.$']).toBe('$.sourceId');
-    expect(buildItemFailureParameters.status).toBe('FAILED');
-    expect(buildItemFailureParameters['error.$']).toBe('$.collectorError.Error');
-    expect(buildItemFailureParameters['cause.$']).toBe('$.collectorError.Cause');
+    const buildItemFailurePayload = asObject(buildItemFailureParameters.result);
+    expect(buildItemFailurePayload['sourceId.$']).toBe('$.sourceId');
+    expect(buildItemFailurePayload.status).toBe('FAILED');
+    expect(buildItemFailurePayload['error.$']).toBe('$.collectorError.Error');
+    expect(buildItemFailurePayload['cause.$']).toBe('$.collectorError.Cause');
+    const buildItemFailureMetric = asObject(buildItemFailureParameters.metric);
+    expect(buildItemFailureMetric['stage.$']).toBe('$.meta.stage');
+    expect(buildItemFailureMetric['executionId.$']).toBe('$.meta.executionId');
+    expect(buildItemFailureMetric['sourceId.$']).toBe('$.sourceId');
+
+    expect(publishItemFailureMetric.Type).toBe('Task');
+    expect(publishItemFailureMetric.Resource).toBe(
+      'arn:aws:states:::aws-sdk:cloudwatch:putMetricData',
+    );
+    expect(publishItemFailureMetric.Next).toBe('ReturnItemFailureResult');
+    const publishItemFailureParams = asObject(publishItemFailureMetric.Parameters);
+    expect(publishItemFailureParams.Namespace).toBe('AlertOrchestrationService/Orchestration');
+    const publishItemFailureMetricData = asArray(publishItemFailureParams.MetricData);
+    expect(publishItemFailureMetricData).toHaveLength(2);
+    const publishItemFailureCatch = asArray(publishItemFailureMetric.Catch);
+    expect(publishItemFailureCatch).toHaveLength(1);
+    const publishItemFailureCatchEntry = asObject(publishItemFailureCatch[0]);
+    expect(publishItemFailureCatchEntry.ErrorEquals).toEqual(['States.ALL']);
+    expect(publishItemFailureCatchEntry.ResultPath).toBe('$.metricPublishError');
+    expect(publishItemFailureCatchEntry.Next).toBe('ReturnItemFailureResult');
+
+    expect(returnItemFailureResult.Type).toBe('Pass');
+    expect(returnItemFailureResult.End).toBe(true);
+    const returnItemFailureParameters = asObject(returnItemFailureResult.Parameters);
+    expect(returnItemFailureParameters['sourceId.$']).toBe('$.result.sourceId');
+    expect(returnItemFailureParameters['status.$']).toBe('$.result.status');
+    expect(returnItemFailureParameters['error.$']).toBe('$.result.error');
+    expect(returnItemFailureParameters['cause.$']).toBe('$.result.cause');
 
     expect(buildExecutionOutput.Type).toBe('Pass');
     expect(buildExecutionOutput.ResultPath).toBe('$');
-    expect(buildExecutionOutput.Next).toBe('Done');
+    expect(buildExecutionOutput.Next).toBe('PublishExecutionSuccessMetric');
     const outputParameters = asObject(buildExecutionOutput.Parameters);
     expect(outputParameters['meta.$']).toBe('$.meta');
     expect(outputParameters['sources.$']).toBe('$.scheduler.sourceIds');
@@ -227,9 +291,25 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(summary['maxConcurrency.$']).toBe('$.scheduler.maxConcurrency');
     expect(summary.schedulerStatus).toBe('SUCCEEDED');
 
+    expect(publishExecutionSuccessMetric.Type).toBe('Task');
+    expect(publishExecutionSuccessMetric.Resource).toBe(
+      'arn:aws:states:::aws-sdk:cloudwatch:putMetricData',
+    );
+    expect(publishExecutionSuccessMetric.Next).toBe('Done');
+    const publishExecutionSuccessParams = asObject(publishExecutionSuccessMetric.Parameters);
+    expect(publishExecutionSuccessParams.Namespace).toBe('AlertOrchestrationService/Orchestration');
+    const publishExecutionSuccessMetricData = asArray(publishExecutionSuccessParams.MetricData);
+    expect(publishExecutionSuccessMetricData).toHaveLength(4);
+    const publishExecutionSuccessCatch = asArray(publishExecutionSuccessMetric.Catch);
+    expect(publishExecutionSuccessCatch).toHaveLength(1);
+    const publishExecutionSuccessCatchEntry = asObject(publishExecutionSuccessCatch[0]);
+    expect(publishExecutionSuccessCatchEntry.ErrorEquals).toEqual(['States.ALL']);
+    expect(publishExecutionSuccessCatchEntry.ResultPath).toBe('$.metricPublishError');
+    expect(publishExecutionSuccessCatchEntry.Next).toBe('Done');
+
     expect(buildSchedulerFailureOutput.Type).toBe('Pass');
     expect(buildSchedulerFailureOutput.ResultPath).toBe('$');
-    expect(buildSchedulerFailureOutput.Next).toBe('SchedulerFailed');
+    expect(buildSchedulerFailureOutput.Next).toBe('PublishExecutionFailureMetric');
     const buildSchedulerFailureParameters = asObject(buildSchedulerFailureOutput.Parameters);
     expect(buildSchedulerFailureParameters['meta.$']).toBe('$.meta');
     expect(buildSchedulerFailureParameters.sources).toEqual([]);
@@ -240,6 +320,22 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(failureSummary.schedulerStatus).toBe('FAILED');
     expect(failureSummary['error.$']).toBe('$.schedulerError.Error');
     expect(failureSummary['cause.$']).toBe('$.schedulerError.Cause');
+
+    expect(publishExecutionFailureMetric.Type).toBe('Task');
+    expect(publishExecutionFailureMetric.Resource).toBe(
+      'arn:aws:states:::aws-sdk:cloudwatch:putMetricData',
+    );
+    expect(publishExecutionFailureMetric.Next).toBe('SchedulerFailed');
+    const publishExecutionFailureParams = asObject(publishExecutionFailureMetric.Parameters);
+    expect(publishExecutionFailureParams.Namespace).toBe('AlertOrchestrationService/Orchestration');
+    const publishExecutionFailureMetricData = asArray(publishExecutionFailureParams.MetricData);
+    expect(publishExecutionFailureMetricData).toHaveLength(2);
+    const publishExecutionFailureCatch = asArray(publishExecutionFailureMetric.Catch);
+    expect(publishExecutionFailureCatch).toHaveLength(1);
+    const publishExecutionFailureCatchEntry = asObject(publishExecutionFailureCatch[0]);
+    expect(publishExecutionFailureCatchEntry.ErrorEquals).toEqual(['States.ALL']);
+    expect(publishExecutionFailureCatchEntry.ResultPath).toBe('$.metricPublishError');
+    expect(publishExecutionFailureCatchEntry.Next).toBe('SchedulerFailed');
 
     expect(schedulerFailed.Type).toBe('Fail');
     expect(schedulerFailed.Error).toBe('SchedulerStepFailed');
@@ -255,38 +351,63 @@ describe('main-orchestration-v1.asl.json', () => {
     const buildExecutionOutput = asObject(states.BuildExecutionOutput);
     const iteratorStates = asObject(asObject(processEligibleSources.Iterator).States);
     const buildItemSuccessResult = asObject(iteratorStates.BuildItemSuccessResult);
+    const returnItemSuccessResult = asObject(iteratorStates.ReturnItemSuccessResult);
     const buildItemFailureResult = asObject(iteratorStates.BuildItemFailureResult);
+    const returnItemFailureResult = asObject(iteratorStates.ReturnItemFailureResult);
 
     const buildItemSuccessParameters = asObject(buildItemSuccessResult.Parameters);
+    const returnItemSuccessParameters = asObject(returnItemSuccessResult.Parameters);
     const buildItemFailureParameters = asObject(buildItemFailureResult.Parameters);
+    const returnItemFailureParameters = asObject(returnItemFailureResult.Parameters);
     const buildExecutionOutputParameters = asObject(buildExecutionOutput.Parameters);
 
-    const sourceAResult = asObject(
+    const sourceARawResult = asObject(
       materializeParameters(buildItemSuccessParameters, {
         sourceId: 'source-a',
+        meta: {
+          stage: 'dev',
+          executionId: 'exec-123',
+        },
         collectorResult: {
           processedAt: '2026-03-03T00:00:00.000Z',
           recordsSent: 12,
         },
       }),
     );
-    const sourceBResult = asObject(
+    const sourceAResult = asObject(
+      materializeParameters(returnItemSuccessParameters, sourceARawResult),
+    );
+    const sourceBRawResult = asObject(
       materializeParameters(buildItemFailureParameters, {
         sourceId: 'source-b',
+        meta: {
+          stage: 'dev',
+          executionId: 'exec-123',
+        },
         collectorError: {
           Error: 'CollectorTimeout',
           Cause: 'Connection timeout while reading source-b',
         },
       }),
     );
-    const sourceCResult = asObject(
+    const sourceBResult = asObject(
+      materializeParameters(returnItemFailureParameters, sourceBRawResult),
+    );
+    const sourceCRawResult = asObject(
       materializeParameters(buildItemSuccessParameters, {
         sourceId: 'source-c',
+        meta: {
+          stage: 'dev',
+          executionId: 'exec-123',
+        },
         collectorResult: {
           processedAt: '2026-03-03T00:00:02.000Z',
           recordsSent: 4,
         },
       }),
+    );
+    const sourceCResult = asObject(
+      materializeParameters(returnItemSuccessParameters, sourceCRawResult),
     );
 
     const executionOutput = asObject(


### PR DESCRIPTION
Closes #38

---

## 🎯 Objetivo

Habilitar observabilidade operacional da orquestração principal com logging estruturado da SFN, métricas de execução/fonte e dashboard com métrica de duração.

---

## 🧠 Decisão Técnica

- Ativei `tracingConfig` e `loggingConfig` na state machine principal com log group dedicado (`/aws/vendedlogs/states/...`).
- Mantive princípio de resiliência: publicação de métricas em estados dedicados com `Catch`, sem bloquear o fluxo principal.
- Usei `arn:aws:states:::aws-sdk:cloudwatch:putMetricData` para métricas customizadas por execução e por `sourceId`.
- Adicionei dashboard CloudWatch com métricas nativas `AWS/States` (`ExecutionsSucceeded`, `ExecutionsFailed`, `ExecutionTime`) e métricas customizadas do namespace da orquestração.
- Atualizei permissões IAM mínimas da role da SFN para entrega de logs e `cloudwatch:PutMetricData` restrito por namespace.

---

## 🧪 BDD Validado

Dado que a orquestração é executada por EventBridge
Quando a state machine processa fontes elegíveis com sucesso parcial ou falha
Então os logs de execução ficam disponíveis no CloudWatch, as métricas de sucesso/erro/duração são observáveis e a rastreabilidade por `executionId` e `sourceId` é preservada.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [x] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [x] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
