### PR TITLE
feat(api): criar endpoint PATCH /sources/{id}

### DIFF
--- a/docs/sources/update-source-endpoint-v1.md
+++ b/docs/sources/update-source-endpoint-v1.md
@@ -1,0 +1,58 @@
+# PATCH /sources/{id} — Atualização Parcial de Fonte (v1)
+
+## Objetivo
+
+Atualizar parcialmente uma fonte já cadastrada no plugin registry, preservando campos imutáveis e aplicando controle de concorrência otimista.
+
+## Requisição
+
+- Método: `PATCH`
+- Rota: `/sources/{id}`
+- `pathParameters.id`: identificador da fonte (`sourceId`)
+- Body: JSON com ao menos um campo mutável
+
+## Campos mutáveis
+
+- `active`
+- `secretArn`
+- `query`
+- `cursorField`
+- `fieldMap`
+- `scheduleType`
+- `intervalMinutes`
+- `cronExpr`
+- `nextRunAt`
+
+## Campos imutáveis
+
+- `sourceId`
+- `engine`
+- `schemaVersion`
+- `createdAt`
+- `updatedAt`
+
+Se o payload incluir campos imutáveis ou desconhecidos, a API retorna `422`.
+
+## Controle de versão
+
+A atualização usa optimistic locking em `updatedAt`:
+
+- A API lê o estado atual.
+- A gravação só é aceita quando o `updatedAt` em banco ainda é o mesmo lido.
+- Em caso de corrida concorrente, retorna `409 SOURCE_VERSION_CONFLICT`.
+
+## Respostas
+
+- `200 OK`
+  - `sourceId`
+  - `metadata.schemaVersion`
+  - `metadata.createdAt`
+  - `metadata.updatedAt`
+  - `metadata.requestId`
+- `404 Not Found`
+  - `code: SOURCE_NOT_FOUND`
+- `409 Conflict`
+  - `code: SOURCE_VERSION_CONFLICT`
+- `422 Unprocessable Entity`
+  - `message: Source patch validation failed.`
+  - `errors[]`

--- a/serverless.yml
+++ b/serverless.yml
@@ -51,6 +51,7 @@ custom:
     prefix: ${self:service}-${self:provider.stage}
     schedulerFunctionName: ${self:custom.naming.prefix}-scheduler
     createSourceFunctionName: ${self:custom.naming.prefix}-create-source
+    updateSourceFunctionName: ${self:custom.naming.prefix}-update-source
     orchestrationStateMachineName: ${self:custom.naming.prefix}-orchestration
     orchestrationScheduleRuleName: ${self:custom.naming.prefix}-orchestration-schedule
     orchestrationLogGroupName: /aws/vendedlogs/states/${self:custom.naming.orchestrationStateMachineName}
@@ -152,6 +153,20 @@ functions:
       - httpApi:
           method: post
           path: /sources
+  updateSource:
+    name: ${self:custom.naming.updateSourceFunctionName}
+    handler: dist/handlers/update-source.handler
+    description: Endpoint PATCH para atualizacao parcial de fontes no plugin registry.
+    memorySize: 256
+    timeout: 30
+    role:
+      Fn::GetAtt:
+        - SourceRegistryApiExecutionRole
+        - Arn
+    events:
+      - httpApi:
+          method: patch
+          path: /sources/{id}
 
 stepFunctions:
   stateMachines:
@@ -192,6 +207,11 @@ resources:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: /aws/lambda/${self:custom.naming.createSourceFunctionName}
+        RetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
+    UpdateSourceLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/lambda/${self:custom.naming.updateSourceFunctionName}
         RetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
     MainOrchestrationStateMachineLogGroup:
       Type: AWS::Logs::LogGroup
@@ -343,7 +363,7 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         RoleName: ${self:custom.naming.sourceRegistryApiRoleName}
-        Description: Role da API de fontes com privilegio minimo para criacao na tabela sources.
+        Description: Role da API de fontes com privilegio minimo para criacao e atualizacao na tabela sources.
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:
@@ -360,18 +380,20 @@ resources:
                 - Sid: CreateSource
                   Effect: Allow
                   Action:
+                    - dynamodb:GetItem
                     - dynamodb:PutItem
                   Resource:
                     - Fn::GetAtt:
                         - SourcesTable
                         - Arn
-                - Sid: WriteCreateSourceLogs
+                - Sid: WriteSourceRegistryApiLogs
                   Effect: Allow
                   Action:
                     - logs:CreateLogStream
                     - logs:PutLogEvents
                   Resource:
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.createSourceFunctionName}:*
+                    - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.updateSourceFunctionName}:*
     SalesforceConsumerExecutionRole:
       Type: AWS::IAM::Role
       Properties:

--- a/src/README.md
+++ b/src/README.md
@@ -22,6 +22,7 @@
 src/
   handlers/
     create-source.ts
+    update-source.ts
   domain/
     scheduler/
     sources/

--- a/src/domain/sources/source-registry-repository.ts
+++ b/src/domain/sources/source-registry-repository.ts
@@ -8,11 +8,24 @@ export type SourceRegistryRecord = SourceSchemaV1 & {
 
 export interface SourceRegistryRepository {
   create(source: SourceRegistryRecord): Promise<void>;
+  getById(sourceId: string): Promise<SourceRegistryRecord | null>;
+  update(params: {
+    sourceId: string;
+    source: SourceRegistryRecord;
+    expectedUpdatedAt: string;
+  }): Promise<void>;
 }
 
 export class SourceAlreadyExistsError extends Error {
   constructor(sourceId: string) {
     super(`Source "${sourceId}" already exists.`);
     this.name = 'SourceAlreadyExistsError';
+  }
+}
+
+export class SourceVersionConflictError extends Error {
+  constructor(sourceId: string) {
+    super(`Source "${sourceId}" version conflict.`);
+    this.name = 'SourceVersionConflictError';
   }
 }

--- a/src/handlers/update-source.ts
+++ b/src/handlers/update-source.ts
@@ -1,0 +1,318 @@
+import {
+  SourceVersionConflictError,
+  type SourceRegistryRecord,
+  type SourceRegistryRepository,
+} from '../domain/sources/source-registry-repository';
+import {
+  type SourceSchemaValidationError,
+  validateSourceSchemaV1,
+} from '../domain/sources/source-schema';
+import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
+import { nowIso } from '../shared/time/now-iso';
+
+const JSON_HEADERS = {
+  'content-type': 'application/json',
+};
+
+const IMMUTABLE_FIELDS = ['sourceId', 'engine', 'schemaVersion', 'createdAt', 'updatedAt'] as const;
+const MUTABLE_FIELDS = [
+  'active',
+  'secretArn',
+  'query',
+  'cursorField',
+  'fieldMap',
+  'scheduleType',
+  'intervalMinutes',
+  'cronExpr',
+  'nextRunAt',
+] as const;
+const KNOWN_FIELDS = new Set<string>([...IMMUTABLE_FIELDS, ...MUTABLE_FIELDS]);
+
+interface UpdateSourcePatchPayload {
+  active?: boolean;
+  secretArn?: string;
+  query?: string;
+  cursorField?: string;
+  fieldMap?: Record<string, string>;
+  scheduleType?: 'interval' | 'cron';
+  intervalMinutes?: number;
+  cronExpr?: string;
+  nextRunAt?: string;
+}
+
+export interface UpdateSourceEvent {
+  body?: string | null;
+  pathParameters?: {
+    id?: string;
+  };
+  requestContext?: {
+    requestId?: string;
+  };
+}
+
+export interface UpdateSourceResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface UpdateSourceDependencies {
+  sourceRegistryRepository: SourceRegistryRepository;
+  now: () => string;
+}
+
+let cachedDefaultDependencies: UpdateSourceDependencies | undefined;
+
+const response = (statusCode: number, payload: unknown): UpdateSourceResponse => ({
+  statusCode,
+  headers: JSON_HEADERS,
+  body: JSON.stringify(payload),
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const parseBody = (
+  rawBody: string | null | undefined,
+): { success: true; value: unknown } | { success: false; response: UpdateSourceResponse } => {
+  if (typeof rawBody !== 'string' || rawBody.trim().length === 0) {
+    return {
+      success: false,
+      response: response(400, {
+        message: 'Request body must be a valid JSON object.',
+      }),
+    };
+  }
+
+  try {
+    return {
+      success: true,
+      value: JSON.parse(rawBody) as unknown,
+    };
+  } catch {
+    return {
+      success: false,
+      response: response(400, {
+        message: 'Request body must be valid JSON.',
+      }),
+    };
+  }
+};
+
+const parseSourceId = (
+  rawSourceId: string | undefined,
+): { success: true; value: string } | { success: false; response: UpdateSourceResponse } => {
+  if (typeof rawSourceId !== 'string' || rawSourceId.trim().length === 0) {
+    return {
+      success: false,
+      response: response(400, {
+        message: 'Path parameter "id" is required.',
+      }),
+    };
+  }
+
+  return {
+    success: true,
+    value: rawSourceId.trim(),
+  };
+};
+
+const validatePatchPayload = (
+  payload: unknown,
+):
+  | { success: true; value: UpdateSourcePatchPayload }
+  | { success: false; errors: SourceSchemaValidationError[] } => {
+  if (!isRecord(payload)) {
+    return {
+      success: false,
+      errors: [
+        {
+          field: '$',
+          code: 'INVALID_TYPE',
+          message: 'patch payload must be an object.',
+        },
+      ],
+    };
+  }
+
+  const errors: SourceSchemaValidationError[] = [];
+  const patch: UpdateSourcePatchPayload = {};
+  let mutableFieldCount = 0;
+
+  for (const key of Object.keys(payload)) {
+    if (!KNOWN_FIELDS.has(key)) {
+      errors.push({
+        field: key,
+        code: 'INVALID_VALUE',
+        message: `field "${key}" is not supported for source updates.`,
+      });
+      continue;
+    }
+
+    if ((IMMUTABLE_FIELDS as readonly string[]).includes(key)) {
+      errors.push({
+        field: key,
+        code: 'INVALID_VALUE',
+        message: `field "${key}" is immutable and cannot be updated.`,
+      });
+      continue;
+    }
+
+    mutableFieldCount += 1;
+    patch[key as keyof UpdateSourcePatchPayload] = payload[key] as never;
+  }
+
+  if (mutableFieldCount === 0) {
+    errors.push({
+      field: '$',
+      code: 'INVALID_VALUE',
+      message: 'patch payload must include at least one mutable field.',
+    });
+  }
+
+  if (errors.length > 0) {
+    return {
+      success: false,
+      errors,
+    };
+  }
+
+  return {
+    success: true,
+    value: patch,
+  };
+};
+
+const mergeSourceRecord = (
+  current: SourceRegistryRecord,
+  patch: UpdateSourcePatchPayload,
+  nextUpdatedAt: string,
+): SourceRegistryRecord | { validationErrors: SourceSchemaValidationError[] } => {
+  const nextScheduleType = patch.scheduleType ?? current.scheduleType;
+  const nextIntervalMinutes =
+    nextScheduleType === 'interval'
+      ? (patch.intervalMinutes ??
+        (current.scheduleType === 'interval' ? current.intervalMinutes : undefined))
+      : patch.intervalMinutes;
+  const nextCronExpr =
+    nextScheduleType === 'cron'
+      ? (patch.cronExpr ?? (current.scheduleType === 'cron' ? current.cronExpr : undefined))
+      : patch.cronExpr;
+
+  const validation = validateSourceSchemaV1({
+    sourceId: current.sourceId,
+    active: patch.active ?? current.active,
+    engine: current.engine,
+    secretArn: patch.secretArn ?? current.secretArn,
+    query: patch.query ?? current.query,
+    cursorField: patch.cursorField ?? current.cursorField,
+    fieldMap: patch.fieldMap ?? current.fieldMap,
+    scheduleType: nextScheduleType,
+    intervalMinutes: nextIntervalMinutes,
+    cronExpr: nextCronExpr,
+    nextRunAt: patch.nextRunAt ?? current.nextRunAt,
+  });
+
+  if (!validation.success) {
+    return {
+      validationErrors: validation.errors,
+    };
+  }
+
+  return {
+    ...validation.value,
+    schemaVersion: current.schemaVersion,
+    createdAt: current.createdAt,
+    updatedAt: nextUpdatedAt,
+  };
+};
+
+const getDefaultDependencies = (): UpdateSourceDependencies => {
+  if (cachedDefaultDependencies) {
+    return cachedDefaultDependencies;
+  }
+
+  const tableName = process.env.SOURCES_TABLE_NAME;
+  if (!tableName || tableName.trim().length === 0) {
+    throw new Error('SOURCES_TABLE_NAME is required.');
+  }
+
+  cachedDefaultDependencies = {
+    sourceRegistryRepository: createDynamoDbSourceRegistryRepository({ tableName }),
+    now: nowIso,
+  };
+
+  return cachedDefaultDependencies;
+};
+
+export const createHandler =
+  ({ sourceRegistryRepository, now }: UpdateSourceDependencies) =>
+  async (event: UpdateSourceEvent): Promise<UpdateSourceResponse> => {
+    const sourceId = parseSourceId(event.pathParameters?.id);
+    if (!sourceId.success) {
+      return sourceId.response;
+    }
+
+    const parsedBody = parseBody(event.body);
+    if (!parsedBody.success) {
+      return parsedBody.response;
+    }
+
+    const patchValidation = validatePatchPayload(parsedBody.value);
+    if (!patchValidation.success) {
+      return response(422, {
+        message: 'Source patch validation failed.',
+        errors: patchValidation.errors,
+      });
+    }
+
+    const current = await sourceRegistryRepository.getById(sourceId.value);
+    if (!current) {
+      return response(404, {
+        message: `Source "${sourceId.value}" was not found.`,
+        code: 'SOURCE_NOT_FOUND',
+      });
+    }
+
+    const nextUpdatedAt = now();
+    const merged = mergeSourceRecord(current, patchValidation.value, nextUpdatedAt);
+    if ('validationErrors' in merged) {
+      return response(422, {
+        message: 'Source patch validation failed.',
+        errors: merged.validationErrors,
+      });
+    }
+
+    try {
+      await sourceRegistryRepository.update({
+        sourceId: current.sourceId,
+        source: merged,
+        expectedUpdatedAt: current.updatedAt,
+      });
+
+      return response(200, {
+        sourceId: merged.sourceId,
+        metadata: {
+          schemaVersion: merged.schemaVersion,
+          createdAt: merged.createdAt,
+          updatedAt: merged.updatedAt,
+          requestId: event.requestContext?.requestId ?? null,
+        },
+      });
+    } catch (error) {
+      if (error instanceof SourceVersionConflictError) {
+        return response(409, {
+          message: error.message,
+          code: 'SOURCE_VERSION_CONFLICT',
+        });
+      }
+
+      return response(500, {
+        message: 'Failed to update source.',
+      });
+    }
+  };
+
+export async function handler(event: UpdateSourceEvent): Promise<UpdateSourceResponse> {
+  return createHandler(getDefaultDependencies())(event);
+}

--- a/src/infra/sources/dynamodb-source-registry-repository.ts
+++ b/src/infra/sources/dynamodb-source-registry-repository.ts
@@ -1,15 +1,19 @@
 import {
+  type AttributeValue,
   ConditionalCheckFailedException,
   DynamoDBClient,
+  GetItemCommand,
   PutItemCommand,
 } from '@aws-sdk/client-dynamodb';
-import { marshall } from '@aws-sdk/util-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 
 import {
   SourceAlreadyExistsError,
+  SourceVersionConflictError,
   type SourceRegistryRecord,
   type SourceRegistryRepository,
 } from '../../domain/sources/source-registry-repository';
+import { validateSourceSchemaV1 } from '../../domain/sources/source-schema';
 
 export interface DynamoDbSourceRegistryRepositoryParams {
   tableName: string;
@@ -45,6 +49,62 @@ const toDynamoItem = (source: SourceRegistryRecord): Record<string, unknown> => 
   updatedAt: source.updatedAt,
 });
 
+const parseActive = (value: unknown): boolean | null => {
+  if (value === 'true' || value === true) {
+    return true;
+  }
+
+  if (value === 'false' || value === false) {
+    return false;
+  }
+
+  return null;
+};
+
+const toSourceRegistryRecord = (item: Record<string, AttributeValue>): SourceRegistryRecord => {
+  const raw = unmarshall(item) as Record<string, unknown>;
+  const active = parseActive(raw.active);
+  if (active === null) {
+    throw new Error('Invalid Source registry record: active must be "true" or "false".');
+  }
+
+  const validation = validateSourceSchemaV1({
+    sourceId: raw.sourceId,
+    active,
+    engine: raw.engine,
+    secretArn: raw.secretArn,
+    query: raw.query,
+    cursorField: raw.cursorField,
+    fieldMap: raw.fieldMap,
+    scheduleType: raw.scheduleType,
+    intervalMinutes: raw.intervalMinutes,
+    cronExpr: raw.cronExpr,
+    nextRunAt: raw.nextRunAt,
+  });
+
+  if (!validation.success) {
+    throw new Error('Invalid Source registry record shape in DynamoDB.');
+  }
+
+  if (
+    typeof raw.schemaVersion !== 'string' ||
+    raw.schemaVersion.trim().length === 0 ||
+    typeof raw.createdAt !== 'string' ||
+    raw.createdAt.trim().length === 0 ||
+    typeof raw.updatedAt !== 'string' ||
+    raw.updatedAt.trim().length === 0
+  ) {
+    throw new Error('Invalid Source registry metadata in DynamoDB.');
+  }
+
+  return {
+    ...validation.value,
+    schemaVersion: raw.schemaVersion,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+};
+
 export function createDynamoDbSourceRegistryRepository({
   tableName,
   client = new DynamoDBClient({}),
@@ -67,6 +127,50 @@ export function createDynamoDbSourceRegistryRepository({
       } catch (error) {
         if (isConditionalCheckFailed(error)) {
           throw new SourceAlreadyExistsError(source.sourceId);
+        }
+
+        throw error;
+      }
+    },
+    async getById(sourceId: string): Promise<SourceRegistryRecord | null> {
+      const command = new GetItemCommand({
+        TableName: resolvedTableName,
+        Key: marshall({ sourceId }),
+        ConsistentRead: true,
+      });
+
+      const result = await client.send(command);
+      if (!result.Item) {
+        return null;
+      }
+
+      return toSourceRegistryRecord(result.Item);
+    },
+    async update({
+      sourceId,
+      source,
+      expectedUpdatedAt,
+    }: {
+      sourceId: string;
+      source: SourceRegistryRecord;
+      expectedUpdatedAt: string;
+    }): Promise<void> {
+      const command = new PutItemCommand({
+        TableName: resolvedTableName,
+        Item: marshall(toDynamoItem(source), { removeUndefinedValues: true }),
+        ConditionExpression: 'attribute_exists(sourceId) AND updatedAt = :expectedUpdatedAt',
+        ExpressionAttributeValues: {
+          ':expectedUpdatedAt': {
+            S: expectedUpdatedAt,
+          },
+        },
+      });
+
+      try {
+        await client.send(command);
+      } catch (error) {
+        if (isConditionalCheckFailed(error)) {
+          throw new SourceVersionConflictError(sourceId);
         }
 
         throw error;

--- a/src/infra/sources/in-memory-source-registry-repository.ts
+++ b/src/infra/sources/in-memory-source-registry-repository.ts
@@ -1,5 +1,6 @@
 import {
   SourceAlreadyExistsError,
+  SourceVersionConflictError,
   type SourceRegistryRecord,
   type SourceRegistryRepository,
 } from '../../domain/sources/source-registry-repository';
@@ -26,6 +27,26 @@ export function createInMemorySourceRegistryRepository(
     },
     get(sourceId: string): SourceRegistryRecord | undefined {
       return storage.get(sourceId);
+    },
+    getById(sourceId: string): Promise<SourceRegistryRecord | null> {
+      return Promise.resolve(storage.get(sourceId) ?? null);
+    },
+    update({
+      sourceId,
+      source,
+      expectedUpdatedAt,
+    }: {
+      sourceId: string;
+      source: SourceRegistryRecord;
+      expectedUpdatedAt: string;
+    }): Promise<void> {
+      const current = storage.get(sourceId);
+      if (!current || current.updatedAt !== expectedUpdatedAt) {
+        throw new SourceVersionConflictError(sourceId);
+      }
+
+      storage.set(sourceId, source);
+      return Promise.resolve();
     },
   };
 }

--- a/tests/unit/handlers/create-source.test.ts
+++ b/tests/unit/handlers/create-source.test.ts
@@ -36,6 +36,15 @@ class SpySourceRegistryRepository implements SourceRegistryRepository {
     this.created.push(source);
     return Promise.resolve();
   }
+
+  getById(sourceId: string): Promise<SourceRegistryRecord | null> {
+    const found = this.created.find((item) => item.sourceId === sourceId);
+    return Promise.resolve(found ?? null);
+  }
+
+  update(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 describe('create-source handler', () => {

--- a/tests/unit/handlers/update-source.test.ts
+++ b/tests/unit/handlers/update-source.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  SourceAlreadyExistsError,
+  SourceVersionConflictError,
+  type SourceRegistryRecord,
+  type SourceRegistryRepository,
+} from '../../../src/domain/sources/source-registry-repository';
+import { createHandler } from '../../../src/handlers/update-source';
+
+const EXISTING_SOURCE: SourceRegistryRecord = {
+  sourceId: 'source-acme',
+  active: true,
+  engine: 'postgres',
+  secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:acme/source-db',
+  query: 'select * from customers where updated_at > {{cursor}}',
+  cursorField: 'updated_at',
+  fieldMap: {
+    id: 'customer_id',
+    email: 'email',
+  },
+  scheduleType: 'interval',
+  intervalMinutes: 30,
+  nextRunAt: '2026-03-03T10:00:00.000Z',
+  schemaVersion: '1.0.0',
+  createdAt: '2026-03-03T09:00:00.000Z',
+  updatedAt: '2026-03-03T09:30:00.000Z',
+};
+
+class SpySourceRegistryRepository implements SourceRegistryRepository {
+  private readonly storage = new Map<string, SourceRegistryRecord>();
+
+  constructor(
+    seed: SourceRegistryRecord[] = [],
+    private readonly failUpdate = false,
+  ) {
+    for (const source of seed) {
+      this.storage.set(source.sourceId, source);
+    }
+  }
+
+  create(source: SourceRegistryRecord): Promise<void> {
+    if (this.storage.has(source.sourceId)) {
+      throw new SourceAlreadyExistsError(source.sourceId);
+    }
+
+    this.storage.set(source.sourceId, source);
+    return Promise.resolve();
+  }
+
+  getById(sourceId: string): Promise<SourceRegistryRecord | null> {
+    return Promise.resolve(this.storage.get(sourceId) ?? null);
+  }
+
+  update({
+    sourceId,
+    source,
+    expectedUpdatedAt,
+  }: {
+    sourceId: string;
+    source: SourceRegistryRecord;
+    expectedUpdatedAt: string;
+  }): Promise<void> {
+    if (this.failUpdate) {
+      throw new SourceVersionConflictError(sourceId);
+    }
+
+    const current = this.storage.get(sourceId);
+    if (!current || current.updatedAt !== expectedUpdatedAt) {
+      throw new SourceVersionConflictError(sourceId);
+    }
+
+    this.storage.set(sourceId, source);
+    return Promise.resolve();
+  }
+
+  getSnapshot(sourceId: string): SourceRegistryRecord | undefined {
+    return this.storage.get(sourceId);
+  }
+}
+
+describe('update-source handler', () => {
+  it('updates only mutable fields and returns 200', async () => {
+    const repository = new SpySourceRegistryRepository([EXISTING_SOURCE]);
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: EXISTING_SOURCE.sourceId },
+      body: JSON.stringify({
+        active: false,
+        nextRunAt: '2026-03-03T12:30:00.000Z',
+      }),
+      requestContext: { requestId: 'req-41' },
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({
+      sourceId: EXISTING_SOURCE.sourceId,
+      metadata: {
+        schemaVersion: '1.0.0',
+        createdAt: '2026-03-03T09:00:00.000Z',
+        updatedAt: '2026-03-03T12:00:00.000Z',
+        requestId: 'req-41',
+      },
+    });
+
+    const stored = repository.getSnapshot(EXISTING_SOURCE.sourceId);
+    expect(stored).toMatchObject({
+      sourceId: 'source-acme',
+      engine: 'postgres',
+      active: false,
+      nextRunAt: '2026-03-03T12:30:00.000Z',
+      createdAt: '2026-03-03T09:00:00.000Z',
+      updatedAt: '2026-03-03T12:00:00.000Z',
+    });
+  });
+
+  it('returns 404 when source does not exist', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: 'missing-source' },
+      body: JSON.stringify({ active: false }),
+    });
+
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Source "missing-source" was not found.',
+      code: 'SOURCE_NOT_FOUND',
+    });
+  });
+
+  it('returns 422 when payload contains immutable fields', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository([EXISTING_SOURCE]),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: EXISTING_SOURCE.sourceId },
+      body: JSON.stringify({
+        sourceId: 'other-source',
+        active: false,
+      }),
+    });
+
+    expect(result.statusCode).toBe(422);
+    const parsed = JSON.parse(result.body) as {
+      message: string;
+      errors: Array<{ field: string }>;
+    };
+    expect(parsed.message).toBe('Source patch validation failed.');
+    expect(parsed.errors.some((entry) => entry.field === 'sourceId')).toBe(true);
+  });
+
+  it('returns 409 when update detects version conflict', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository([EXISTING_SOURCE], true),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: EXISTING_SOURCE.sourceId },
+      body: JSON.stringify({ active: false }),
+    });
+
+    expect(result.statusCode).toBe(409);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Source "source-acme" version conflict.',
+      code: 'SOURCE_VERSION_CONFLICT',
+    });
+  });
+
+  it('returns 422 when merged state violates source schema', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository([EXISTING_SOURCE]),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: EXISTING_SOURCE.sourceId },
+      body: JSON.stringify({
+        scheduleType: 'cron',
+      }),
+    });
+
+    expect(result.statusCode).toBe(422);
+    const parsed = JSON.parse(result.body) as {
+      message: string;
+      errors: Array<{ field: string }>;
+    };
+    expect(parsed.message).toBe('Source patch validation failed.');
+    expect(parsed.errors.some((entry) => entry.field === 'cronExpr')).toBe(true);
+  });
+
+  it('allows switching from interval to cron when cronExpr is provided', async () => {
+    const repository = new SpySourceRegistryRepository([EXISTING_SOURCE]);
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: EXISTING_SOURCE.sourceId },
+      body: JSON.stringify({
+        scheduleType: 'cron',
+        cronExpr: '0 */15 * * *',
+      }),
+    });
+
+    expect(result.statusCode).toBe(200);
+    const stored = repository.getSnapshot(EXISTING_SOURCE.sourceId);
+    expect(stored).toMatchObject({
+      sourceId: 'source-acme',
+      scheduleType: 'cron',
+      cronExpr: '0 */15 * * *',
+    });
+    expect(stored?.intervalMinutes).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #41

---

## 🎯 Objetivo

Implementar o endpoint `PATCH /sources/{id}` para atualização parcial de fontes no plugin registry com validação de campos permitidos, proteção de campos imutáveis e controle de concorrência otimista.

---

## 🧠 Decisão Técnica

- Mantido o fluxo `handler -> domain -> infra`.
- Reutilizado `validateSourceSchemaV1` para validar o estado final após merge (`estado atual + patch`).
- Evoluída a porta `SourceRegistryRepository` com `getById` e `update`.
- `update` no DynamoDB usa `ConditionExpression` com `updatedAt` para detectar corrida concorrente e mapear para `409`.
- API limita patch a campos mutáveis e rejeita campos imutáveis/desconhecidos com `422`.

---

## 🧪 BDD Validado

Dado uma fonte existente
Quando recebo `PATCH /sources/{id}` com campos permitidos
Então a API atualiza apenas os campos mutáveis e retorna `200`.

Dado um `sourceId` inexistente
Quando recebo `PATCH /sources/{id}`
Então a API retorna `404`.

Dado conflito de versão durante persistência
Quando a condição otimista falha
Então a API retorna `409` com código explícito.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
