### PR TITLE
[EPIC 3] Criar endpoint GET /sources

### DIFF
--- a/docs/sources/list-sources-endpoint-v1.md
+++ b/docs/sources/list-sources-endpoint-v1.md
@@ -1,0 +1,57 @@
+# GET /sources (v1)
+
+Endpoint para listagem paginada das fontes cadastradas no plugin registry.
+
+## Query Params
+
+- `limit` (opcional): inteiro entre `1` e `100`. Padrão: `25`.
+- `nextToken` (opcional): token opaco retornado na página anterior.
+- `active` (opcional): `true` ou `false`.
+- `engine` (opcional): `postgres` ou `mysql`.
+
+## Response `200 OK`
+
+```json
+{
+  "items": [
+    {
+      "sourceId": "source-acme",
+      "active": true,
+      "engine": "postgres",
+      "secretArn": "arn:aws:secretsmanager:us-east-1:123456789012:secret:acme/source-db",
+      "query": "select * from customers where updated_at > {{cursor}}",
+      "cursorField": "updated_at",
+      "fieldMap": {
+        "id": "customer_id",
+        "email": "email"
+      },
+      "scheduleType": "interval",
+      "intervalMinutes": 30,
+      "nextRunAt": "2026-03-03T10:00:00.000Z",
+      "schemaVersion": "1.0.0",
+      "createdAt": "2026-03-03T09:00:00.000Z",
+      "updatedAt": "2026-03-03T09:30:00.000Z"
+    }
+  ],
+  "filters": {
+    "active": true,
+    "engine": "postgres"
+  },
+  "pagination": {
+    "limit": 25,
+    "nextToken": "eyJvZmZzZXQiOjI1LCJhY3RpdmUiOnRydWUsImVuZ2luZSI6InBvc3RncmVzIn0"
+  },
+  "requestId": "req-42"
+}
+```
+
+## Responses de erro
+
+### `400 Bad Request`
+
+- `limit`, `active`, `engine` ou `nextToken` inválidos.
+- `nextToken` incompatível com os filtros informados.
+
+### `500 Internal Server Error`
+
+- Falha inesperada ao consultar o repositório.

--- a/serverless.yml
+++ b/serverless.yml
@@ -52,6 +52,7 @@ custom:
     schedulerFunctionName: ${self:custom.naming.prefix}-scheduler
     createSourceFunctionName: ${self:custom.naming.prefix}-create-source
     updateSourceFunctionName: ${self:custom.naming.prefix}-update-source
+    listSourceFunctionName: ${self:custom.naming.prefix}-list-sources
     orchestrationStateMachineName: ${self:custom.naming.prefix}-orchestration
     orchestrationScheduleRuleName: ${self:custom.naming.prefix}-orchestration-schedule
     orchestrationLogGroupName: /aws/vendedlogs/states/${self:custom.naming.orchestrationStateMachineName}
@@ -167,6 +168,20 @@ functions:
       - httpApi:
           method: patch
           path: /sources/{id}
+  listSource:
+    name: ${self:custom.naming.listSourceFunctionName}
+    handler: dist/handlers/list-sources.handler
+    description: Endpoint GET para listagem paginada de fontes no plugin registry.
+    memorySize: 256
+    timeout: 30
+    role:
+      Fn::GetAtt:
+        - SourceRegistryApiExecutionRole
+        - Arn
+    events:
+      - httpApi:
+          method: get
+          path: /sources
 
 stepFunctions:
   stateMachines:
@@ -212,6 +227,11 @@ resources:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: /aws/lambda/${self:custom.naming.updateSourceFunctionName}
+        RetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
+    ListSourceLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/lambda/${self:custom.naming.listSourceFunctionName}
         RetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
     MainOrchestrationStateMachineLogGroup:
       Type: AWS::Logs::LogGroup
@@ -382,6 +402,7 @@ resources:
                   Action:
                     - dynamodb:GetItem
                     - dynamodb:PutItem
+                    - dynamodb:Scan
                   Resource:
                     - Fn::GetAtt:
                         - SourcesTable
@@ -394,6 +415,7 @@ resources:
                   Resource:
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.createSourceFunctionName}:*
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.updateSourceFunctionName}:*
+                    - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.listSourceFunctionName}:*
     SalesforceConsumerExecutionRole:
       Type: AWS::IAM::Role
       Properties:

--- a/src/README.md
+++ b/src/README.md
@@ -22,6 +22,7 @@
 src/
   handlers/
     create-source.ts
+    list-sources.ts
     update-source.ts
   domain/
     scheduler/

--- a/src/domain/sources/source-registry-repository.ts
+++ b/src/domain/sources/source-registry-repository.ts
@@ -1,4 +1,4 @@
-import type { SourceSchemaV1 } from './source-schema';
+import type { SourceEngine, SourceSchemaV1 } from './source-schema';
 
 export type SourceRegistryRecord = SourceSchemaV1 & {
   schemaVersion: string;
@@ -6,9 +6,22 @@ export type SourceRegistryRecord = SourceSchemaV1 & {
   updatedAt: string;
 };
 
+export interface ListSourceRegistryParams {
+  limit: number;
+  nextToken?: string;
+  active?: boolean;
+  engine?: SourceEngine;
+}
+
+export interface ListSourceRegistryResult {
+  items: SourceRegistryRecord[];
+  nextToken: string | null;
+}
+
 export interface SourceRegistryRepository {
   create(source: SourceRegistryRecord): Promise<void>;
   getById(sourceId: string): Promise<SourceRegistryRecord | null>;
+  list(params: ListSourceRegistryParams): Promise<ListSourceRegistryResult>;
   update(params: {
     sourceId: string;
     source: SourceRegistryRecord;
@@ -27,5 +40,12 @@ export class SourceVersionConflictError extends Error {
   constructor(sourceId: string) {
     super(`Source "${sourceId}" version conflict.`);
     this.name = 'SourceVersionConflictError';
+  }
+}
+
+export class SourcePaginationTokenError extends Error {
+  constructor(message = 'Invalid pagination token.') {
+    super(message);
+    this.name = 'SourcePaginationTokenError';
   }
 }

--- a/src/handlers/list-sources.ts
+++ b/src/handlers/list-sources.ts
@@ -1,0 +1,258 @@
+import {
+  SourcePaginationTokenError,
+  type ListSourceRegistryParams,
+  type SourceRegistryRepository,
+} from '../domain/sources/source-registry-repository';
+import { SOURCE_ENGINES, type SourceEngine } from '../domain/sources/source-schema';
+import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
+
+const JSON_HEADERS = {
+  'content-type': 'application/json',
+};
+
+const DEFAULT_LIMIT = 25;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 100;
+
+export interface ListSourcesEvent {
+  queryStringParameters?: {
+    limit?: string;
+    nextToken?: string;
+    active?: string;
+    engine?: string;
+  };
+  requestContext?: {
+    requestId?: string;
+  };
+}
+
+export interface ListSourcesResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface ListSourcesDependencies {
+  sourceRegistryRepository: SourceRegistryRepository;
+}
+
+let cachedDefaultDependencies: ListSourcesDependencies | undefined;
+
+const response = (statusCode: number, payload: unknown): ListSourcesResponse => ({
+  statusCode,
+  headers: JSON_HEADERS,
+  body: JSON.stringify(payload),
+});
+
+const parseLimit = (
+  rawLimit: string | undefined,
+): { success: true; value: number } | { success: false; response: ListSourcesResponse } => {
+  if (rawLimit === undefined) {
+    return {
+      success: true,
+      value: DEFAULT_LIMIT,
+    };
+  }
+
+  const normalized = rawLimit.trim();
+  if (normalized.length === 0) {
+    return {
+      success: false,
+      response: response(400, {
+        message: 'Query parameter "limit" must be an integer between 1 and 100.',
+      }),
+    };
+  }
+
+  const parsed = Number.parseInt(normalized, 10);
+  if (
+    !Number.isInteger(parsed) ||
+    parsed < MIN_LIMIT ||
+    parsed > MAX_LIMIT ||
+    parsed.toString() !== normalized
+  ) {
+    return {
+      success: false,
+      response: response(400, {
+        message: 'Query parameter "limit" must be an integer between 1 and 100.',
+      }),
+    };
+  }
+
+  return {
+    success: true,
+    value: parsed,
+  };
+};
+
+const parseNextToken = (
+  rawNextToken: string | undefined,
+):
+  | { success: true; value: string | undefined }
+  | { success: false; response: ListSourcesResponse } => {
+  if (rawNextToken === undefined) {
+    return {
+      success: true,
+      value: undefined,
+    };
+  }
+
+  const normalized = rawNextToken.trim();
+  if (normalized.length === 0) {
+    return {
+      success: false,
+      response: response(400, {
+        message: 'Query parameter "nextToken" must be a non-empty string when provided.',
+      }),
+    };
+  }
+
+  return {
+    success: true,
+    value: normalized,
+  };
+};
+
+const parseActive = (
+  rawActive: string | undefined,
+):
+  | { success: true; value: boolean | undefined }
+  | { success: false; response: ListSourcesResponse } => {
+  if (rawActive === undefined) {
+    return {
+      success: true,
+      value: undefined,
+    };
+  }
+
+  const normalized = rawActive.trim().toLowerCase();
+  if (normalized === 'true') {
+    return {
+      success: true,
+      value: true,
+    };
+  }
+
+  if (normalized === 'false') {
+    return {
+      success: true,
+      value: false,
+    };
+  }
+
+  return {
+    success: false,
+    response: response(400, {
+      message: 'Query parameter "active" must be "true" or "false".',
+    }),
+  };
+};
+
+const parseEngine = (
+  rawEngine: string | undefined,
+):
+  | { success: true; value: SourceEngine | undefined }
+  | { success: false; response: ListSourcesResponse } => {
+  if (rawEngine === undefined) {
+    return {
+      success: true,
+      value: undefined,
+    };
+  }
+
+  const normalized = rawEngine.trim().toLowerCase();
+  if ((SOURCE_ENGINES as readonly string[]).includes(normalized)) {
+    return {
+      success: true,
+      value: normalized as SourceEngine,
+    };
+  }
+
+  return {
+    success: false,
+    response: response(400, {
+      message: `Query parameter "engine" must be one of: ${SOURCE_ENGINES.join(', ')}.`,
+    }),
+  };
+};
+
+const getDefaultDependencies = (): ListSourcesDependencies => {
+  if (cachedDefaultDependencies) {
+    return cachedDefaultDependencies;
+  }
+
+  const tableName = process.env.SOURCES_TABLE_NAME;
+  if (!tableName || tableName.trim().length === 0) {
+    throw new Error('SOURCES_TABLE_NAME is required.');
+  }
+
+  cachedDefaultDependencies = {
+    sourceRegistryRepository: createDynamoDbSourceRegistryRepository({ tableName }),
+  };
+
+  return cachedDefaultDependencies;
+};
+
+export const createHandler =
+  ({ sourceRegistryRepository }: ListSourcesDependencies) =>
+  async (event: ListSourcesEvent): Promise<ListSourcesResponse> => {
+    const query = event.queryStringParameters ?? {};
+
+    const limit = parseLimit(query.limit);
+    if (!limit.success) {
+      return limit.response;
+    }
+
+    const nextToken = parseNextToken(query.nextToken);
+    if (!nextToken.success) {
+      return nextToken.response;
+    }
+
+    const active = parseActive(query.active);
+    if (!active.success) {
+      return active.response;
+    }
+
+    const engine = parseEngine(query.engine);
+    if (!engine.success) {
+      return engine.response;
+    }
+
+    const params: ListSourceRegistryParams = {
+      limit: limit.value,
+      nextToken: nextToken.value,
+      active: active.value,
+      engine: engine.value,
+    };
+
+    try {
+      const result = await sourceRegistryRepository.list(params);
+      return response(200, {
+        items: result.items,
+        filters: {
+          active: active.value ?? null,
+          engine: engine.value ?? null,
+        },
+        pagination: {
+          limit: limit.value,
+          nextToken: result.nextToken,
+        },
+        requestId: event.requestContext?.requestId ?? null,
+      });
+    } catch (error) {
+      if (error instanceof SourcePaginationTokenError) {
+        return response(400, {
+          message: error.message,
+          code: 'INVALID_PAGINATION_TOKEN',
+        });
+      }
+
+      return response(500, {
+        message: 'Failed to list sources.',
+      });
+    }
+  };
+
+export async function handler(event: ListSourcesEvent): Promise<ListSourcesResponse> {
+  return createHandler(getDefaultDependencies())(event);
+}

--- a/src/infra/sources/dynamodb-source-registry-repository.ts
+++ b/src/infra/sources/dynamodb-source-registry-repository.ts
@@ -4,20 +4,30 @@ import {
   DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
+  ScanCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 
 import {
+  SourcePaginationTokenError,
   SourceAlreadyExistsError,
   SourceVersionConflictError,
+  type ListSourceRegistryParams,
+  type ListSourceRegistryResult,
   type SourceRegistryRecord,
   type SourceRegistryRepository,
 } from '../../domain/sources/source-registry-repository';
-import { validateSourceSchemaV1 } from '../../domain/sources/source-schema';
+import { type SourceEngine, validateSourceSchemaV1 } from '../../domain/sources/source-schema';
 
 export interface DynamoDbSourceRegistryRepositoryParams {
   tableName: string;
   client?: DynamoDBClient;
+}
+
+interface ListTokenPayload {
+  offset: number;
+  active?: boolean;
+  engine?: SourceEngine;
 }
 
 const isConditionalCheckFailed = (error: unknown): boolean => {
@@ -30,6 +40,87 @@ const isConditionalCheckFailed = (error: unknown): boolean => {
   }
 
   return false;
+};
+
+const encodeListToken = (payload: ListTokenPayload): string =>
+  Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
+
+const decodeListToken = (token: string): ListTokenPayload => {
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf-8')) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new SourcePaginationTokenError();
+    }
+
+    const record = parsed as Record<string, unknown>;
+    if (!Number.isInteger(record.offset) || (record.offset as number) < 0) {
+      throw new SourcePaginationTokenError();
+    }
+
+    const active =
+      record.active === undefined
+        ? undefined
+        : typeof record.active === 'boolean'
+          ? record.active
+          : null;
+    if (active === null) {
+      throw new SourcePaginationTokenError();
+    }
+
+    const engine =
+      record.engine === undefined
+        ? undefined
+        : record.engine === 'postgres' || record.engine === 'mysql'
+          ? record.engine
+          : null;
+    if (engine === null) {
+      throw new SourcePaginationTokenError();
+    }
+
+    return {
+      offset: record.offset as number,
+      active,
+      engine,
+    };
+  } catch (error) {
+    if (error instanceof SourcePaginationTokenError) {
+      throw error;
+    }
+
+    throw new SourcePaginationTokenError();
+  }
+};
+
+const areFiltersEqual = (token: ListTokenPayload, params: ListSourceRegistryParams): boolean =>
+  token.active === params.active && token.engine === params.engine;
+
+const buildScanFilter = (
+  params: ListSourceRegistryParams,
+): {
+  FilterExpression?: string;
+  ExpressionAttributeValues?: Record<string, AttributeValue>;
+} => {
+  const expressions: string[] = [];
+  const values: Record<string, AttributeValue> = {};
+
+  if (params.active !== undefined) {
+    expressions.push('active = :active');
+    values[':active'] = { S: params.active ? 'true' : 'false' };
+  }
+
+  if (params.engine !== undefined) {
+    expressions.push('engine = :engine');
+    values[':engine'] = { S: params.engine };
+  }
+
+  if (expressions.length === 0) {
+    return {};
+  }
+
+  return {
+    FilterExpression: expressions.join(' AND '),
+    ExpressionAttributeValues: values,
+  };
 };
 
 const toDynamoItem = (source: SourceRegistryRecord): Record<string, unknown> => ({
@@ -145,6 +236,50 @@ export function createDynamoDbSourceRegistryRepository({
       }
 
       return toSourceRegistryRecord(result.Item);
+    },
+    async list(params: ListSourceRegistryParams): Promise<ListSourceRegistryResult> {
+      const tokenPayload = params.nextToken ? decodeListToken(params.nextToken) : undefined;
+      const offset = tokenPayload?.offset ?? 0;
+      if (tokenPayload && !areFiltersEqual(tokenPayload, params)) {
+        throw new SourcePaginationTokenError('Pagination token does not match provided filters.');
+      }
+
+      const filter = buildScanFilter(params);
+      const items: SourceRegistryRecord[] = [];
+      let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
+
+      do {
+        const result = await client.send(
+          new ScanCommand({
+            TableName: resolvedTableName,
+            ExclusiveStartKey: lastEvaluatedKey,
+            ...filter,
+          }),
+        );
+
+        if (result.Items) {
+          items.push(...result.Items.map((item) => toSourceRegistryRecord(item)));
+        }
+
+        lastEvaluatedKey = result.LastEvaluatedKey;
+      } while (lastEvaluatedKey);
+
+      const sorted = items.sort((left, right) => left.sourceId.localeCompare(right.sourceId));
+      const pageItems = sorted.slice(offset, offset + params.limit);
+      const nextOffset = offset + pageItems.length;
+      const nextToken =
+        nextOffset < sorted.length
+          ? encodeListToken({
+              offset: nextOffset,
+              active: params.active,
+              engine: params.engine,
+            })
+          : null;
+
+      return {
+        items: pageItems,
+        nextToken,
+      };
     },
     async update({
       sourceId,

--- a/src/infra/sources/in-memory-source-registry-repository.ts
+++ b/src/infra/sources/in-memory-source-registry-repository.ts
@@ -1,9 +1,71 @@
 import {
   SourceAlreadyExistsError,
+  SourcePaginationTokenError,
   SourceVersionConflictError,
+  type ListSourceRegistryParams,
+  type ListSourceRegistryResult,
   type SourceRegistryRecord,
   type SourceRegistryRepository,
 } from '../../domain/sources/source-registry-repository';
+import type { SourceEngine } from '../../domain/sources/source-schema';
+
+interface ListTokenPayload {
+  offset: number;
+  active?: boolean;
+  engine?: SourceEngine;
+}
+
+const encodeListToken = (payload: ListTokenPayload): string =>
+  Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
+
+const decodeListToken = (token: string): ListTokenPayload => {
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf-8')) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new SourcePaginationTokenError();
+    }
+
+    const record = parsed as Record<string, unknown>;
+    if (!Number.isInteger(record.offset) || (record.offset as number) < 0) {
+      throw new SourcePaginationTokenError();
+    }
+
+    const active =
+      record.active === undefined
+        ? undefined
+        : typeof record.active === 'boolean'
+          ? record.active
+          : null;
+    if (active === null) {
+      throw new SourcePaginationTokenError();
+    }
+
+    const engine =
+      record.engine === undefined
+        ? undefined
+        : record.engine === 'postgres' || record.engine === 'mysql'
+          ? record.engine
+          : null;
+    if (engine === null) {
+      throw new SourcePaginationTokenError();
+    }
+
+    return {
+      offset: record.offset as number,
+      active,
+      engine,
+    };
+  } catch (error) {
+    if (error instanceof SourcePaginationTokenError) {
+      throw error;
+    }
+
+    throw new SourcePaginationTokenError();
+  }
+};
+
+const areFiltersEqual = (token: ListTokenPayload, params: ListSourceRegistryParams): boolean =>
+  token.active === params.active && token.engine === params.engine;
 
 export interface InMemorySourceRegistryStore {
   get(sourceId: string): SourceRegistryRecord | undefined;
@@ -30,6 +92,33 @@ export function createInMemorySourceRegistryRepository(
     },
     getById(sourceId: string): Promise<SourceRegistryRecord | null> {
       return Promise.resolve(storage.get(sourceId) ?? null);
+    },
+    list(params: ListSourceRegistryParams): Promise<ListSourceRegistryResult> {
+      const tokenPayload = params.nextToken ? decodeListToken(params.nextToken) : undefined;
+      const offset = tokenPayload?.offset ?? 0;
+      if (tokenPayload) {
+        if (!areFiltersEqual(tokenPayload, params)) {
+          throw new SourcePaginationTokenError('Pagination token does not match provided filters.');
+        }
+      }
+
+      const filtered = [...storage.values()]
+        .filter((source) => (params.active === undefined ? true : source.active === params.active))
+        .filter((source) => (params.engine === undefined ? true : source.engine === params.engine))
+        .sort((left, right) => left.sourceId.localeCompare(right.sourceId));
+
+      const items = filtered.slice(offset, offset + params.limit);
+      const nextOffset = offset + items.length;
+      const nextToken =
+        nextOffset < filtered.length
+          ? encodeListToken({
+              offset: nextOffset,
+              active: params.active,
+              engine: params.engine,
+            })
+          : null;
+
+      return Promise.resolve({ items, nextToken });
     },
     update({
       sourceId,

--- a/tests/unit/handlers/create-source.test.ts
+++ b/tests/unit/handlers/create-source.test.ts
@@ -42,6 +42,13 @@ class SpySourceRegistryRepository implements SourceRegistryRepository {
     return Promise.resolve(found ?? null);
   }
 
+  list(): Promise<{ items: SourceRegistryRecord[]; nextToken: string | null }> {
+    return Promise.resolve({
+      items: this.created,
+      nextToken: null,
+    });
+  }
+
   update(): Promise<void> {
     return Promise.resolve();
   }

--- a/tests/unit/handlers/list-sources.test.ts
+++ b/tests/unit/handlers/list-sources.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  SourcePaginationTokenError,
+  type ListSourceRegistryParams,
+  type ListSourceRegistryResult,
+  type SourceRegistryRecord,
+  type SourceRegistryRepository,
+} from '../../../src/domain/sources/source-registry-repository';
+import { createHandler } from '../../../src/handlers/list-sources';
+
+const SOURCE_A: SourceRegistryRecord = {
+  sourceId: 'source-acme',
+  active: true,
+  engine: 'postgres',
+  secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:acme/source-db',
+  query: 'select * from customers where updated_at > {{cursor}}',
+  cursorField: 'updated_at',
+  fieldMap: {
+    id: 'customer_id',
+    email: 'email',
+  },
+  scheduleType: 'interval',
+  intervalMinutes: 30,
+  nextRunAt: '2026-03-03T10:00:00.000Z',
+  schemaVersion: '1.0.0',
+  createdAt: '2026-03-03T09:00:00.000Z',
+  updatedAt: '2026-03-03T09:30:00.000Z',
+};
+
+class SpySourceRegistryRepository implements SourceRegistryRepository {
+  public readonly listCalls: ListSourceRegistryParams[] = [];
+
+  constructor(
+    private readonly listResult: ListSourceRegistryResult = { items: [], nextToken: null },
+    private readonly listError?: Error,
+  ) {}
+
+  create(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  getById(): Promise<SourceRegistryRecord | null> {
+    return Promise.resolve(null);
+  }
+
+  list(params: ListSourceRegistryParams): Promise<ListSourceRegistryResult> {
+    this.listCalls.push(params);
+    if (this.listError) {
+      throw this.listError;
+    }
+
+    return Promise.resolve(this.listResult);
+  }
+
+  update(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe('list-sources handler', () => {
+  it('returns paginated source list with default limit', async () => {
+    const repository = new SpySourceRegistryRepository({
+      items: [SOURCE_A],
+      nextToken: null,
+    });
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+    });
+
+    const result = await handler({
+      requestContext: { requestId: 'req-42' },
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(result.headers['content-type']).toBe('application/json');
+    expect(repository.listCalls).toEqual([
+      {
+        limit: 25,
+        nextToken: undefined,
+        active: undefined,
+        engine: undefined,
+      },
+    ]);
+    expect(JSON.parse(result.body)).toEqual({
+      items: [SOURCE_A],
+      filters: {
+        active: null,
+        engine: null,
+      },
+      pagination: {
+        limit: 25,
+        nextToken: null,
+      },
+      requestId: 'req-42',
+    });
+  });
+
+  it('parses filters and forwards token to repository', async () => {
+    const repository = new SpySourceRegistryRepository({
+      items: [],
+      nextToken: 'next-page-token',
+    });
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+    });
+
+    const result = await handler({
+      queryStringParameters: {
+        limit: '10',
+        nextToken: 'opaque-token',
+        active: 'false',
+        engine: 'mysql',
+      },
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(repository.listCalls).toEqual([
+      {
+        limit: 10,
+        nextToken: 'opaque-token',
+        active: false,
+        engine: 'mysql',
+      },
+    ]);
+    expect(JSON.parse(result.body)).toEqual({
+      items: [],
+      filters: {
+        active: false,
+        engine: 'mysql',
+      },
+      pagination: {
+        limit: 10,
+        nextToken: 'next-page-token',
+      },
+      requestId: null,
+    });
+  });
+
+  it('returns 400 when limit is invalid', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(),
+    });
+
+    const result = await handler({
+      queryStringParameters: {
+        limit: '0',
+      },
+    });
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Query parameter "limit" must be an integer between 1 and 100.',
+    });
+  });
+
+  it('returns 400 when active filter is invalid', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(),
+    });
+
+    const result = await handler({
+      queryStringParameters: {
+        active: 'yes',
+      },
+    });
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Query parameter "active" must be "true" or "false".',
+    });
+  });
+
+  it('returns 400 when engine filter is invalid', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(),
+    });
+
+    const result = await handler({
+      queryStringParameters: {
+        engine: 'oracle',
+      },
+    });
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Query parameter "engine" must be one of: postgres, mysql.',
+    });
+  });
+
+  it('returns 400 when nextToken is empty', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(),
+    });
+
+    const result = await handler({
+      queryStringParameters: {
+        nextToken: '   ',
+      },
+    });
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Query parameter "nextToken" must be a non-empty string when provided.',
+    });
+  });
+
+  it('returns 400 when repository rejects pagination token', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(
+        { items: [], nextToken: null },
+        new SourcePaginationTokenError(),
+      ),
+    });
+
+    const result = await handler({
+      queryStringParameters: {
+        nextToken: 'invalid-token',
+      },
+    });
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Invalid pagination token.',
+      code: 'INVALID_PAGINATION_TOKEN',
+    });
+  });
+
+  it('returns 500 for unexpected repository errors', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(
+        { items: [], nextToken: null },
+        new Error('timeout'),
+      ),
+    });
+
+    const result = await handler({});
+
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Failed to list sources.',
+    });
+  });
+});

--- a/tests/unit/handlers/update-source.test.ts
+++ b/tests/unit/handlers/update-source.test.ts
@@ -52,6 +52,13 @@ class SpySourceRegistryRepository implements SourceRegistryRepository {
     return Promise.resolve(this.storage.get(sourceId) ?? null);
   }
 
+  list(): Promise<{ items: SourceRegistryRecord[]; nextToken: string | null }> {
+    return Promise.resolve({
+      items: [...this.storage.values()],
+      nextToken: null,
+    });
+  }
+
   update({
     sourceId,
     source,


### PR DESCRIPTION
Closes #42

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Implementar o endpoint `GET /sources` com paginação por token, filtros opcionais (`active`, `engine`) e retorno consistente para operação/auditoria do plugin registry.

---

## 🧠 Decisão Técnica

Evoluímos a porta `SourceRegistryRepository` com `list(params)` e implementamos nos adapters in-memory e DynamoDB. A paginação usa token opaco (base64url) contendo `offset + filtros`, com validação para impedir reuso de token com outro conjunto de filtros. O handler valida query params e mapeia erros de token para `400`.

---

## 🧪 BDD Validado

Dado que existem fontes cadastradas
Quando `GET /sources` é chamado com `limit` e filtros válidos
Então a API retorna `items`, `filters`, `pagination.nextToken` e `requestId`.

Dado um `nextToken` inválido
Quando `GET /sources` é chamado
Então a API retorna `400` com `INVALID_PAGINATION_TOKEN`.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [ ] PATCH
- [x] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
