### PR TITLE
feat(security): implementar autenticacao da API de fontes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
   - Stage `prod`: `10`
   - Limites aceitos em runtime: inteiro entre `1` e `40`.
   - Fallback no scheduler quando ausente: `5`.
+- API de fontes protegida por JWT Authorizer no HTTP API:
+  - Header obrigatório: `Authorization: Bearer <jwt>`.
+  - Configuração por stage:
+    - `sourceRegistryJwtIssuerUrl`
+    - `sourceRegistryJwtAudience`
+  - Overrides por ambiente (opcionais):
+    - `SOURCE_REGISTRY_JWT_ISSUER_URL_DEV|STG|PROD`
+    - `SOURCE_REGISTRY_JWT_AUDIENCE_DEV|STG|PROD`
+  - Escopos mínimos por operação:
+    - `GET /sources` requer `sources:read`.
+    - `POST /sources`, `PATCH /sources/{id}`, `DELETE /sources/{id}` requerem `sources:write`.
+  - Contrato de erro de auth no gateway:
+    - `401` para token ausente/inválido.
+    - `403` para token sem escopo exigido.
 - Definição da state machine principal versionada em `state-machines/main-orchestration-v1.asl.json`.
 - Contratos de entrada/saída por estado documentados em `docs/step-functions/main-orchestration-v1.md`.
 - Retry com backoff exponencial configurado na state machine para tasks críticas:

--- a/docs/sources/create-source-endpoint-v1.md
+++ b/docs/sources/create-source-endpoint-v1.md
@@ -6,6 +6,8 @@ Endpoint para cadastro de novas fontes no plugin registry.
 
 - Método: `POST`
 - Path: `/sources`
+- Header obrigatório: `Authorization: Bearer <jwt>`
+- Scope obrigatório: `sources:write`
 - Body: contrato `SourceSchemaV1` (ver `docs/sources/source-schema-v1.md`).
 
 ## Responses
@@ -27,6 +29,14 @@ Endpoint para cadastro de novas fontes no plugin registry.
 ### `400 Bad Request`
 
 Body ausente, JSON inválido ou payload inválido conforme regras de `SourceSchemaV1` (campos obrigatórios, formatos e condicionais).
+
+### `401 Unauthorized`
+
+Token JWT ausente, expirado ou inválido no `Authorization`.
+
+### `403 Forbidden`
+
+Token válido sem o scope `sources:write`.
 
 ### `409 Conflict`
 

--- a/docs/sources/delete-source-endpoint-v1.md
+++ b/docs/sources/delete-source-endpoint-v1.md
@@ -8,6 +8,8 @@ Desativar uma fonte do plugin registry com **soft delete** (`active=false`), man
 
 - Método: `DELETE`
 - Rota: `/sources/{id}`
+- Header obrigatório: `Authorization: Bearer <jwt>`
+- Scope obrigatório: `sources:write`
 - `pathParameters.id`: identificador da fonte (`sourceId`)
 
 ## Comportamento
@@ -29,3 +31,7 @@ Desativar uma fonte do plugin registry com **soft delete** (`active=false`), man
   - `code: SOURCE_VERSION_CONFLICT` quando ocorre corrida concorrente e a fonte segue ativa após revalidação.
 - `500 Internal Server Error`
   - falha inesperada na persistência.
+- `401 Unauthorized`
+  - JWT ausente, expirado ou inválido.
+- `403 Forbidden`
+  - JWT válido sem o scope `sources:write`.

--- a/docs/sources/list-sources-endpoint-v1.md
+++ b/docs/sources/list-sources-endpoint-v1.md
@@ -2,6 +2,11 @@
 
 Endpoint para listagem paginada das fontes cadastradas no plugin registry.
 
+## Autenticação
+
+- Header obrigatório: `Authorization: Bearer <jwt>`.
+- Scope obrigatório: `sources:read`.
+
 ## Query Params
 
 - `limit` (opcional): inteiro entre `1` e `100`. Padrão: `25`.
@@ -55,3 +60,11 @@ Endpoint para listagem paginada das fontes cadastradas no plugin registry.
 ### `500 Internal Server Error`
 
 - Falha inesperada ao consultar o repositório.
+
+### `401 Unauthorized`
+
+- JWT ausente, expirado ou inválido.
+
+### `403 Forbidden`
+
+- JWT válido sem o scope `sources:read`.

--- a/docs/sources/update-source-endpoint-v1.md
+++ b/docs/sources/update-source-endpoint-v1.md
@@ -8,6 +8,8 @@ Atualizar parcialmente uma fonte já cadastrada no plugin registry, preservando 
 
 - Método: `PATCH`
 - Rota: `/sources/{id}`
+- Header obrigatório: `Authorization: Bearer <jwt>`
+- Scope obrigatório: `sources:write`
 - `pathParameters.id`: identificador da fonte (`sourceId`)
 - Body: JSON com ao menos um campo mutável
 
@@ -56,3 +58,7 @@ A atualização usa optimistic locking em `updatedAt`:
 - `400 Bad Request`
   - `message: Source payload validation failed.`
   - `errors[]`
+- `401 Unauthorized`
+  - JWT ausente, expirado ou inválido.
+- `403 Forbidden`
+  - JWT válido sem o scope `sources:write`.

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -28,6 +28,20 @@ const staticFallback = () => {
     'region: ${self:custom.stages.${self:provider.stage}.region}',
     'logRetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}',
     'lambda: ${self:custom.stages.${self:provider.stage}.tracing}',
+    'httpApi:',
+    'authorizers:',
+    'sourceRegistryJwtAuthorizer:',
+    'type: jwt',
+    'identitySource: $request.header.Authorization',
+    'issuerUrl: ${self:custom.stages.${self:provider.stage}.sourceRegistryJwtIssuerUrl}',
+    'sourceRegistryReadScope: sources:read',
+    'sourceRegistryWriteScope: sources:write',
+    "sourceRegistryJwtIssuerUrl: ${env:SOURCE_REGISTRY_JWT_ISSUER_URL_DEV, 'https://auth.dev.alert-orchestration.internal'}",
+    "sourceRegistryJwtIssuerUrl: ${env:SOURCE_REGISTRY_JWT_ISSUER_URL_STG, 'https://auth.stg.alert-orchestration.internal'}",
+    "sourceRegistryJwtIssuerUrl: ${env:SOURCE_REGISTRY_JWT_ISSUER_URL_PROD, 'https://auth.alert-orchestration.internal'}",
+    "sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_DEV, 'alert-orchestration-service-dev-source-registry-api'}",
+    "sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_STG, 'alert-orchestration-service-stg-source-registry-api'}",
+    "sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_PROD, 'alert-orchestration-service-prod-source-registry-api'}",
     'SOURCES_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.sourcesTableName}',
     'CURSORS_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.cursorsTableName}',
     'MAP_MAX_CONCURRENCY: ${self:custom.stages.${self:provider.stage}.mapMaxConcurrency}',
@@ -185,11 +199,54 @@ const staticFallback = () => {
     'prod:',
   ];
 
+  const sourceRegistryProtectedRouteSnippets = [
+    `- httpApi:
+          method: post
+          path: /sources
+          authorizer:
+            name: sourceRegistryJwtAuthorizer
+            scopes:
+              - \${self:custom.auth.sourceRegistryWriteScope}`,
+    `- httpApi:
+          method: patch
+          path: /sources/{id}
+          authorizer:
+            name: sourceRegistryJwtAuthorizer
+            scopes:
+              - \${self:custom.auth.sourceRegistryWriteScope}`,
+    `- httpApi:
+          method: delete
+          path: /sources/{id}
+          authorizer:
+            name: sourceRegistryJwtAuthorizer
+            scopes:
+              - \${self:custom.auth.sourceRegistryWriteScope}`,
+    `- httpApi:
+          method: get
+          path: /sources
+          authorizer:
+            name: sourceRegistryJwtAuthorizer
+            scopes:
+              - \${self:custom.auth.sourceRegistryReadScope}`,
+  ];
+
   const missing = checks.filter((check) => !serverless.includes(check));
   if (missing.length > 0) {
     console.error('Falha no fallback estático de stage render:');
     for (const check of missing) {
       console.error(`- Ausente: ${check}`);
+    }
+    process.exit(1);
+  }
+
+  const missingProtectedRoutes = sourceRegistryProtectedRouteSnippets.filter(
+    (snippet) => !serverless.includes(snippet),
+  );
+  if (missingProtectedRoutes.length > 0) {
+    console.error('Falha no fallback estático de stage render: rotas /sources sem auth esperada.');
+    for (const snippet of missingProtectedRoutes) {
+      const firstLine = snippet.split('\n')[0] ?? snippet;
+      console.error(`- Snippet ausente: ${firstLine.trim()}`);
     }
     process.exit(1);
   }

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,6 +9,14 @@ provider:
   logRetentionInDays: ${self:custom.stages.${self:provider.stage}.logRetentionInDays}
   tracing:
     lambda: ${self:custom.stages.${self:provider.stage}.tracing}
+  httpApi:
+    authorizers:
+      sourceRegistryJwtAuthorizer:
+        type: jwt
+        identitySource: $request.header.Authorization
+        issuerUrl: ${self:custom.stages.${self:provider.stage}.sourceRegistryJwtIssuerUrl}
+        audience:
+          - ${self:custom.stages.${self:provider.stage}.sourceRegistryJwtAudience}
   environment:
     STAGE: ${self:provider.stage}
     SERVICE_NAME: ${self:service}
@@ -47,6 +55,9 @@ provider:
     ManagedBy: serverless-framework
 
 custom:
+  auth:
+    sourceRegistryReadScope: sources:read
+    sourceRegistryWriteScope: sources:write
   naming:
     prefix: ${self:service}-${self:provider.stage}
     schedulerFunctionName: ${self:custom.naming.prefix}-scheduler
@@ -69,6 +80,8 @@ custom:
       region: us-east-1
       logRetentionInDays: 7
       tracing: false
+      sourceRegistryJwtIssuerUrl: ${env:SOURCE_REGISTRY_JWT_ISSUER_URL_DEV, 'https://auth.dev.alert-orchestration.internal'}
+      sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_DEV, 'alert-orchestration-service-dev-source-registry-api'}
       sourcesTableName: ${self:service}-dev-sources
       cursorsTableName: ${self:service}-dev-cursors
       clientEventsTopicName: ${self:service}-dev-client-events
@@ -86,6 +99,8 @@ custom:
       region: us-east-1
       logRetentionInDays: 14
       tracing: true
+      sourceRegistryJwtIssuerUrl: ${env:SOURCE_REGISTRY_JWT_ISSUER_URL_STG, 'https://auth.stg.alert-orchestration.internal'}
+      sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_STG, 'alert-orchestration-service-stg-source-registry-api'}
       sourcesTableName: ${self:service}-stg-sources
       cursorsTableName: ${self:service}-stg-cursors
       clientEventsTopicName: ${self:service}-stg-client-events
@@ -103,6 +118,8 @@ custom:
       region: us-east-1
       logRetentionInDays: 30
       tracing: true
+      sourceRegistryJwtIssuerUrl: ${env:SOURCE_REGISTRY_JWT_ISSUER_URL_PROD, 'https://auth.alert-orchestration.internal'}
+      sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_PROD, 'alert-orchestration-service-prod-source-registry-api'}
       sourcesTableName: ${self:service}-prod-sources
       cursorsTableName: ${self:service}-prod-cursors
       clientEventsTopicName: ${self:service}-prod-client-events
@@ -155,6 +172,10 @@ functions:
       - httpApi:
           method: post
           path: /sources
+          authorizer:
+            name: sourceRegistryJwtAuthorizer
+            scopes:
+              - ${self:custom.auth.sourceRegistryWriteScope}
   updateSource:
     name: ${self:custom.naming.updateSourceFunctionName}
     handler: dist/handlers/update-source.handler
@@ -169,6 +190,10 @@ functions:
       - httpApi:
           method: patch
           path: /sources/{id}
+          authorizer:
+            name: sourceRegistryJwtAuthorizer
+            scopes:
+              - ${self:custom.auth.sourceRegistryWriteScope}
   deleteSource:
     name: ${self:custom.naming.deleteSourceFunctionName}
     handler: dist/handlers/delete-source.handler
@@ -183,6 +208,10 @@ functions:
       - httpApi:
           method: delete
           path: /sources/{id}
+          authorizer:
+            name: sourceRegistryJwtAuthorizer
+            scopes:
+              - ${self:custom.auth.sourceRegistryWriteScope}
   listSource:
     name: ${self:custom.naming.listSourceFunctionName}
     handler: dist/handlers/list-sources.handler
@@ -197,6 +226,10 @@ functions:
       - httpApi:
           method: get
           path: /sources
+          authorizer:
+            name: sourceRegistryJwtAuthorizer
+            scopes:
+              - ${self:custom.auth.sourceRegistryReadScope}
 
 stepFunctions:
   stateMachines:


### PR DESCRIPTION
Closes #45

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Proteger a API de fontes (`/sources`) com autenticação e autorização no API Gateway HTTP API, garantindo bloqueio sem credenciais e escopos mínimos por operação.

---

## 🧠 Decisão Técnica

- Configurado `provider.httpApi.authorizers.sourceRegistryJwtAuthorizer` (JWT) no `serverless.yml`.
- `issuerUrl` e `audience` foram parametrizados por stage (`dev/stg/prod`) com opção de override por variáveis de ambiente.
- Escopos mínimos por rota:
  - `GET /sources`: `sources:read`
  - `POST /sources`, `PATCH /sources/{id}`, `DELETE /sources/{id}`: `sources:write`
- Atualizado `validate-stage-render` para detectar regressão de auth/scopes no fallback estático.
- Atualizada documentação dos endpoints e README com contrato `401/403` e requisitos de escopo.

---

## 🧪 BDD Validado

Dado que a API de fontes está protegida por JWT
Quando uma chamada é feita sem token ou sem scope exigido
Então o gateway deve bloquear com `401`/`403` antes da execução do handler.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [ ] PATCH
- [x] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
