### PR TITLE
feat(api): criar endpoint DELETE /sources/{id} com soft delete

### DIFF
--- a/docs/sources/delete-source-endpoint-v1.md
+++ b/docs/sources/delete-source-endpoint-v1.md
@@ -1,0 +1,31 @@
+# DELETE /sources/{id} — Desativação Lógica de Fonte (v1)
+
+## Objetivo
+
+Desativar uma fonte do plugin registry com **soft delete** (`active=false`), mantendo rastreabilidade e sem remover o registro da tabela.
+
+## Requisição
+
+- Método: `DELETE`
+- Rota: `/sources/{id}`
+- `pathParameters.id`: identificador da fonte (`sourceId`)
+
+## Comportamento
+
+- Se a fonte estiver ativa, a API marca `active=false`.
+- Se a fonte já estiver inativa, a API retorna sucesso sem nova mutação (idempotência).
+- O registro permanece em banco para auditoria e troubleshooting.
+
+## Respostas
+
+- `204 No Content`
+  - fonte desativada com sucesso;
+  - ou chamada repetida para fonte já inativa.
+- `400 Bad Request`
+  - `pathParameters.id` ausente ou vazio.
+- `404 Not Found`
+  - `code: SOURCE_NOT_FOUND`
+- `409 Conflict`
+  - `code: SOURCE_VERSION_CONFLICT` quando ocorre corrida concorrente e a fonte segue ativa após revalidação.
+- `500 Internal Server Error`
+  - falha inesperada na persistência.

--- a/serverless.yml
+++ b/serverless.yml
@@ -52,6 +52,7 @@ custom:
     schedulerFunctionName: ${self:custom.naming.prefix}-scheduler
     createSourceFunctionName: ${self:custom.naming.prefix}-create-source
     updateSourceFunctionName: ${self:custom.naming.prefix}-update-source
+    deleteSourceFunctionName: ${self:custom.naming.prefix}-delete-source
     listSourceFunctionName: ${self:custom.naming.prefix}-list-sources
     orchestrationStateMachineName: ${self:custom.naming.prefix}-orchestration
     orchestrationScheduleRuleName: ${self:custom.naming.prefix}-orchestration-schedule
@@ -168,6 +169,20 @@ functions:
       - httpApi:
           method: patch
           path: /sources/{id}
+  deleteSource:
+    name: ${self:custom.naming.deleteSourceFunctionName}
+    handler: dist/handlers/delete-source.handler
+    description: Endpoint DELETE para desativacao logica de fontes no plugin registry.
+    memorySize: 256
+    timeout: 30
+    role:
+      Fn::GetAtt:
+        - SourceRegistryApiExecutionRole
+        - Arn
+    events:
+      - httpApi:
+          method: delete
+          path: /sources/{id}
   listSource:
     name: ${self:custom.naming.listSourceFunctionName}
     handler: dist/handlers/list-sources.handler
@@ -227,6 +242,11 @@ resources:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: /aws/lambda/${self:custom.naming.updateSourceFunctionName}
+        RetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
+    DeleteSourceLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/lambda/${self:custom.naming.deleteSourceFunctionName}
         RetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
     ListSourceLogGroup:
       Type: AWS::Logs::LogGroup
@@ -383,7 +403,7 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         RoleName: ${self:custom.naming.sourceRegistryApiRoleName}
-        Description: Role da API de fontes com privilegio minimo para criacao e atualizacao na tabela sources.
+        Description: Role da API de fontes com privilegio minimo para CRUD da tabela sources.
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:
@@ -415,6 +435,7 @@ resources:
                   Resource:
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.createSourceFunctionName}:*
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.updateSourceFunctionName}:*
+                    - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.deleteSourceFunctionName}:*
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.listSourceFunctionName}:*
     SalesforceConsumerExecutionRole:
       Type: AWS::IAM::Role

--- a/src/README.md
+++ b/src/README.md
@@ -22,6 +22,7 @@
 src/
   handlers/
     create-source.ts
+    delete-source.ts
     list-sources.ts
     update-source.ts
   domain/

--- a/src/handlers/delete-source.ts
+++ b/src/handlers/delete-source.ts
@@ -1,0 +1,145 @@
+import {
+  SourceVersionConflictError,
+  type SourceRegistryRecord,
+  type SourceRegistryRepository,
+} from '../domain/sources/source-registry-repository';
+import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
+import { nowIso } from '../shared/time/now-iso';
+
+const JSON_HEADERS = {
+  'content-type': 'application/json',
+};
+
+export interface DeleteSourceEvent {
+  pathParameters?: {
+    id?: string;
+  };
+}
+
+export interface DeleteSourceResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface DeleteSourceDependencies {
+  sourceRegistryRepository: SourceRegistryRepository;
+  now: () => string;
+}
+
+let cachedDefaultDependencies: DeleteSourceDependencies | undefined;
+
+const response = (statusCode: number, payload: unknown): DeleteSourceResponse => ({
+  statusCode,
+  headers: JSON_HEADERS,
+  body: JSON.stringify(payload),
+});
+
+const noContent = (): DeleteSourceResponse => ({
+  statusCode: 204,
+  headers: {},
+  body: '',
+});
+
+const parseSourceId = (
+  rawSourceId: string | undefined,
+): { success: true; value: string } | { success: false; response: DeleteSourceResponse } => {
+  if (typeof rawSourceId !== 'string' || rawSourceId.trim().length === 0) {
+    return {
+      success: false,
+      response: response(400, {
+        message: 'Path parameter "id" is required.',
+      }),
+    };
+  }
+
+  return {
+    success: true,
+    value: rawSourceId.trim(),
+  };
+};
+
+const getDefaultDependencies = (): DeleteSourceDependencies => {
+  if (cachedDefaultDependencies) {
+    return cachedDefaultDependencies;
+  }
+
+  const tableName = process.env.SOURCES_TABLE_NAME;
+  if (!tableName || tableName.trim().length === 0) {
+    throw new Error('SOURCES_TABLE_NAME is required.');
+  }
+
+  cachedDefaultDependencies = {
+    sourceRegistryRepository: createDynamoDbSourceRegistryRepository({ tableName }),
+    now: nowIso,
+  };
+
+  return cachedDefaultDependencies;
+};
+
+const deactivateSourceRecord = (
+  source: SourceRegistryRecord,
+  updatedAt: string,
+): SourceRegistryRecord => ({
+  ...source,
+  active: false,
+  updatedAt,
+});
+
+export const createHandler =
+  ({ sourceRegistryRepository, now }: DeleteSourceDependencies) =>
+  async (event: DeleteSourceEvent): Promise<DeleteSourceResponse> => {
+    const sourceId = parseSourceId(event.pathParameters?.id);
+    if (!sourceId.success) {
+      return sourceId.response;
+    }
+
+    const current = await sourceRegistryRepository.getById(sourceId.value);
+    if (!current) {
+      return response(404, {
+        message: `Source "${sourceId.value}" was not found.`,
+        code: 'SOURCE_NOT_FOUND',
+      });
+    }
+
+    if (!current.active) {
+      return noContent();
+    }
+
+    try {
+      const deactivatedSource = deactivateSourceRecord(current, now());
+      await sourceRegistryRepository.update({
+        sourceId: current.sourceId,
+        source: deactivatedSource,
+        expectedUpdatedAt: current.updatedAt,
+      });
+      return noContent();
+    } catch (error) {
+      if (error instanceof SourceVersionConflictError) {
+        const latest = await sourceRegistryRepository.getById(sourceId.value);
+        if (!latest) {
+          return response(404, {
+            message: `Source "${sourceId.value}" was not found.`,
+            code: 'SOURCE_NOT_FOUND',
+          });
+        }
+
+        if (!latest.active) {
+          return noContent();
+        }
+
+        return response(409, {
+          message: error.message,
+          code: 'SOURCE_VERSION_CONFLICT',
+        });
+      }
+
+      return response(500, {
+        message: 'Failed to delete source.',
+      });
+    }
+  };
+
+export async function handler(event: DeleteSourceEvent): Promise<DeleteSourceResponse> {
+  return createHandler(getDefaultDependencies())(event);
+}

--- a/tests/unit/handlers/delete-source.test.ts
+++ b/tests/unit/handlers/delete-source.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  SourceAlreadyExistsError,
+  SourceVersionConflictError,
+  type ListSourceRegistryParams,
+  type ListSourceRegistryResult,
+  type SourceRegistryRecord,
+  type SourceRegistryRepository,
+} from '../../../src/domain/sources/source-registry-repository';
+import { createHandler } from '../../../src/handlers/delete-source';
+
+const ACTIVE_SOURCE: SourceRegistryRecord = {
+  sourceId: 'source-acme',
+  active: true,
+  engine: 'postgres',
+  secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:acme/source-db',
+  query: 'select * from customers where updated_at > {{cursor}}',
+  cursorField: 'updated_at',
+  fieldMap: {
+    id: 'customer_id',
+    email: 'email',
+  },
+  scheduleType: 'interval',
+  intervalMinutes: 30,
+  nextRunAt: '2026-03-03T10:00:00.000Z',
+  schemaVersion: '1.0.0',
+  createdAt: '2026-03-03T09:00:00.000Z',
+  updatedAt: '2026-03-03T09:30:00.000Z',
+};
+
+class SpySourceRegistryRepository implements SourceRegistryRepository {
+  private readonly storage = new Map<string, SourceRegistryRecord>();
+  public readonly updateCalls: Array<{ sourceId: string; expectedUpdatedAt: string }> = [];
+
+  constructor(
+    seed: SourceRegistryRecord[] = [],
+    private readonly updateError?: Error,
+    private readonly mutateStorageBeforeUpdateError?: (
+      storage: Map<string, SourceRegistryRecord>,
+    ) => void,
+  ) {
+    for (const source of seed) {
+      this.storage.set(source.sourceId, source);
+    }
+  }
+
+  create(source: SourceRegistryRecord): Promise<void> {
+    if (this.storage.has(source.sourceId)) {
+      throw new SourceAlreadyExistsError(source.sourceId);
+    }
+
+    this.storage.set(source.sourceId, source);
+    return Promise.resolve();
+  }
+
+  getById(sourceId: string): Promise<SourceRegistryRecord | null> {
+    return Promise.resolve(this.storage.get(sourceId) ?? null);
+  }
+
+  list(params: ListSourceRegistryParams): Promise<ListSourceRegistryResult> {
+    void params;
+    return Promise.resolve({
+      items: [...this.storage.values()],
+      nextToken: null,
+    });
+  }
+
+  update({
+    sourceId,
+    source,
+    expectedUpdatedAt,
+  }: {
+    sourceId: string;
+    source: SourceRegistryRecord;
+    expectedUpdatedAt: string;
+  }): Promise<void> {
+    this.updateCalls.push({
+      sourceId,
+      expectedUpdatedAt,
+    });
+
+    const current = this.storage.get(sourceId);
+    if (!current || current.updatedAt !== expectedUpdatedAt) {
+      throw new SourceVersionConflictError(sourceId);
+    }
+
+    if (this.updateError) {
+      this.mutateStorageBeforeUpdateError?.(this.storage);
+      throw this.updateError;
+    }
+
+    this.storage.set(sourceId, source);
+    return Promise.resolve();
+  }
+
+  getSnapshot(sourceId: string): SourceRegistryRecord | undefined {
+    return this.storage.get(sourceId);
+  }
+}
+
+describe('delete-source handler', () => {
+  it('deactivates active source and returns 204', async () => {
+    const repository = new SpySourceRegistryRepository([ACTIVE_SOURCE]);
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: ACTIVE_SOURCE.sourceId },
+    });
+
+    expect(result).toEqual({
+      statusCode: 204,
+      headers: {},
+      body: '',
+    });
+    expect(repository.updateCalls).toHaveLength(1);
+
+    const stored = repository.getSnapshot(ACTIVE_SOURCE.sourceId);
+    expect(stored).toMatchObject({
+      sourceId: ACTIVE_SOURCE.sourceId,
+      active: false,
+      updatedAt: '2026-03-03T12:00:00.000Z',
+    });
+  });
+
+  it('returns 204 without update when source is already inactive', async () => {
+    const repository = new SpySourceRegistryRepository([
+      {
+        ...ACTIVE_SOURCE,
+        active: false,
+      },
+    ]);
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: ACTIVE_SOURCE.sourceId },
+    });
+
+    expect(result.statusCode).toBe(204);
+    expect(repository.updateCalls).toHaveLength(0);
+  });
+
+  it('returns 404 when source does not exist', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: 'missing-source' },
+    });
+
+    expect(result.statusCode).toBe(404);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Source "missing-source" was not found.',
+      code: 'SOURCE_NOT_FOUND',
+    });
+  });
+
+  it('returns 400 when path parameter id is missing', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository([ACTIVE_SOURCE]),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: {},
+    });
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Path parameter "id" is required.',
+    });
+  });
+
+  it('returns 409 when update conflicts and source remains active', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(
+        [ACTIVE_SOURCE],
+        new SourceVersionConflictError(ACTIVE_SOURCE.sourceId),
+      ),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: ACTIVE_SOURCE.sourceId },
+    });
+
+    expect(result.statusCode).toBe(409);
+    expect(JSON.parse(result.body)).toEqual({
+      message: `Source "${ACTIVE_SOURCE.sourceId}" version conflict.`,
+      code: 'SOURCE_VERSION_CONFLICT',
+    });
+  });
+
+  it('returns 204 when conflict happens but source is already inactive after revalidation', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(
+        [ACTIVE_SOURCE],
+        new SourceVersionConflictError(ACTIVE_SOURCE.sourceId),
+        (storage) => {
+          storage.set(ACTIVE_SOURCE.sourceId, {
+            ...ACTIVE_SOURCE,
+            active: false,
+            updatedAt: '2026-03-03T11:45:00.000Z',
+          });
+        },
+      ),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: ACTIVE_SOURCE.sourceId },
+    });
+
+    expect(result.statusCode).toBe(204);
+    expect(result.body).toBe('');
+  });
+
+  it('returns 500 for unexpected persistence errors', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(
+        [ACTIVE_SOURCE],
+        new Error('timeout'),
+      ),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: ACTIVE_SOURCE.sourceId },
+    });
+
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Failed to delete source.',
+    });
+  });
+});


### PR DESCRIPTION
Closes #43

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Implementar o endpoint `DELETE /sources/{id}` com soft delete (`active=false`) no plugin registry, garantindo idempotência para chamadas repetidas e preservando rastreabilidade operacional.

---

## 🧠 Decisão Técnica

- Mantido o fluxo `handler -> domain port -> infra adapter`.
- Aplicado soft delete (sem remoção física) para não quebrar execuções concorrentes.
- Reuso de `getById` + `update` com optimistic locking (`expectedUpdatedAt`).
- Em conflito de versão, o handler revalida o estado e retorna `204` se a fonte já estiver inativa (idempotência concorrente).

---

## 🧪 BDD Validado

Dado que uma fonte existe e está ativa
Quando `DELETE /sources/{id}` é chamado
Então a fonte é marcada como inativa e a API retorna `204`

Dado que a fonte já está inativa
Quando `DELETE /sources/{id}` é chamado novamente
Então a API retorna `204` sem nova mutação

Dado que a fonte não existe
Quando `DELETE /sources/{id}` é chamado
Então a API retorna `404` com `SOURCE_NOT_FOUND`

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
