### PR TITLE
[EPIC 3] Atualizar nextRunAt no cadastro/edição de fontes

### DIFF
--- a/.codex/runs/platform_architect-issue-46.md
+++ b/.codex/runs/platform_architect-issue-46.md
@@ -1,0 +1,29 @@
+## Issue #46 — [EPIC 3] Atualizar nextRunAt no cadastro/edição de fontes
+
+### Objetivo
+Garantir que `nextRunAt` seja calculado automaticamente no backend em UTC durante `POST /sources` e em `PATCH /sources/{id}` quando houver alteração de agenda.
+
+### Decisões arquiteturais
+1. **Cálculo centralizado em domínio**
+- Criar utilitário dedicado (`src/domain/sources/next-run-at.ts`) para calcular `nextRunAt` com base em `scheduleType`.
+- Evitar lógica de data espalhada em handlers.
+
+2. **Regra de cálculo por tipo de agenda**
+- `interval`: `nextRunAt = now + intervalMinutes`.
+- `cron`: calcular próxima ocorrência em UTC via parser de cron (`cron-parser`).
+- Normalizar expressão cron para UTC e validar erro de formato.
+
+3. **Comportamento de API**
+- `POST /sources`: ignorar `nextRunAt` de entrada e sempre persistir valor calculado.
+- `PATCH /sources/{id}`: recalcular `nextRunAt` quando `scheduleType`, `intervalMinutes` ou `cronExpr` forem alterados.
+- Atualizações sem mudança de agenda preservam `nextRunAt` existente.
+
+4. **Governança de contrato**
+- Remover `nextRunAt` da lista de campos mutáveis do PATCH para impedir sobrescrita manual.
+- Atualizar documentação dos endpoints para explicitar cálculo automático em UTC.
+
+### Critérios técnicos de aceite
+- `nextRunAt` é preenchido automaticamente no create.
+- `nextRunAt` é recalculado no update quando schedule muda.
+- Valor persistido permanece em ISO-8601 UTC.
+- Testes unitários cobrindo `interval` e `cron` em create/update.

--- a/.codex/runs/qa-issue-46.md
+++ b/.codex/runs/qa-issue-46.md
@@ -1,0 +1,25 @@
+**QA — Issue #46 (Atualizar nextRunAt no cadastro/edição de fontes)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante.
+3. Médio: nenhum bloqueante.
+4. Baixo: nenhum.
+
+**Checklist de aceite da issue**
+
+- [x] `nextRunAt` é calculado e salvo automaticamente na criação de fonte.
+- [x] `PATCH` recalcula `nextRunAt` quando o schedule muda (`scheduleType`, `intervalMinutes`, `cronExpr`).
+- [x] Cálculo/persistência usam formato ISO-8601 UTC.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- --passWithNoTests` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ✅ (fallback esperado por ausência de credenciais AWS)
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-46.md
+++ b/.codex/runs/worker-issue-46.md
@@ -1,0 +1,37 @@
+**Status de execução — Issue #46**
+
+**Escopo implementado**
+
+- Cálculo automático de `nextRunAt` em UTC implementado no domínio:
+  - novo módulo `src/domain/sources/next-run-at.ts`.
+  - suporte para `scheduleType=interval` e `scheduleType=cron`.
+  - erro de validação estruturado para `cronExpr` inválido.
+- Handler `POST /sources` ajustado para:
+  - validar payload sem depender de `nextRunAt` fornecido pelo cliente;
+  - calcular e persistir `nextRunAt` automaticamente no create.
+- Handler `PATCH /sources/{id}` ajustado para:
+  - recalcular `nextRunAt` apenas quando `scheduleType`, `intervalMinutes` ou `cronExpr` mudam;
+  - preservar `nextRunAt` quando não há mudança de agenda.
+- Validação de patch atualizada:
+  - `nextRunAt` removido da lista de campos mutáveis de atualização.
+- Documentação atualizada:
+  - `docs/sources/create-source-endpoint-v1.md`
+  - `docs/sources/update-source-endpoint-v1.md`
+  - `docs/sources/source-schema-v1.md`
+- Testes adicionados/atualizados:
+  - `tests/unit/domain/sources/next-run-at.test.ts`
+  - `tests/unit/handlers/create-source.test.ts`
+  - `tests/unit/handlers/update-source.test.ts`
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- --passWithNoTests` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ✅ (fallback esperado por ausência de credenciais AWS)
+
+**Resultado**
+
+Implementação concluída no escopo da issue #46, pronta para PR.

--- a/docs/sources/create-source-endpoint-v1.md
+++ b/docs/sources/create-source-endpoint-v1.md
@@ -8,7 +8,7 @@ Endpoint para cadastro de novas fontes no plugin registry.
 - Path: `/sources`
 - Header obrigatório: `Authorization: Bearer <jwt>`
 - Scope obrigatório: `sources:write`
-- Body: contrato `SourceSchemaV1` (ver `docs/sources/source-schema-v1.md`).
+- Body: contrato de criação baseado em `SourceSchemaV1` (ver `docs/sources/source-schema-v1.md`), com `nextRunAt` calculado automaticamente no backend.
 
 ## Responses
 
@@ -29,6 +29,8 @@ Endpoint para cadastro de novas fontes no plugin registry.
 ### `400 Bad Request`
 
 Body ausente, JSON inválido ou payload inválido conforme regras de `SourceSchemaV1` (campos obrigatórios, formatos e condicionais).
+
+`cronExpr` inválido também retorna `400` com erro estruturado no campo `cronExpr`.
 
 ### `401 Unauthorized`
 

--- a/docs/sources/source-schema-v1.md
+++ b/docs/sources/source-schema-v1.md
@@ -17,6 +17,8 @@ Contrato versionado para registro de fontes (`sources`) usado em:
 - `scheduleType` (`interval` ou `cron`)
 - `nextRunAt` (`string`, ISO-8601 UTC)
 
+> Para os endpoints de cadastro/edição, `nextRunAt` é calculado automaticamente no backend com base no schedule.
+
 ## Campos condicionais
 
 - `scheduleType=interval`:

--- a/docs/sources/update-source-endpoint-v1.md
+++ b/docs/sources/update-source-endpoint-v1.md
@@ -23,7 +23,6 @@ Atualizar parcialmente uma fonte já cadastrada no plugin registry, preservando 
 - `scheduleType`
 - `intervalMinutes`
 - `cronExpr`
-- `nextRunAt`
 
 ## Campos imutáveis
 
@@ -34,6 +33,12 @@ Atualizar parcialmente uma fonte já cadastrada no plugin registry, preservando 
 - `updatedAt`
 
 Se o payload incluir campos imutáveis ou desconhecidos, a API retorna `400`.
+
+## Regras de agenda (`nextRunAt`)
+
+- `nextRunAt` é controlado pelo backend e não pode ser enviado no PATCH.
+- Quando `scheduleType`, `intervalMinutes` ou `cronExpr` mudam, o backend recalcula `nextRunAt` em UTC.
+- Quando não há mudança de agenda, `nextRunAt` é preservado.
 
 ## Controle de versão
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.1001.0",
-        "@aws-sdk/util-dynamodb": "^3.996.1"
+        "@aws-sdk/util-dynamodb": "^3.996.1",
+        "cron-parser": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.3",
@@ -5146,6 +5147,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cron-parser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
+      "integrity": "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8268,6 +8281,15 @@
       "license": "MIT",
       "dependencies": {
         "es5-ext": "~0.10.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.1001.0",
-    "@aws-sdk/util-dynamodb": "^3.996.1"
+    "@aws-sdk/util-dynamodb": "^3.996.1",
+    "cron-parser": "^5.5.0"
   }
 }

--- a/src/domain/sources/next-run-at.ts
+++ b/src/domain/sources/next-run-at.ts
@@ -1,0 +1,72 @@
+import { CronExpressionParser } from 'cron-parser';
+
+import type { SourceSchemaValidationError } from './source-schema';
+
+export type NextRunSchedule =
+  | {
+      scheduleType: 'interval';
+      intervalMinutes: number;
+      cronExpr?: undefined;
+    }
+  | {
+      scheduleType: 'cron';
+      intervalMinutes?: undefined;
+      cronExpr: string;
+    };
+
+const invalidNowError = (): SourceSchemaValidationError => ({
+  field: '$',
+  code: 'INVALID_VALUE',
+  message: 'Unable to compute nextRunAt from current reference time.',
+});
+
+const invalidCronError = (): SourceSchemaValidationError => ({
+  field: 'cronExpr',
+  code: 'INVALID_FORMAT',
+  message: 'cronExpr must be a valid cron expression.',
+});
+
+export const calculateNextRunAt = (
+  schedule: NextRunSchedule,
+  referenceIso: string,
+):
+  | {
+      success: true;
+      value: string;
+    }
+  | {
+      success: false;
+      errors: SourceSchemaValidationError[];
+    } => {
+  const referenceDate = new Date(referenceIso);
+  if (Number.isNaN(referenceDate.getTime())) {
+    return {
+      success: false,
+      errors: [invalidNowError()],
+    };
+  }
+
+  if (schedule.scheduleType === 'interval') {
+    return {
+      success: true,
+      value: new Date(referenceDate.getTime() + schedule.intervalMinutes * 60_000).toISOString(),
+    };
+  }
+
+  try {
+    const interval = CronExpressionParser.parse(schedule.cronExpr.trim(), {
+      currentDate: referenceDate,
+      tz: 'UTC',
+    });
+
+    return {
+      success: true,
+      value: interval.next().toDate().toISOString(),
+    };
+  } catch {
+    return {
+      success: false,
+      errors: [invalidCronError()],
+    };
+  }
+};

--- a/src/domain/sources/source-payload-validation.ts
+++ b/src/domain/sources/source-payload-validation.ts
@@ -15,7 +15,6 @@ const MUTABLE_FIELDS = [
   'scheduleType',
   'intervalMinutes',
   'cronExpr',
-  'nextRunAt',
 ] as const;
 const KNOWN_FIELDS = new Set<string>([...IMMUTABLE_FIELDS, ...MUTABLE_FIELDS]);
 
@@ -30,8 +29,19 @@ export interface SourcePatchPayload {
   scheduleType?: 'interval' | 'cron';
   intervalMinutes?: number;
   cronExpr?: string;
-  nextRunAt?: string;
 }
+
+export type ResolvedSourceSchedule =
+  | {
+      scheduleType: 'interval';
+      intervalMinutes: number;
+      cronExpr?: undefined;
+    }
+  | {
+      scheduleType: 'cron';
+      intervalMinutes?: undefined;
+      cronExpr: string;
+    };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -40,7 +50,19 @@ export const validateSourceCreatePayload = (
   payload: unknown,
 ):
   | { success: true; value: SourceSchemaV1 }
-  | { success: false; errors: SourceSchemaValidationError[] } => validateSourceSchemaV1(payload);
+  | { success: false; errors: SourceSchemaValidationError[] } => {
+  if (!isRecord(payload)) {
+    return validateSourceSchemaV1(payload);
+  }
+
+  // `nextRunAt` is controlled by the backend at runtime.
+  const payloadWithoutNextRunAt = { ...payload };
+  delete payloadWithoutNextRunAt.nextRunAt;
+  return validateSourceSchemaV1({
+    ...payloadWithoutNextRunAt,
+    nextRunAt: new Date(0).toISOString(),
+  });
+};
 
 export const validateSourcePatchPayload = (
   payload: unknown,
@@ -112,19 +134,11 @@ export const mergeAndValidateSourcePatch = (
   current: SourceRegistryRecord,
   patch: SourcePatchPayload,
   nextUpdatedAt: string,
+  nextRunAt: string,
 ):
   | { success: true; value: SourceRegistryRecord }
   | { success: false; errors: SourceSchemaValidationError[] } => {
-  const nextScheduleType = patch.scheduleType ?? current.scheduleType;
-  const nextIntervalMinutes =
-    nextScheduleType === 'interval'
-      ? (patch.intervalMinutes ??
-        (current.scheduleType === 'interval' ? current.intervalMinutes : undefined))
-      : patch.intervalMinutes;
-  const nextCronExpr =
-    nextScheduleType === 'cron'
-      ? (patch.cronExpr ?? (current.scheduleType === 'cron' ? current.cronExpr : undefined))
-      : patch.cronExpr;
+  const nextSchedule = resolveSourceSchedule(current, patch);
 
   const validation = validateSourceSchemaV1({
     sourceId: current.sourceId,
@@ -134,10 +148,10 @@ export const mergeAndValidateSourcePatch = (
     query: patch.query ?? current.query,
     cursorField: patch.cursorField ?? current.cursorField,
     fieldMap: patch.fieldMap ?? current.fieldMap,
-    scheduleType: nextScheduleType,
-    intervalMinutes: nextIntervalMinutes,
-    cronExpr: nextCronExpr,
-    nextRunAt: patch.nextRunAt ?? current.nextRunAt,
+    scheduleType: nextSchedule.scheduleType,
+    intervalMinutes: nextSchedule.intervalMinutes,
+    cronExpr: nextSchedule.cronExpr,
+    nextRunAt,
   });
 
   if (!validation.success) {
@@ -156,4 +170,47 @@ export const mergeAndValidateSourcePatch = (
       updatedAt: nextUpdatedAt,
     },
   };
+};
+
+export const resolveSourceSchedule = (
+  current: SourceRegistryRecord,
+  patch: SourcePatchPayload,
+): ResolvedSourceSchedule => {
+  const nextScheduleType = patch.scheduleType ?? current.scheduleType;
+  if (nextScheduleType === 'interval') {
+    const nextIntervalMinutes =
+      patch.intervalMinutes ??
+      (current.scheduleType === 'interval' ? current.intervalMinutes : undefined);
+
+    return {
+      scheduleType: 'interval',
+      intervalMinutes: nextIntervalMinutes as number,
+    };
+  }
+
+  const nextCronExpr =
+    patch.cronExpr ?? (current.scheduleType === 'cron' ? current.cronExpr : undefined);
+
+  return {
+    scheduleType: 'cron',
+    cronExpr: nextCronExpr as string,
+  };
+};
+
+export const hasSourceScheduleChanged = (
+  current: SourceRegistryRecord,
+  nextSchedule: ResolvedSourceSchedule,
+): boolean => {
+  if (current.scheduleType !== nextSchedule.scheduleType) {
+    return true;
+  }
+
+  if (nextSchedule.scheduleType === 'interval') {
+    return (
+      current.scheduleType !== 'interval' ||
+      current.intervalMinutes !== nextSchedule.intervalMinutes
+    );
+  }
+
+  return current.scheduleType !== 'cron' || current.cronExpr !== nextSchedule.cronExpr;
 };

--- a/src/handlers/create-source.ts
+++ b/src/handlers/create-source.ts
@@ -8,6 +8,7 @@ import {
   type SourceRegistryRecord,
   type SourceRegistryRepository,
 } from '../domain/sources/source-registry-repository';
+import { calculateNextRunAt } from '../domain/sources/next-run-at';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
 import { nowIso } from '../shared/time/now-iso';
 
@@ -103,8 +104,32 @@ export const createHandler =
     }
 
     const createdAt = now();
+    const nextRunAt =
+      validation.value.scheduleType === 'interval'
+        ? calculateNextRunAt(
+            {
+              scheduleType: 'interval',
+              intervalMinutes: validation.value.intervalMinutes,
+            },
+            createdAt,
+          )
+        : calculateNextRunAt(
+            {
+              scheduleType: 'cron',
+              cronExpr: validation.value.cronExpr,
+            },
+            createdAt,
+          );
+    if (!nextRunAt.success) {
+      return response(400, {
+        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+        errors: nextRunAt.errors,
+      });
+    }
+
     const record: SourceRegistryRecord = {
       ...validation.value,
+      nextRunAt: nextRunAt.value,
       schemaVersion: SOURCE_SCHEMA_VERSION,
       createdAt,
       updatedAt: createdAt,

--- a/src/handlers/update-source.ts
+++ b/src/handlers/update-source.ts
@@ -3,10 +3,13 @@ import {
   type SourceRegistryRepository,
 } from '../domain/sources/source-registry-repository';
 import {
+  hasSourceScheduleChanged,
   mergeAndValidateSourcePatch,
+  resolveSourceSchedule,
   SOURCE_PAYLOAD_VALIDATION_MESSAGE,
   validateSourcePatchPayload,
 } from '../domain/sources/source-payload-validation';
+import { calculateNextRunAt } from '../domain/sources/next-run-at';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
 import { nowIso } from '../shared/time/now-iso';
 
@@ -136,7 +139,27 @@ export const createHandler =
     }
 
     const nextUpdatedAt = now();
-    const merged = mergeAndValidateSourcePatch(current, patchValidation.value, nextUpdatedAt);
+    const nextSchedule = resolveSourceSchedule(current, patchValidation.value);
+    const shouldRecalculateNextRunAt = hasSourceScheduleChanged(current, nextSchedule);
+    const nextRunAt = shouldRecalculateNextRunAt
+      ? calculateNextRunAt(nextSchedule, nextUpdatedAt)
+      : {
+          success: true as const,
+          value: current.nextRunAt,
+        };
+    if (!nextRunAt.success) {
+      return response(400, {
+        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+        errors: nextRunAt.errors,
+      });
+    }
+
+    const merged = mergeAndValidateSourcePatch(
+      current,
+      patchValidation.value,
+      nextUpdatedAt,
+      nextRunAt.value,
+    );
     if (!merged.success) {
       return response(400, {
         message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,

--- a/tests/unit/domain/sources/next-run-at.test.ts
+++ b/tests/unit/domain/sources/next-run-at.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { calculateNextRunAt } from '../../../../src/domain/sources/next-run-at';
+
+describe('next-run-at', () => {
+  it('calculates next run for interval schedule', () => {
+    const result = calculateNextRunAt(
+      {
+        scheduleType: 'interval',
+        intervalMinutes: 30,
+      },
+      '2026-03-03T12:00:00.000Z',
+    );
+
+    expect(result).toEqual({
+      success: true,
+      value: '2026-03-03T12:30:00.000Z',
+    });
+  });
+
+  it('calculates next run for cron schedule in UTC', () => {
+    const result = calculateNextRunAt(
+      {
+        scheduleType: 'cron',
+        cronExpr: '0 */10 * * * *',
+      },
+      '2026-03-03T12:00:00.000Z',
+    );
+
+    expect(result).toEqual({
+      success: true,
+      value: '2026-03-03T12:10:00.000Z',
+    });
+  });
+
+  it('returns validation error for invalid cron expression', () => {
+    const result = calculateNextRunAt(
+      {
+        scheduleType: 'cron',
+        cronExpr: 'invalid cron',
+      },
+      '2026-03-03T12:00:00.000Z',
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        field: 'cronExpr',
+        code: 'INVALID_FORMAT',
+      }),
+    );
+  });
+
+  it('returns validation error for invalid reference time', () => {
+    const result = calculateNextRunAt(
+      {
+        scheduleType: 'interval',
+        intervalMinutes: 30,
+      },
+      'invalid-date',
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        field: '$',
+        code: 'INVALID_VALUE',
+      }),
+    );
+  });
+});

--- a/tests/unit/handlers/create-source.test.ts
+++ b/tests/unit/handlers/create-source.test.ts
@@ -20,7 +20,6 @@ const VALID_INTERVAL_SOURCE = {
   },
   scheduleType: 'interval',
   intervalMinutes: 30,
-  nextRunAt: '2026-03-03T10:00:00.000Z',
 } as const;
 
 class SpySourceRegistryRepository implements SourceRegistryRepository {
@@ -81,10 +80,31 @@ describe('create-source handler', () => {
     expect(repository.created).toHaveLength(1);
     expect(repository.created[0]).toMatchObject({
       sourceId: 'source-acme',
+      nextRunAt: '2026-03-03T12:30:00.000Z',
       schemaVersion: '1.0.0',
       createdAt: '2026-03-03T12:00:00.000Z',
       updatedAt: '2026-03-03T12:00:00.000Z',
     });
+  });
+
+  it('calculates nextRunAt for cron schedules in UTC', async () => {
+    const repository = new SpySourceRegistryRepository();
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      body: JSON.stringify({
+        ...VALID_INTERVAL_SOURCE,
+        scheduleType: 'cron',
+        intervalMinutes: undefined,
+        cronExpr: '0 */15 * * * *',
+      }),
+    });
+
+    expect(result.statusCode).toBe(201);
+    expect(repository.created[0]?.nextRunAt).toBe('2026-03-03T12:15:00.000Z');
   });
 
   it('returns 400 when payload validation fails', async () => {
@@ -160,5 +180,34 @@ describe('create-source handler', () => {
     expect(JSON.parse(result.body)).toEqual({
       message: 'Failed to create source.',
     });
+  });
+
+  it('returns 400 when cron expression is invalid', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      body: JSON.stringify({
+        ...VALID_INTERVAL_SOURCE,
+        scheduleType: 'cron',
+        intervalMinutes: undefined,
+        cronExpr: 'invalid cron',
+      }),
+    });
+
+    expect(result.statusCode).toBe(400);
+    const parsedBody = JSON.parse(result.body) as {
+      message: string;
+      errors: Array<{ field: string; code: string }>;
+    };
+    expect(parsedBody.message).toBe('Source payload validation failed.');
+    expect(parsedBody.errors).toContainEqual(
+      expect.objectContaining({
+        field: 'cronExpr',
+        code: 'INVALID_FORMAT',
+      }),
+    );
   });
 });

--- a/tests/unit/handlers/update-source.test.ts
+++ b/tests/unit/handlers/update-source.test.ts
@@ -98,7 +98,6 @@ describe('update-source handler', () => {
       pathParameters: { id: EXISTING_SOURCE.sourceId },
       body: JSON.stringify({
         active: false,
-        nextRunAt: '2026-03-03T12:30:00.000Z',
       }),
       requestContext: { requestId: 'req-41' },
     });
@@ -119,9 +118,32 @@ describe('update-source handler', () => {
       sourceId: 'source-acme',
       engine: 'postgres',
       active: false,
-      nextRunAt: '2026-03-03T12:30:00.000Z',
+      nextRunAt: '2026-03-03T10:00:00.000Z',
       createdAt: '2026-03-03T09:00:00.000Z',
       updatedAt: '2026-03-03T12:00:00.000Z',
+    });
+  });
+
+  it('recalculates nextRunAt when interval schedule is updated', async () => {
+    const repository = new SpySourceRegistryRepository([EXISTING_SOURCE]);
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: EXISTING_SOURCE.sourceId },
+      body: JSON.stringify({
+        intervalMinutes: 45,
+      }),
+    });
+
+    expect(result.statusCode).toBe(200);
+    const stored = repository.getSnapshot(EXISTING_SOURCE.sourceId);
+    expect(stored).toMatchObject({
+      scheduleType: 'interval',
+      intervalMinutes: 45,
+      nextRunAt: '2026-03-03T12:45:00.000Z',
     });
   });
 
@@ -164,6 +186,28 @@ describe('update-source handler', () => {
     };
     expect(parsed.message).toBe('Source payload validation failed.');
     expect(parsed.errors.some((entry) => entry.field === 'sourceId')).toBe(true);
+  });
+
+  it('returns 400 when payload tries to update nextRunAt directly', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository([EXISTING_SOURCE]),
+      now: () => '2026-03-03T12:00:00.000Z',
+    });
+
+    const result = await handler({
+      pathParameters: { id: EXISTING_SOURCE.sourceId },
+      body: JSON.stringify({
+        nextRunAt: '2026-03-03T12:30:00.000Z',
+      }),
+    });
+
+    expect(result.statusCode).toBe(400);
+    const parsed = JSON.parse(result.body) as {
+      message: string;
+      errors: Array<{ field: string }>;
+    };
+    expect(parsed.message).toBe('Source payload validation failed.');
+    expect(parsed.errors.some((entry) => entry.field === 'nextRunAt')).toBe(true);
   });
 
   it('returns 409 when update detects version conflict', async () => {
@@ -227,6 +271,7 @@ describe('update-source handler', () => {
       sourceId: 'source-acme',
       scheduleType: 'cron',
       cronExpr: '0 */15 * * *',
+      nextRunAt: '2026-03-03T15:00:00.000Z',
     });
     expect(stored?.intervalMinutes).toBeUndefined();
   });


### PR DESCRIPTION
Closes #46

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Implementar cálculo automático de `nextRunAt` no cadastro (`POST /sources`) e na edição (`PATCH /sources/{id}`), com recálculo em mudanças de agenda e persistência em UTC.

---

## 🧠 Decisão Técnica

Centralizamos o cálculo em `src/domain/sources/next-run-at.ts`:

- `interval`: soma de `intervalMinutes` ao timestamp de referência.
- `cron`: próxima ocorrência em UTC usando `cron-parser`.

No `PATCH`, `nextRunAt` deixou de ser mutável diretamente e passa a ser recalculado quando houver mudança em `scheduleType`, `intervalMinutes` ou `cronExpr`.

---

## 🧪 BDD Validado

Dado que uma fonte é criada com `scheduleType=interval` ou `scheduleType=cron`
Quando o cadastro é processado
Então `nextRunAt` é calculado e salvo automaticamente em ISO-8601 UTC.

Dado que uma fonte existente recebe PATCH sem alteração de schedule
Quando a atualização é aplicada
Então `nextRunAt` é preservado.

Dado que uma fonte existente recebe PATCH com alteração de schedule
Quando a atualização é aplicada
Então `nextRunAt` é recalculado em UTC.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [ ] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [ ] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
