### PR TITLE
feat(api): centralizar validacao de payload dos endpoints de fontes

### DIFF
--- a/docs/sources/create-source-endpoint-v1.md
+++ b/docs/sources/create-source-endpoint-v1.md
@@ -26,11 +26,7 @@ Endpoint para cadastro de novas fontes no plugin registry.
 
 ### `400 Bad Request`
 
-Body ausente ou JSON inválido.
-
-### `422 Unprocessable Entity`
-
-Payload inválido conforme regras de `SourceSchemaV1`.
+Body ausente, JSON inválido ou payload inválido conforme regras de `SourceSchemaV1` (campos obrigatórios, formatos e condicionais).
 
 ### `409 Conflict`
 

--- a/docs/sources/update-source-endpoint-v1.md
+++ b/docs/sources/update-source-endpoint-v1.md
@@ -31,7 +31,7 @@ Atualizar parcialmente uma fonte já cadastrada no plugin registry, preservando 
 - `createdAt`
 - `updatedAt`
 
-Se o payload incluir campos imutáveis ou desconhecidos, a API retorna `422`.
+Se o payload incluir campos imutáveis ou desconhecidos, a API retorna `400`.
 
 ## Controle de versão
 
@@ -53,6 +53,6 @@ A atualização usa optimistic locking em `updatedAt`:
   - `code: SOURCE_NOT_FOUND`
 - `409 Conflict`
   - `code: SOURCE_VERSION_CONFLICT`
-- `422 Unprocessable Entity`
-  - `message: Source patch validation failed.`
+- `400 Bad Request`
+  - `message: Source payload validation failed.`
   - `errors[]`

--- a/src/domain/sources/source-payload-validation.ts
+++ b/src/domain/sources/source-payload-validation.ts
@@ -1,0 +1,159 @@
+import type { SourceRegistryRecord } from './source-registry-repository';
+import {
+  type SourceSchemaValidationError,
+  type SourceSchemaV1,
+  validateSourceSchemaV1,
+} from './source-schema';
+
+const IMMUTABLE_FIELDS = ['sourceId', 'engine', 'schemaVersion', 'createdAt', 'updatedAt'] as const;
+const MUTABLE_FIELDS = [
+  'active',
+  'secretArn',
+  'query',
+  'cursorField',
+  'fieldMap',
+  'scheduleType',
+  'intervalMinutes',
+  'cronExpr',
+  'nextRunAt',
+] as const;
+const KNOWN_FIELDS = new Set<string>([...IMMUTABLE_FIELDS, ...MUTABLE_FIELDS]);
+
+export const SOURCE_PAYLOAD_VALIDATION_MESSAGE = 'Source payload validation failed.';
+
+export interface SourcePatchPayload {
+  active?: boolean;
+  secretArn?: string;
+  query?: string;
+  cursorField?: string;
+  fieldMap?: Record<string, string>;
+  scheduleType?: 'interval' | 'cron';
+  intervalMinutes?: number;
+  cronExpr?: string;
+  nextRunAt?: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const validateSourceCreatePayload = (
+  payload: unknown,
+):
+  | { success: true; value: SourceSchemaV1 }
+  | { success: false; errors: SourceSchemaValidationError[] } => validateSourceSchemaV1(payload);
+
+export const validateSourcePatchPayload = (
+  payload: unknown,
+):
+  | { success: true; value: SourcePatchPayload }
+  | { success: false; errors: SourceSchemaValidationError[] } => {
+  if (!isRecord(payload)) {
+    return {
+      success: false,
+      errors: [
+        {
+          field: '$',
+          code: 'INVALID_TYPE',
+          message: 'patch payload must be an object.',
+        },
+      ],
+    };
+  }
+
+  const errors: SourceSchemaValidationError[] = [];
+  const patch: SourcePatchPayload = {};
+  let mutableFieldCount = 0;
+
+  for (const key of Object.keys(payload)) {
+    if (!KNOWN_FIELDS.has(key)) {
+      errors.push({
+        field: key,
+        code: 'INVALID_VALUE',
+        message: `field "${key}" is not supported for source updates.`,
+      });
+      continue;
+    }
+
+    if ((IMMUTABLE_FIELDS as readonly string[]).includes(key)) {
+      errors.push({
+        field: key,
+        code: 'INVALID_VALUE',
+        message: `field "${key}" is immutable and cannot be updated.`,
+      });
+      continue;
+    }
+
+    mutableFieldCount += 1;
+    patch[key as keyof SourcePatchPayload] = payload[key] as never;
+  }
+
+  if (mutableFieldCount === 0) {
+    errors.push({
+      field: '$',
+      code: 'INVALID_VALUE',
+      message: 'patch payload must include at least one mutable field.',
+    });
+  }
+
+  if (errors.length > 0) {
+    return {
+      success: false,
+      errors,
+    };
+  }
+
+  return {
+    success: true,
+    value: patch,
+  };
+};
+
+export const mergeAndValidateSourcePatch = (
+  current: SourceRegistryRecord,
+  patch: SourcePatchPayload,
+  nextUpdatedAt: string,
+):
+  | { success: true; value: SourceRegistryRecord }
+  | { success: false; errors: SourceSchemaValidationError[] } => {
+  const nextScheduleType = patch.scheduleType ?? current.scheduleType;
+  const nextIntervalMinutes =
+    nextScheduleType === 'interval'
+      ? (patch.intervalMinutes ??
+        (current.scheduleType === 'interval' ? current.intervalMinutes : undefined))
+      : patch.intervalMinutes;
+  const nextCronExpr =
+    nextScheduleType === 'cron'
+      ? (patch.cronExpr ?? (current.scheduleType === 'cron' ? current.cronExpr : undefined))
+      : patch.cronExpr;
+
+  const validation = validateSourceSchemaV1({
+    sourceId: current.sourceId,
+    active: patch.active ?? current.active,
+    engine: current.engine,
+    secretArn: patch.secretArn ?? current.secretArn,
+    query: patch.query ?? current.query,
+    cursorField: patch.cursorField ?? current.cursorField,
+    fieldMap: patch.fieldMap ?? current.fieldMap,
+    scheduleType: nextScheduleType,
+    intervalMinutes: nextIntervalMinutes,
+    cronExpr: nextCronExpr,
+    nextRunAt: patch.nextRunAt ?? current.nextRunAt,
+  });
+
+  if (!validation.success) {
+    return {
+      success: false,
+      errors: validation.errors,
+    };
+  }
+
+  return {
+    success: true,
+    value: {
+      ...validation.value,
+      schemaVersion: current.schemaVersion,
+      createdAt: current.createdAt,
+      updatedAt: nextUpdatedAt,
+    },
+  };
+};

--- a/src/handlers/create-source.ts
+++ b/src/handlers/create-source.ts
@@ -1,4 +1,8 @@
-import { SOURCE_SCHEMA_VERSION, validateSourceSchemaV1 } from '../domain/sources/source-schema';
+import {
+  SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+  validateSourceCreatePayload,
+} from '../domain/sources/source-payload-validation';
+import { SOURCE_SCHEMA_VERSION } from '../domain/sources/source-schema';
 import {
   SourceAlreadyExistsError,
   type SourceRegistryRecord,
@@ -90,10 +94,10 @@ export const createHandler =
       return parsedBody.response;
     }
 
-    const validation = validateSourceSchemaV1(parsedBody.value);
+    const validation = validateSourceCreatePayload(parsedBody.value);
     if (!validation.success) {
-      return response(422, {
-        message: 'Source payload validation failed.',
+      return response(400, {
+        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
         errors: validation.errors,
       });
     }

--- a/src/handlers/update-source.ts
+++ b/src/handlers/update-source.ts
@@ -1,44 +1,18 @@
 import {
   SourceVersionConflictError,
-  type SourceRegistryRecord,
   type SourceRegistryRepository,
 } from '../domain/sources/source-registry-repository';
 import {
-  type SourceSchemaValidationError,
-  validateSourceSchemaV1,
-} from '../domain/sources/source-schema';
+  mergeAndValidateSourcePatch,
+  SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+  validateSourcePatchPayload,
+} from '../domain/sources/source-payload-validation';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
 import { nowIso } from '../shared/time/now-iso';
 
 const JSON_HEADERS = {
   'content-type': 'application/json',
 };
-
-const IMMUTABLE_FIELDS = ['sourceId', 'engine', 'schemaVersion', 'createdAt', 'updatedAt'] as const;
-const MUTABLE_FIELDS = [
-  'active',
-  'secretArn',
-  'query',
-  'cursorField',
-  'fieldMap',
-  'scheduleType',
-  'intervalMinutes',
-  'cronExpr',
-  'nextRunAt',
-] as const;
-const KNOWN_FIELDS = new Set<string>([...IMMUTABLE_FIELDS, ...MUTABLE_FIELDS]);
-
-interface UpdateSourcePatchPayload {
-  active?: boolean;
-  secretArn?: string;
-  query?: string;
-  cursorField?: string;
-  fieldMap?: Record<string, string>;
-  scheduleType?: 'interval' | 'cron';
-  intervalMinutes?: number;
-  cronExpr?: string;
-  nextRunAt?: string;
-}
 
 export interface UpdateSourceEvent {
   body?: string | null;
@@ -68,9 +42,6 @@ const response = (statusCode: number, payload: unknown): UpdateSourceResponse =>
   headers: JSON_HEADERS,
   body: JSON.stringify(payload),
 });
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const parseBody = (
   rawBody: string | null | undefined,
@@ -117,116 +88,6 @@ const parseSourceId = (
   };
 };
 
-const validatePatchPayload = (
-  payload: unknown,
-):
-  | { success: true; value: UpdateSourcePatchPayload }
-  | { success: false; errors: SourceSchemaValidationError[] } => {
-  if (!isRecord(payload)) {
-    return {
-      success: false,
-      errors: [
-        {
-          field: '$',
-          code: 'INVALID_TYPE',
-          message: 'patch payload must be an object.',
-        },
-      ],
-    };
-  }
-
-  const errors: SourceSchemaValidationError[] = [];
-  const patch: UpdateSourcePatchPayload = {};
-  let mutableFieldCount = 0;
-
-  for (const key of Object.keys(payload)) {
-    if (!KNOWN_FIELDS.has(key)) {
-      errors.push({
-        field: key,
-        code: 'INVALID_VALUE',
-        message: `field "${key}" is not supported for source updates.`,
-      });
-      continue;
-    }
-
-    if ((IMMUTABLE_FIELDS as readonly string[]).includes(key)) {
-      errors.push({
-        field: key,
-        code: 'INVALID_VALUE',
-        message: `field "${key}" is immutable and cannot be updated.`,
-      });
-      continue;
-    }
-
-    mutableFieldCount += 1;
-    patch[key as keyof UpdateSourcePatchPayload] = payload[key] as never;
-  }
-
-  if (mutableFieldCount === 0) {
-    errors.push({
-      field: '$',
-      code: 'INVALID_VALUE',
-      message: 'patch payload must include at least one mutable field.',
-    });
-  }
-
-  if (errors.length > 0) {
-    return {
-      success: false,
-      errors,
-    };
-  }
-
-  return {
-    success: true,
-    value: patch,
-  };
-};
-
-const mergeSourceRecord = (
-  current: SourceRegistryRecord,
-  patch: UpdateSourcePatchPayload,
-  nextUpdatedAt: string,
-): SourceRegistryRecord | { validationErrors: SourceSchemaValidationError[] } => {
-  const nextScheduleType = patch.scheduleType ?? current.scheduleType;
-  const nextIntervalMinutes =
-    nextScheduleType === 'interval'
-      ? (patch.intervalMinutes ??
-        (current.scheduleType === 'interval' ? current.intervalMinutes : undefined))
-      : patch.intervalMinutes;
-  const nextCronExpr =
-    nextScheduleType === 'cron'
-      ? (patch.cronExpr ?? (current.scheduleType === 'cron' ? current.cronExpr : undefined))
-      : patch.cronExpr;
-
-  const validation = validateSourceSchemaV1({
-    sourceId: current.sourceId,
-    active: patch.active ?? current.active,
-    engine: current.engine,
-    secretArn: patch.secretArn ?? current.secretArn,
-    query: patch.query ?? current.query,
-    cursorField: patch.cursorField ?? current.cursorField,
-    fieldMap: patch.fieldMap ?? current.fieldMap,
-    scheduleType: nextScheduleType,
-    intervalMinutes: nextIntervalMinutes,
-    cronExpr: nextCronExpr,
-    nextRunAt: patch.nextRunAt ?? current.nextRunAt,
-  });
-
-  if (!validation.success) {
-    return {
-      validationErrors: validation.errors,
-    };
-  }
-
-  return {
-    ...validation.value,
-    schemaVersion: current.schemaVersion,
-    createdAt: current.createdAt,
-    updatedAt: nextUpdatedAt,
-  };
-};
-
 const getDefaultDependencies = (): UpdateSourceDependencies => {
   if (cachedDefaultDependencies) {
     return cachedDefaultDependencies;
@@ -258,10 +119,10 @@ export const createHandler =
       return parsedBody.response;
     }
 
-    const patchValidation = validatePatchPayload(parsedBody.value);
+    const patchValidation = validateSourcePatchPayload(parsedBody.value);
     if (!patchValidation.success) {
-      return response(422, {
-        message: 'Source patch validation failed.',
+      return response(400, {
+        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
         errors: patchValidation.errors,
       });
     }
@@ -275,27 +136,27 @@ export const createHandler =
     }
 
     const nextUpdatedAt = now();
-    const merged = mergeSourceRecord(current, patchValidation.value, nextUpdatedAt);
-    if ('validationErrors' in merged) {
-      return response(422, {
-        message: 'Source patch validation failed.',
-        errors: merged.validationErrors,
+    const merged = mergeAndValidateSourcePatch(current, patchValidation.value, nextUpdatedAt);
+    if (!merged.success) {
+      return response(400, {
+        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+        errors: merged.errors,
       });
     }
 
     try {
       await sourceRegistryRepository.update({
         sourceId: current.sourceId,
-        source: merged,
+        source: merged.value,
         expectedUpdatedAt: current.updatedAt,
       });
 
       return response(200, {
-        sourceId: merged.sourceId,
+        sourceId: merged.value.sourceId,
         metadata: {
-          schemaVersion: merged.schemaVersion,
-          createdAt: merged.createdAt,
-          updatedAt: merged.updatedAt,
+          schemaVersion: merged.value.schemaVersion,
+          createdAt: merged.value.createdAt,
+          updatedAt: merged.value.updatedAt,
           requestId: event.requestContext?.requestId ?? null,
         },
       });

--- a/tests/unit/handlers/create-source.test.ts
+++ b/tests/unit/handlers/create-source.test.ts
@@ -87,7 +87,7 @@ describe('create-source handler', () => {
     });
   });
 
-  it('returns 422 when payload validation fails', async () => {
+  it('returns 400 when payload validation fails', async () => {
     const repository = new SpySourceRegistryRepository();
     const handler = createHandler({
       sourceRegistryRepository: repository,
@@ -101,7 +101,7 @@ describe('create-source handler', () => {
       }),
     });
 
-    expect(result.statusCode).toBe(422);
+    expect(result.statusCode).toBe(400);
     const parsedBody = JSON.parse(result.body) as {
       message: string;
       errors: Array<{ field: string }>;

--- a/tests/unit/handlers/update-source.test.ts
+++ b/tests/unit/handlers/update-source.test.ts
@@ -143,7 +143,7 @@ describe('update-source handler', () => {
     });
   });
 
-  it('returns 422 when payload contains immutable fields', async () => {
+  it('returns 400 when payload contains immutable fields', async () => {
     const handler = createHandler({
       sourceRegistryRepository: new SpySourceRegistryRepository([EXISTING_SOURCE]),
       now: () => '2026-03-03T12:00:00.000Z',
@@ -157,12 +157,12 @@ describe('update-source handler', () => {
       }),
     });
 
-    expect(result.statusCode).toBe(422);
+    expect(result.statusCode).toBe(400);
     const parsed = JSON.parse(result.body) as {
       message: string;
       errors: Array<{ field: string }>;
     };
-    expect(parsed.message).toBe('Source patch validation failed.');
+    expect(parsed.message).toBe('Source payload validation failed.');
     expect(parsed.errors.some((entry) => entry.field === 'sourceId')).toBe(true);
   });
 
@@ -184,7 +184,7 @@ describe('update-source handler', () => {
     });
   });
 
-  it('returns 422 when merged state violates source schema', async () => {
+  it('returns 400 when merged state violates source schema', async () => {
     const handler = createHandler({
       sourceRegistryRepository: new SpySourceRegistryRepository([EXISTING_SOURCE]),
       now: () => '2026-03-03T12:00:00.000Z',
@@ -197,12 +197,12 @@ describe('update-source handler', () => {
       }),
     });
 
-    expect(result.statusCode).toBe(422);
+    expect(result.statusCode).toBe(400);
     const parsed = JSON.parse(result.body) as {
       message: string;
       errors: Array<{ field: string }>;
     };
-    expect(parsed.message).toBe('Source patch validation failed.');
+    expect(parsed.message).toBe('Source payload validation failed.');
     expect(parsed.errors.some((entry) => entry.field === 'cronExpr')).toBe(true);
   });
 


### PR DESCRIPTION
Closes #44

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Centralizar a validação de payload dos endpoints de fontes (`POST /sources` e `PATCH /sources/{id}`), mantendo regras condicionais de `scheduleType` e padronizando retorno de erro de payload inválido para `400`.

---

## 🧠 Decisão Técnica

- Extraída validação para `src/domain/sources/source-payload-validation.ts`.
- `create-source` e `update-source` passaram a consumir o mesmo contrato de validação.
- Regras condicionais (`intervalMinutes` vs `cronExpr`) continuam sendo aplicadas via `validateSourceSchemaV1` após merge de patch.
- Mensagem de erro funcional de payload inválido foi unificada em `Source payload validation failed.`.

---

## 🧪 BDD Validado

Dado que o cliente envia payload inválido para `POST` ou `PATCH`
Quando o handler valida o contrato de entrada
Então a API retorna `400` com mensagem consistente e lista de erros.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [ ] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [ ] PATCH
- [x] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
