### PR TITLE
feat(scheduler): ler fontes ativas na lambda scheduler

### DIFF
--- a/.codex/runs/platform_architect-issue-47.md
+++ b/.codex/runs/platform_architect-issue-47.md
@@ -1,0 +1,34 @@
+## Issue #47 — [EPIC 4] Ler fontes ativas na Lambda Scheduler
+
+### Objetivo
+Implementar leitura paginada de fontes ativas no Scheduler usando DynamoDB com baixo custo e sem carregar a tabela inteira em memória.
+
+### Decisões arquiteturais
+1. **Separar contrato do Scheduler para leitura paginada**
+- Evoluir o contrato de `SourceRepository` do domínio de scheduler para expor `listActiveSources` paginado.
+- Manter o handler retornando `sourceIds` para não quebrar o contrato externo atual da Step Functions.
+
+2. **Consulta eficiente em DynamoDB com índice dedicado**
+- Usar `Query` no GSI `active-nextRunAt-index` com partição `active = "true"`.
+- Evitar `Scan` completo para reduzir latência e consumo de RCUs.
+- Paginar com `LastEvaluatedKey`/`ExclusiveStartKey` até esgotar resultados.
+
+3. **Normalização mínima para próxima etapa de elegibilidade**
+- Normalizar itens ativos para estrutura mínima interna:
+  - `sourceId`
+  - `nextRunAt`
+- Validar shape mínimo e falhar rápido em item inválido para evitar propagação de dados corrompidos.
+
+4. **Evolução incremental sem misturar escopo da #48**
+- Nesta issue, carregar apenas fontes ativas com paginação.
+- Não aplicar filtro `nextRunAt <= now` ainda (escopo da #48).
+
+5. **Testabilidade por injeção de dependências**
+- Expor `createHandler` no scheduler para testes unitários com repositório fake.
+- Cobrir cenários de múltiplas páginas e validação de configuração de paginação.
+
+### Critérios técnicos de aceite
+- Scheduler consulta fontes ativas via DynamoDB com paginação.
+- Não há `Scan` completo no fluxo do scheduler.
+- Saída interna é normalizada e utilizada para produzir `sourceIds`.
+- Testes unitários cobrem paginação e contrato do handler.

--- a/.codex/runs/qa-issue-47.md
+++ b/.codex/runs/qa-issue-47.md
@@ -1,0 +1,25 @@
+**QA — Issue #47 (Ler fontes ativas na Lambda Scheduler)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante.
+3. Médio: nenhum bloqueante.
+4. Baixo: nenhum.
+
+**Checklist de aceite da issue**
+
+- [x] Scheduler consulta fontes ativas (`active=true`) no DynamoDB.
+- [x] Leitura é paginada com `LastEvaluatedKey` (sem scan completo em memória).
+- [x] Saída interna é normalizada com campos mínimos (`sourceId`, `nextRunAt`).
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- --passWithNoTests` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ✅ (fallback esperado por ausência de credenciais AWS)
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-47.md
+++ b/.codex/runs/worker-issue-47.md
@@ -1,0 +1,34 @@
+**Status de execução — Issue #47**
+
+**Escopo implementado**
+
+- Scheduler deixou de usar repositório em memória no fluxo padrão e passou a consumir DynamoDB:
+  - novo repositório `src/infra/sources/dynamodb-scheduler-source-repository.ts`;
+  - consulta por `Query` no índice `active-nextRunAt-index` com `active = "true"`;
+  - paginação via `ExclusiveStartKey`/`LastEvaluatedKey`.
+- Domínio do scheduler evoluído para leitura paginada e normalização:
+  - `src/domain/scheduler/list-eligible-sources.ts` agora agrega páginas, valida formato mínimo (`sourceId`, `nextRunAt`) e deduplica por `sourceId`.
+- Handler do scheduler refatorado para DI e contrato estável de saída:
+  - `src/handlers/scheduler.ts` expõe `createHandler` para testes;
+  - fluxo padrão exige `SOURCES_TABLE_NAME` e mantém retorno `{ sourceIds, generatedAt, maxConcurrency }`.
+- Repositório em memória atualizado para o novo contrato paginado:
+  - `src/infra/sources/in-memory-source-repository.ts`.
+- Documentação técnica atualizada:
+  - `docs/step-functions/main-orchestration-v1.md` com nota de leitura paginada no scheduler.
+- Testes adicionados/atualizados:
+  - `tests/unit/domain/scheduler/list-eligible-sources.test.ts`
+  - `tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts`
+  - `tests/unit/handlers/scheduler.test.ts`
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- --passWithNoTests` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ✅ (fallback esperado por ausência de credenciais AWS)
+
+**Resultado**
+
+Implementação concluída no escopo da issue #47, pronta para PR.

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -31,6 +31,9 @@ Payload esperado na execução:
 
 - Entrada: `schedulerInput.now`.
 - Ação: invoca `SchedulerLambdaFunction`.
+- Implementação do scheduler:
+  - Consulta fontes ativas no DynamoDB usando o índice `active-nextRunAt-index`.
+  - Consome páginas de forma incremental (paginação por `LastEvaluatedKey`) para evitar carga total em memória.
 - Retry com backoff exponencial para falhas transitórias:
   - Erros Lambda transitórios (`ServiceException`, `AWSLambdaException`, `SdkClientException`, `TooManyRequestsException`):
     - `IntervalSeconds: 2`

--- a/src/domain/scheduler/list-eligible-sources.ts
+++ b/src/domain/scheduler/list-eligible-sources.ts
@@ -1,19 +1,89 @@
 /**
- * Domain use-case for loading source IDs that can run in the current tick.
+ * Domain use-case for loading active sources from the registry in a paginated way.
  * Infrastructure details are hidden behind the repository contract.
  */
+export interface SchedulerSource {
+  sourceId: string;
+  nextRunAt: string;
+}
+
+export interface ListActiveSourcesParams {
+  limit: number;
+  nextToken?: string;
+  now?: string;
+}
+
+export interface ListActiveSourcesResult {
+  items: SchedulerSource[];
+  nextToken: string | null;
+}
+
 export interface SourceRepository {
-  listEligibleSourceIds(params: { now?: string }): Promise<string[]>;
+  listActiveSources(params: ListActiveSourcesParams): Promise<ListActiveSourcesResult>;
 }
 
 export interface ListEligibleSourcesInput {
   sourceRepository: SourceRepository;
+  pageSize: number;
   now?: string;
 }
 
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const isIsoDateTime = (value: string): boolean =>
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value) &&
+  !Number.isNaN(Date.parse(value));
+
+const normalizeSchedulerSource = (source: SchedulerSource): SchedulerSource => {
+  if (!isNonEmptyString(source.sourceId)) {
+    throw new Error('Invalid scheduler source record: sourceId is required.');
+  }
+
+  if (!isNonEmptyString(source.nextRunAt) || !isIsoDateTime(source.nextRunAt.trim())) {
+    throw new Error(
+      'Invalid scheduler source record: nextRunAt must use ISO-8601 UTC format.',
+    );
+  }
+
+  return {
+    sourceId: source.sourceId.trim(),
+    nextRunAt: source.nextRunAt.trim(),
+  };
+};
+
 export async function listEligibleSources({
   sourceRepository,
+  pageSize,
   now,
-}: ListEligibleSourcesInput): Promise<string[]> {
-  return sourceRepository.listEligibleSourceIds({ now });
+}: ListEligibleSourcesInput): Promise<SchedulerSource[]> {
+  if (!Number.isInteger(pageSize) || pageSize < 1) {
+    throw new Error('pageSize must be an integer greater than zero.');
+  }
+
+  const collected: SchedulerSource[] = [];
+  const seen = new Set<string>();
+  let nextToken: string | undefined;
+
+  do {
+    const page = await sourceRepository.listActiveSources({
+      limit: pageSize,
+      nextToken,
+      now,
+    });
+
+    for (const item of page.items) {
+      const normalized = normalizeSchedulerSource(item);
+      if (seen.has(normalized.sourceId)) {
+        continue;
+      }
+
+      seen.add(normalized.sourceId);
+      collected.push(normalized);
+    }
+
+    nextToken = page.nextToken ?? undefined;
+  } while (nextToken);
+
+  return collected;
 }

--- a/src/handlers/scheduler.ts
+++ b/src/handlers/scheduler.ts
@@ -1,10 +1,14 @@
+import type { SourceRepository } from '../domain/scheduler/list-eligible-sources';
 import { listEligibleSources } from '../domain/scheduler/list-eligible-sources';
-import { createInMemorySourceRepository } from '../infra/sources/in-memory-source-repository';
+import { createDynamoDbSchedulerSourceRepository } from '../infra/sources/dynamodb-scheduler-source-repository';
 import { nowIso } from '../shared/time/now-iso';
 
 const MAP_MAX_CONCURRENCY_DEFAULT = 5;
 const MAP_MAX_CONCURRENCY_MIN = 1;
 const MAP_MAX_CONCURRENCY_MAX = 40;
+const ACTIVE_SOURCES_PAGE_SIZE_DEFAULT = 100;
+const ACTIVE_SOURCES_PAGE_SIZE_MIN = 1;
+const ACTIVE_SOURCES_PAGE_SIZE_MAX = 200;
 
 export interface SchedulerEvent {
   now?: string;
@@ -15,6 +19,14 @@ export interface SchedulerResult {
   generatedAt: string;
   maxConcurrency: number;
 }
+
+export interface SchedulerDependencies {
+  sourceRepository: SourceRepository;
+  now: () => string;
+  activeSourcesPageSize: number;
+}
+
+let cachedDefaultDependencies: SchedulerDependencies | undefined;
 
 const resolveMapMaxConcurrency = (rawValue: string | undefined): number => {
   if (!rawValue) {
@@ -34,17 +46,67 @@ const resolveMapMaxConcurrency = (rawValue: string | undefined): number => {
   return parsed;
 };
 
-export async function handler(event: SchedulerEvent = {}): Promise<SchedulerResult> {
-  const sourceRepository = createInMemorySourceRepository();
-  const sourceIds = await listEligibleSources({
-    sourceRepository,
-    now: event.now,
-  });
-  const maxConcurrency = resolveMapMaxConcurrency(process.env.MAP_MAX_CONCURRENCY);
+const resolveActiveSourcesPageSize = (rawValue: string | undefined): number => {
+  if (!rawValue) {
+    return ACTIVE_SOURCES_PAGE_SIZE_DEFAULT;
+  }
 
-  return {
-    sourceIds,
-    generatedAt: nowIso(),
-    maxConcurrency,
+  const parsed = Number.parseInt(rawValue, 10);
+  const isValidInteger = Number.isInteger(parsed);
+  const isInRange = parsed >= ACTIVE_SOURCES_PAGE_SIZE_MIN && parsed <= ACTIVE_SOURCES_PAGE_SIZE_MAX;
+
+  if (!isValidInteger || !isInRange) {
+    throw new Error(
+      `Invalid SCHEDULER_ACTIVE_SOURCES_PAGE_SIZE="${rawValue}". Expected integer between ${ACTIVE_SOURCES_PAGE_SIZE_MIN} and ${ACTIVE_SOURCES_PAGE_SIZE_MAX}.`,
+    );
+  }
+
+  return parsed;
+};
+
+const getDefaultDependencies = (): SchedulerDependencies => {
+  if (cachedDefaultDependencies) {
+    return cachedDefaultDependencies;
+  }
+
+  const tableName = process.env.SOURCES_TABLE_NAME;
+  if (!tableName || tableName.trim().length === 0) {
+    throw new Error('SOURCES_TABLE_NAME is required.');
+  }
+
+  cachedDefaultDependencies = {
+    sourceRepository: createDynamoDbSchedulerSourceRepository({
+      tableName,
+      activeIndexName: process.env.SOURCES_ACTIVE_NEXT_RUN_AT_INDEX_NAME,
+    }),
+    now: nowIso,
+    activeSourcesPageSize: resolveActiveSourcesPageSize(
+      process.env.SCHEDULER_ACTIVE_SOURCES_PAGE_SIZE,
+    ),
   };
+
+  return cachedDefaultDependencies;
+};
+
+export const createHandler =
+  ({ sourceRepository, now, activeSourcesPageSize }: SchedulerDependencies) =>
+  async (event: SchedulerEvent = {}): Promise<SchedulerResult> => {
+    const sources = await listEligibleSources({
+      sourceRepository,
+      now: event.now,
+      pageSize: activeSourcesPageSize,
+    });
+
+    const sourceIds = sources.map((source) => source.sourceId);
+    const maxConcurrency = resolveMapMaxConcurrency(process.env.MAP_MAX_CONCURRENCY);
+
+    return {
+      sourceIds,
+      generatedAt: now(),
+      maxConcurrency,
+    };
+  };
+
+export async function handler(event: SchedulerEvent = {}): Promise<SchedulerResult> {
+  return createHandler(getDefaultDependencies())(event);
 }

--- a/src/infra/sources/dynamodb-scheduler-source-repository.ts
+++ b/src/infra/sources/dynamodb-scheduler-source-repository.ts
@@ -1,0 +1,116 @@
+import { type AttributeValue, DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+
+import type {
+  ListActiveSourcesParams,
+  ListActiveSourcesResult,
+  SchedulerSource,
+  SourceRepository,
+} from '../../domain/scheduler/list-eligible-sources';
+
+const ACTIVE_INDEX_DEFAULT = 'active-nextRunAt-index';
+
+interface SchedulerPaginationTokenPayload {
+  lastEvaluatedKey: Record<string, unknown>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const encodeToken = (lastEvaluatedKey?: Record<string, AttributeValue>): string | null => {
+  if (!lastEvaluatedKey) {
+    return null;
+  }
+
+  const payload: SchedulerPaginationTokenPayload = {
+    lastEvaluatedKey: unmarshall(lastEvaluatedKey) as Record<string, unknown>,
+  };
+
+  return Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
+};
+
+const decodeToken = (token: string): Record<string, AttributeValue> => {
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf-8')) as unknown;
+    if (!isRecord(parsed) || !isRecord(parsed.lastEvaluatedKey)) {
+      throw new Error('Invalid token format');
+    }
+
+    return marshall(parsed.lastEvaluatedKey, { removeUndefinedValues: true });
+  } catch {
+    throw new Error('Invalid scheduler pagination token.');
+  }
+};
+
+const toSchedulerSource = (item: Record<string, AttributeValue>): SchedulerSource => {
+  const raw = unmarshall(item) as Record<string, unknown>;
+
+  const sourceId = raw.sourceId;
+  if (typeof sourceId !== 'string' || sourceId.trim().length === 0) {
+    throw new Error('Invalid scheduler source item: sourceId is required.');
+  }
+
+  const nextRunAt = raw.nextRunAt;
+  if (typeof nextRunAt !== 'string' || nextRunAt.trim().length === 0) {
+    throw new Error('Invalid scheduler source item: nextRunAt is required.');
+  }
+
+  return {
+    sourceId: sourceId.trim(),
+    nextRunAt: nextRunAt.trim(),
+  };
+};
+
+export interface DynamoDbSchedulerSourceRepositoryParams {
+  tableName: string;
+  activeIndexName?: string;
+  client?: DynamoDBClient;
+}
+
+export function createDynamoDbSchedulerSourceRepository({
+  tableName,
+  activeIndexName = ACTIVE_INDEX_DEFAULT,
+  client = new DynamoDBClient({}),
+}: DynamoDbSchedulerSourceRepositoryParams): SourceRepository {
+  const resolvedTableName = tableName.trim();
+  if (resolvedTableName.length === 0) {
+    throw new Error('tableName is required for scheduler source repository.');
+  }
+
+  const resolvedActiveIndexName = activeIndexName.trim();
+  if (resolvedActiveIndexName.length === 0) {
+    throw new Error('activeIndexName is required for scheduler source repository.');
+  }
+
+  return {
+    async listActiveSources({
+      limit,
+      nextToken,
+    }: ListActiveSourcesParams): Promise<ListActiveSourcesResult> {
+      const command = new QueryCommand({
+        TableName: resolvedTableName,
+        IndexName: resolvedActiveIndexName,
+        KeyConditionExpression: '#active = :active',
+        ExpressionAttributeNames: {
+          '#active': 'active',
+        },
+        ExpressionAttributeValues: {
+          ':active': {
+            S: 'true',
+          },
+        },
+        ProjectionExpression: 'sourceId, nextRunAt',
+        ExclusiveStartKey: nextToken ? decodeToken(nextToken) : undefined,
+        Limit: limit,
+        ScanIndexForward: true,
+      });
+
+      const result = await client.send(command);
+
+      return {
+        items: (result.Items ?? []).map((item) => toSchedulerSource(item)),
+        nextToken: encodeToken(result.LastEvaluatedKey),
+      };
+    },
+  };
+}

--- a/src/infra/sources/in-memory-source-repository.ts
+++ b/src/infra/sources/in-memory-source-repository.ts
@@ -1,13 +1,74 @@
-import type { SourceRepository } from '../../domain/scheduler/list-eligible-sources';
+import type {
+  ListActiveSourcesResult,
+  SourceRepository,
+} from '../../domain/scheduler/list-eligible-sources';
 
 export interface InMemorySource {
   sourceId: string;
+  nextRunAt: string;
+  active?: boolean;
 }
 
-export function createInMemorySourceRepository(seed: InMemorySource[] = []): SourceRepository {
+interface InMemoryPaginationToken {
+  offset: number;
+}
+
+const encodeToken = (offset: number): string =>
+  Buffer.from(JSON.stringify({ offset } satisfies InMemoryPaginationToken), 'utf-8').toString(
+    'base64url',
+  );
+
+const decodeToken = (token: string): InMemoryPaginationToken => {
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf-8')) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('Invalid token');
+    }
+
+    const record = parsed as Record<string, unknown>;
+    if (!Number.isInteger(record.offset) || (record.offset as number) < 0) {
+      throw new Error('Invalid offset');
+    }
+
+    return {
+      offset: record.offset as number,
+    };
+  } catch {
+    throw new Error('Invalid in-memory source pagination token.');
+  }
+};
+
+const resolvePage = (
+  items: InMemorySource[],
+  limit: number,
+  nextToken?: string,
+): ListActiveSourcesResult => {
+  const offset = nextToken ? decodeToken(nextToken).offset : 0;
+  const pageItems = items.slice(offset, offset + limit);
+  const nextOffset = offset + pageItems.length;
+
   return {
-    listEligibleSourceIds(): Promise<string[]> {
-      return Promise.resolve(seed.map((source) => source.sourceId));
+    items: pageItems.map((item) => ({
+      sourceId: item.sourceId,
+      nextRunAt: item.nextRunAt,
+    })),
+    nextToken: nextOffset < items.length ? encodeToken(nextOffset) : null,
+  };
+};
+
+export function createInMemorySourceRepository(seed: InMemorySource[] = []): SourceRepository {
+  const activeItems = seed
+    .filter((item) => item.active !== false)
+    .map((item) => ({
+      sourceId: item.sourceId,
+      nextRunAt: item.nextRunAt,
+      active: true,
+    }))
+    .sort((left, right) => left.sourceId.localeCompare(right.sourceId));
+
+  return {
+    listActiveSources(params): Promise<ListActiveSourcesResult> {
+      return Promise.resolve(resolvePage(activeItems, params.limit, params.nextToken));
     },
   };
 }

--- a/tests/unit/domain/scheduler/list-eligible-sources.test.ts
+++ b/tests/unit/domain/scheduler/list-eligible-sources.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  listEligibleSources,
+  type ListActiveSourcesParams,
+  type ListActiveSourcesResult,
+  type SourceRepository,
+} from '../../../../src/domain/scheduler/list-eligible-sources';
+
+class SpySourceRepository implements SourceRepository {
+  public readonly calls: ListActiveSourcesParams[] = [];
+  private readonly pages: ListActiveSourcesResult[];
+
+  constructor(pages: ListActiveSourcesResult[]) {
+    this.pages = pages;
+  }
+
+  listActiveSources(params: ListActiveSourcesParams): Promise<ListActiveSourcesResult> {
+    this.calls.push(params);
+    return Promise.resolve(this.pages[this.calls.length - 1] ?? { items: [], nextToken: null });
+  }
+}
+
+describe('listEligibleSources', () => {
+  it('loads all pages and forwards now reference', async () => {
+    const repository = new SpySourceRepository([
+      {
+        items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }],
+        nextToken: 'page-2',
+      },
+      {
+        items: [{ sourceId: 'source-b', nextRunAt: '2026-03-04T09:05:00.000Z' }],
+        nextToken: null,
+      },
+    ]);
+
+    const result = await listEligibleSources({
+      sourceRepository: repository,
+      pageSize: 1,
+      now: '2026-03-04T08:00:00.000Z',
+    });
+
+    expect(repository.calls).toEqual([
+      { limit: 1, nextToken: undefined, now: '2026-03-04T08:00:00.000Z' },
+      { limit: 1, nextToken: 'page-2', now: '2026-03-04T08:00:00.000Z' },
+    ]);
+    expect(result).toEqual([
+      { sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' },
+      { sourceId: 'source-b', nextRunAt: '2026-03-04T09:05:00.000Z' },
+    ]);
+  });
+
+  it('deduplicates repeated sourceIds across pages', async () => {
+    const repository = new SpySourceRepository([
+      {
+        items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }],
+        nextToken: 'page-2',
+      },
+      {
+        items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }],
+        nextToken: null,
+      },
+    ]);
+
+    const result = await listEligibleSources({
+      sourceRepository: repository,
+      pageSize: 1,
+    });
+
+    expect(result).toEqual([{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }]);
+  });
+
+  it('throws when repository returns invalid normalized source', async () => {
+    const repository = new SpySourceRepository([
+      {
+        items: [{ sourceId: '', nextRunAt: '2026-03-04T09:00:00.000Z' }],
+        nextToken: null,
+      },
+    ]);
+
+    await expect(
+      listEligibleSources({
+        sourceRepository: repository,
+        pageSize: 1,
+      }),
+    ).rejects.toThrow('Invalid scheduler source record: sourceId is required.');
+  });
+
+  it('throws for invalid page size', async () => {
+    const repository = new SpySourceRepository([{ items: [], nextToken: null }]);
+
+    await expect(
+      listEligibleSources({
+        sourceRepository: repository,
+        pageSize: 0,
+      }),
+    ).rejects.toThrow('pageSize must be an integer greater than zero.');
+  });
+});

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -1,8 +1,27 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 
-import { handler } from '../../../src/handlers/scheduler';
+import type {
+  ListActiveSourcesParams,
+  ListActiveSourcesResult,
+  SourceRepository,
+} from '../../../src/domain/scheduler/list-eligible-sources';
+import { createHandler } from '../../../src/handlers/scheduler';
 
 const ORIGINAL_MAP_MAX_CONCURRENCY = process.env.MAP_MAX_CONCURRENCY;
+
+class SpySourceRepository implements SourceRepository {
+  public readonly calls: ListActiveSourcesParams[] = [];
+  private readonly pages: ListActiveSourcesResult[];
+
+  constructor(pages: ListActiveSourcesResult[]) {
+    this.pages = pages;
+  }
+
+  listActiveSources(params: ListActiveSourcesParams): Promise<ListActiveSourcesResult> {
+    this.calls.push(params);
+    return Promise.resolve(this.pages[this.calls.length - 1] ?? { items: [], nextToken: null });
+  }
+}
 
 afterEach(() => {
   if (ORIGINAL_MAP_MAX_CONCURRENCY === undefined) {
@@ -14,18 +33,58 @@ afterEach(() => {
 });
 
 describe('scheduler handler', () => {
-  it('returns expected payload with default max concurrency', async () => {
+  it('returns expected payload with default max concurrency and paginated sources', async () => {
     delete process.env.MAP_MAX_CONCURRENCY;
-    const result = await handler();
+    const repository = new SpySourceRepository([
+      {
+        items: [
+          { sourceId: 'source-b', nextRunAt: '2026-03-04T09:00:00.000Z' },
+          { sourceId: 'source-a', nextRunAt: '2026-03-04T09:05:00.000Z' },
+        ],
+        nextToken: 'page-2',
+      },
+      {
+        items: [{ sourceId: 'source-c', nextRunAt: '2026-03-04T09:10:00.000Z' }],
+        nextToken: null,
+      },
+    ]);
 
-    expect(result.sourceIds).toEqual([]);
-    expect(typeof result.generatedAt).toBe('string');
-    expect(Number.isNaN(Date.parse(result.generatedAt))).toBe(false);
+    const handler = createHandler({
+      sourceRepository: repository,
+      now: () => '2026-03-04T10:00:00.000Z',
+      activeSourcesPageSize: 2,
+    });
+
+    const result = await handler({
+      now: '2026-03-04T08:00:00.000Z',
+    });
+
+    expect(repository.calls).toEqual([
+      {
+        limit: 2,
+        nextToken: undefined,
+        now: '2026-03-04T08:00:00.000Z',
+      },
+      {
+        limit: 2,
+        nextToken: 'page-2',
+        now: '2026-03-04T08:00:00.000Z',
+      },
+    ]);
+    expect(result.sourceIds).toEqual(['source-b', 'source-a', 'source-c']);
+    expect(result.generatedAt).toBe('2026-03-04T10:00:00.000Z');
     expect(result.maxConcurrency).toBe(5);
   });
 
   it('returns configured max concurrency from environment', async () => {
     process.env.MAP_MAX_CONCURRENCY = '12';
+
+    const repository = new SpySourceRepository([{ items: [], nextToken: null }]);
+    const handler = createHandler({
+      sourceRepository: repository,
+      now: () => '2026-03-04T10:00:00.000Z',
+      activeSourcesPageSize: 10,
+    });
 
     const result = await handler();
 
@@ -34,6 +93,13 @@ describe('scheduler handler', () => {
 
   it('throws on invalid MAP_MAX_CONCURRENCY', async () => {
     process.env.MAP_MAX_CONCURRENCY = '0';
+
+    const repository = new SpySourceRepository([{ items: [], nextToken: null }]);
+    const handler = createHandler({
+      sourceRepository: repository,
+      now: () => '2026-03-04T10:00:00.000Z',
+      activeSourcesPageSize: 10,
+    });
 
     await expect(handler()).rejects.toThrow(
       'Invalid MAP_MAX_CONCURRENCY="0". Expected integer between 1 and 40.',

--- a/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts
+++ b/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from '@jest/globals';
+import type { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+
+import { createDynamoDbSchedulerSourceRepository } from '../../../../src/infra/sources/dynamodb-scheduler-source-repository';
+
+class FakeDynamoClient {
+  public readonly commands: QueryCommand[] = [];
+  private readonly responses: Array<Record<string, unknown>>;
+
+  constructor(responses: Array<Record<string, unknown>>) {
+    this.responses = responses;
+  }
+
+  send(command: QueryCommand): Promise<Record<string, unknown>> {
+    this.commands.push(command);
+    return Promise.resolve(this.responses.shift() ?? {});
+  }
+}
+
+describe('createDynamoDbSchedulerSourceRepository', () => {
+  it('queries only active sources with configured index and returns normalized page', async () => {
+    const lastEvaluatedKey = marshall({
+      active: 'true',
+      nextRunAt: '2026-03-04T10:00:00.000Z',
+      sourceId: 'source-a',
+    });
+    const client = new FakeDynamoClient([
+      {
+        Items: [
+          marshall({
+            sourceId: 'source-a',
+            nextRunAt: '2026-03-04T10:00:00.000Z',
+          }),
+          marshall({
+            sourceId: 'source-b',
+            nextRunAt: '2026-03-04T11:00:00.000Z',
+          }),
+        ],
+        LastEvaluatedKey: lastEvaluatedKey,
+      },
+    ]);
+
+    const repository = createDynamoDbSchedulerSourceRepository({
+      tableName: 'sources-table',
+      client: client as unknown as DynamoDBClient,
+    });
+
+    const result = await repository.listActiveSources({ limit: 2 });
+    const command = client.commands[0];
+
+    expect(command.input.TableName).toBe('sources-table');
+    expect(command.input.IndexName).toBe('active-nextRunAt-index');
+    expect(command.input.KeyConditionExpression).toBe('#active = :active');
+    expect(command.input.ProjectionExpression).toBe('sourceId, nextRunAt');
+    expect(command.input.Limit).toBe(2);
+    expect(command.input.ScanIndexForward).toBe(true);
+    expect(result.items).toEqual([
+      { sourceId: 'source-a', nextRunAt: '2026-03-04T10:00:00.000Z' },
+      { sourceId: 'source-b', nextRunAt: '2026-03-04T11:00:00.000Z' },
+    ]);
+    expect(typeof result.nextToken).toBe('string');
+  });
+
+  it('decodes nextToken into ExclusiveStartKey', async () => {
+    const firstLastEvaluatedKey = marshall({
+      active: 'true',
+      nextRunAt: '2026-03-04T11:00:00.000Z',
+      sourceId: 'source-b',
+    });
+    const client = new FakeDynamoClient([
+      {
+        Items: [
+          marshall({
+            sourceId: 'source-a',
+            nextRunAt: '2026-03-04T10:00:00.000Z',
+          }),
+        ],
+        LastEvaluatedKey: firstLastEvaluatedKey,
+      },
+      {
+        Items: [
+          marshall({
+            sourceId: 'source-c',
+            nextRunAt: '2026-03-04T12:00:00.000Z',
+          }),
+        ],
+      },
+    ]);
+
+    const repository = createDynamoDbSchedulerSourceRepository({
+      tableName: 'sources-table',
+      client: client as unknown as DynamoDBClient,
+    });
+
+    const first = await repository.listActiveSources({ limit: 1 });
+    await repository.listActiveSources({
+      limit: 1,
+      nextToken: first.nextToken ?? undefined,
+    });
+
+    expect(client.commands).toHaveLength(2);
+    expect(client.commands[1].input.ExclusiveStartKey).toEqual(firstLastEvaluatedKey);
+  });
+
+  it('throws when nextToken is invalid', async () => {
+    const client = new FakeDynamoClient([]);
+    const repository = createDynamoDbSchedulerSourceRepository({
+      tableName: 'sources-table',
+      client: client as unknown as DynamoDBClient,
+    });
+
+    await expect(
+      repository.listActiveSources({
+        limit: 1,
+        nextToken: 'not-base64-token',
+      }),
+    ).rejects.toThrow('Invalid scheduler pagination token.');
+  });
+
+  it('throws when item does not contain required fields', async () => {
+    const client = new FakeDynamoClient([
+      {
+        Items: [
+          marshall({
+            sourceId: '',
+            nextRunAt: '2026-03-04T10:00:00.000Z',
+          }),
+        ],
+      },
+    ]);
+
+    const repository = createDynamoDbSchedulerSourceRepository({
+      tableName: 'sources-table',
+      client: client as unknown as DynamoDBClient,
+    });
+
+    await expect(repository.listActiveSources({ limit: 1 })).rejects.toThrow(
+      'Invalid scheduler source item: sourceId is required.',
+    );
+  });
+});


### PR DESCRIPTION
Closes #47

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Implementar leitura eficiente de fontes ativas no Scheduler via DynamoDB, com paginação, mantendo o contrato externo consumido pela Step Functions (`sourceIds`, `generatedAt`, `maxConcurrency`).

---

## 🧠 Decisão Técnica

- Evolução do domínio do Scheduler para leitura paginada (`listActiveSources`) com normalização mínima (`sourceId`, `nextRunAt`).
- Novo repositório DynamoDB dedicado ao Scheduler com `Query` no índice `active-nextRunAt-index` e paginação por `LastEvaluatedKey`.
- Refatoração do handler para DI (`createHandler`) visando testabilidade sem AWS real.
- Contrato externo preservado para não gerar regressão no `Map State` da orquestração.

---

## 🧪 BDD Validado

Dado que existam fontes ativas distribuídas em múltiplas páginas no DynamoDB
Quando o Scheduler for executado
Então ele deve percorrer todas as páginas, normalizar os itens e retornar todos os `sourceIds` elegíveis para etapas seguintes.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
