### PR TITLE
feat(scheduler): filtrar fontes por nextRunAt <= now

### DIFF
--- a/.codex/runs/platform_architect-issue-48.md
+++ b/.codex/runs/platform_architect-issue-48.md
@@ -1,0 +1,29 @@
+## Issue #48 — [EPIC 4] Filtrar fontes por nextRunAt <= now
+
+### Objetivo
+Garantir que o Scheduler retorne apenas fontes elegíveis para execução imediata (`nextRunAt <= now`) com comparação UTC e baixo custo em DynamoDB.
+
+### Decisões arquiteturais
+1. **Filtro de elegibilidade no domínio com referência UTC explícita**
+- Normalizar e validar `now` como ISO-8601 UTC.
+- Aplicar regra `nextRunAt <= now` durante a consolidação de páginas para proteção adicional de consistência.
+
+2. **Otimização da query DynamoDB para reduzir leitura de fontes futuras**
+- Quando `now` estiver disponível, usar `KeyConditionExpression` com sort key:
+  - `#active = :active AND #nextRunAt <= :nextRunAt`
+- Manter fallback para `#active = :active` quando `now` não for informado.
+
+3. **Determinismo temporal no handler**
+- Definir `generatedAt` uma única vez por execução.
+- Reutilizar `generatedAt` como referência de elegibilidade quando `event.now` não for enviado.
+
+4. **Observabilidade mínima do filtro**
+- Registrar log estruturado com:
+  - `referenceNow`
+  - `eligibleSources`
+
+### Critérios técnicos de aceite
+- Apenas fontes com `nextRunAt <= now` são retornadas pelo Scheduler.
+- Comparação de tempo ocorre em UTC (timestamps ISO-8601 com `Z`).
+- Query no DynamoDB aproveita sort key para elegibilidade quando `now` é fornecido.
+- Logs do Scheduler indicam quantidade de fontes elegíveis.

--- a/.codex/runs/qa-issue-48.md
+++ b/.codex/runs/qa-issue-48.md
@@ -1,0 +1,25 @@
+**QA — Issue #48 (Filtrar fontes por `nextRunAt <= now`)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante no escopo da issue.
+3. Médio: `lint/typecheck/build` seguem falhando no baseline por problema pré-existente em `src/domain/sources/next-run-at.ts` e ausência de `cron-parser`; não introduzido por esta mudança.
+4. Baixo: nenhum.
+
+**Checklist de aceite da issue**
+
+- [x] Somente fontes elegíveis (`nextRunAt <= now`) são retornadas.
+- [x] Comparação temporal considera UTC (ISO-8601 com `Z`).
+- [x] Logs indicam quantidade filtrada (`eligibleSources`).
+
+**Evidências de validação**
+
+- `npm run test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts --runInBand` ✅
+- `npm run validate:stage-render` ✅
+- `npm run lint` ❌ (baseline fora de escopo)
+- `npm run typecheck` ❌ (baseline fora de escopo)
+- `npm run build` ❌ (baseline fora de escopo)
+- `npm run validate:stage-package` ❌ (bloqueado por `build`)
+
+**Status final**: **APPROVED WITH KNOWN BASELINE GAPS**

--- a/.codex/runs/worker-issue-48.md
+++ b/.codex/runs/worker-issue-48.md
@@ -1,0 +1,36 @@
+**Status de execução — Issue #48**
+
+**Escopo implementado**
+
+- Filtro de elegibilidade por tempo UTC no domínio do Scheduler:
+  - [src/domain/scheduler/list-eligible-sources.ts](/home/icaro/projetos/cognx/alert-orchestration-service/src/domain/scheduler/list-eligible-sources.ts)
+  - validação de `now` em ISO-8601 UTC;
+  - regra `nextRunAt <= now` aplicada durante agregação paginada;
+  - `now` normalizado propagado para o repositório.
+- Determinismo temporal e log de contagem no handler:
+  - [src/handlers/scheduler.ts](/home/icaro/projetos/cognx/alert-orchestration-service/src/handlers/scheduler.ts)
+  - `generatedAt` calculado uma única vez;
+  - fallback para usar `generatedAt` como referência quando `event.now` não existe;
+  - log `scheduler.eligible_sources.filtered` com `referenceNow` e `eligibleSources`.
+- Otimização de query no DynamoDB:
+  - [src/infra/sources/dynamodb-scheduler-source-repository.ts](/home/icaro/projetos/cognx/alert-orchestration-service/src/infra/sources/dynamodb-scheduler-source-repository.ts)
+  - `KeyConditionExpression` com `#nextRunAt <= :nextRunAt` quando `now` é informado.
+
+**Testes atualizados**
+
+- [tests/unit/domain/scheduler/list-eligible-sources.test.ts](/home/icaro/projetos/cognx/alert-orchestration-service/tests/unit/domain/scheduler/list-eligible-sources.test.ts)
+- [tests/unit/handlers/scheduler.test.ts](/home/icaro/projetos/cognx/alert-orchestration-service/tests/unit/handlers/scheduler.test.ts)
+- [tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts](/home/icaro/projetos/cognx/alert-orchestration-service/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts)
+
+**Validações executadas**
+
+- `npm run test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts --runInBand` ✅
+- `npm run validate:stage-render` ✅
+- `npm run lint` ❌ (falha de baseline fora do escopo em `src/domain/sources/next-run-at.ts`)
+- `npm run typecheck` ❌ (`cron-parser` ausente no baseline)
+- `npm run build` ❌ (`cron-parser` ausente no baseline)
+- `npm run validate:stage-package` ❌ (depende de `build`, falha pelo mesmo motivo de baseline)
+
+**Resultado**
+
+Implementação da regra `nextRunAt <= now` concluída no escopo da issue #48, com cobertura unitária e validação de render da stack.

--- a/src/domain/scheduler/list-eligible-sources.ts
+++ b/src/domain/scheduler/list-eligible-sources.ts
@@ -35,6 +35,20 @@ const isIsoDateTime = (value: string): boolean =>
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value) &&
   !Number.isNaN(Date.parse(value));
 
+const resolveReferenceNow = (rawNow?: string): { iso: string; timestamp: number } => {
+  const normalizedNow = rawNow?.trim();
+  const now = normalizedNow && normalizedNow.length > 0 ? normalizedNow : new Date().toISOString();
+
+  if (!isIsoDateTime(now)) {
+    throw new Error('Invalid scheduler reference time: now must use ISO-8601 UTC format.');
+  }
+
+  return {
+    iso: now,
+    timestamp: Date.parse(now),
+  };
+};
+
 const normalizeSchedulerSource = (source: SchedulerSource): SchedulerSource => {
   if (!isNonEmptyString(source.sourceId)) {
     throw new Error('Invalid scheduler source record: sourceId is required.');
@@ -61,6 +75,7 @@ export async function listEligibleSources({
     throw new Error('pageSize must be an integer greater than zero.');
   }
 
+  const referenceNow = resolveReferenceNow(now);
   const collected: SchedulerSource[] = [];
   const seen = new Set<string>();
   let nextToken: string | undefined;
@@ -69,11 +84,17 @@ export async function listEligibleSources({
     const page = await sourceRepository.listActiveSources({
       limit: pageSize,
       nextToken,
-      now,
+      now: referenceNow.iso,
     });
 
     for (const item of page.items) {
       const normalized = normalizeSchedulerSource(item);
+      const nextRunAtTimestamp = Date.parse(normalized.nextRunAt);
+
+      if (nextRunAtTimestamp > referenceNow.timestamp) {
+        continue;
+      }
+
       if (seen.has(normalized.sourceId)) {
         continue;
       }

--- a/src/handlers/scheduler.ts
+++ b/src/handlers/scheduler.ts
@@ -91,18 +91,24 @@ const getDefaultDependencies = (): SchedulerDependencies => {
 export const createHandler =
   ({ sourceRepository, now, activeSourcesPageSize }: SchedulerDependencies) =>
   async (event: SchedulerEvent = {}): Promise<SchedulerResult> => {
+    const generatedAt = now();
+    const referenceNow = event.now ?? generatedAt;
     const sources = await listEligibleSources({
       sourceRepository,
-      now: event.now,
+      now: referenceNow,
       pageSize: activeSourcesPageSize,
     });
 
     const sourceIds = sources.map((source) => source.sourceId);
     const maxConcurrency = resolveMapMaxConcurrency(process.env.MAP_MAX_CONCURRENCY);
+    console.info('scheduler.eligible_sources.filtered', {
+      referenceNow,
+      eligibleSources: sourceIds.length,
+    });
 
     return {
       sourceIds,
-      generatedAt: now(),
+      generatedAt,
       maxConcurrency,
     };
   };

--- a/src/infra/sources/dynamodb-scheduler-source-repository.ts
+++ b/src/infra/sources/dynamodb-scheduler-source-repository.ts
@@ -86,19 +86,38 @@ export function createDynamoDbSchedulerSourceRepository({
     async listActiveSources({
       limit,
       nextToken,
+      now,
     }: ListActiveSourcesParams): Promise<ListActiveSourcesResult> {
+      const normalizedNow = now?.trim();
+      const hasReferenceNow = typeof normalizedNow === 'string' && normalizedNow.length > 0;
       const command = new QueryCommand({
         TableName: resolvedTableName,
         IndexName: resolvedActiveIndexName,
-        KeyConditionExpression: '#active = :active',
-        ExpressionAttributeNames: {
-          '#active': 'active',
-        },
-        ExpressionAttributeValues: {
-          ':active': {
-            S: 'true',
-          },
-        },
+        KeyConditionExpression: hasReferenceNow
+          ? '#active = :active AND #nextRunAt <= :nextRunAt'
+          : '#active = :active',
+        ExpressionAttributeNames: hasReferenceNow
+          ? {
+              '#active': 'active',
+              '#nextRunAt': 'nextRunAt',
+            }
+          : {
+              '#active': 'active',
+            },
+        ExpressionAttributeValues: hasReferenceNow
+          ? {
+              ':active': {
+                S: 'true',
+              },
+              ':nextRunAt': {
+                S: normalizedNow,
+              },
+            }
+          : {
+              ':active': {
+                S: 'true',
+              },
+            },
         ProjectionExpression: 'sourceId, nextRunAt',
         ExclusiveStartKey: nextToken ? decodeToken(nextToken) : undefined,
         Limit: limit,

--- a/tests/unit/domain/scheduler/list-eligible-sources.test.ts
+++ b/tests/unit/domain/scheduler/list-eligible-sources.test.ts
@@ -22,7 +22,7 @@ class SpySourceRepository implements SourceRepository {
 }
 
 describe('listEligibleSources', () => {
-  it('loads all pages and forwards now reference', async () => {
+  it('loads all pages, forwards now reference and keeps only nextRunAt <= now', async () => {
     const repository = new SpySourceRepository([
       {
         items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }],
@@ -37,27 +37,27 @@ describe('listEligibleSources', () => {
     const result = await listEligibleSources({
       sourceRepository: repository,
       pageSize: 1,
-      now: '2026-03-04T08:00:00.000Z',
+      now: '2026-03-04T09:01:00.000Z',
     });
 
     expect(repository.calls).toEqual([
-      { limit: 1, nextToken: undefined, now: '2026-03-04T08:00:00.000Z' },
-      { limit: 1, nextToken: 'page-2', now: '2026-03-04T08:00:00.000Z' },
+      { limit: 1, nextToken: undefined, now: '2026-03-04T09:01:00.000Z' },
+      { limit: 1, nextToken: 'page-2', now: '2026-03-04T09:01:00.000Z' },
     ]);
-    expect(result).toEqual([
-      { sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' },
-      { sourceId: 'source-b', nextRunAt: '2026-03-04T09:05:00.000Z' },
-    ]);
+    expect(result).toEqual([{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }]);
   });
 
-  it('deduplicates repeated sourceIds across pages', async () => {
+  it('deduplicates repeated sourceIds across pages after eligibility filtering', async () => {
     const repository = new SpySourceRepository([
       {
-        items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }],
+        items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T08:55:00.000Z' }],
         nextToken: 'page-2',
       },
       {
-        items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }],
+        items: [
+          { sourceId: 'source-a', nextRunAt: '2026-03-04T08:55:00.000Z' },
+          { sourceId: 'source-b', nextRunAt: '2026-03-04T09:10:00.000Z' },
+        ],
         nextToken: null,
       },
     ]);
@@ -65,9 +65,10 @@ describe('listEligibleSources', () => {
     const result = await listEligibleSources({
       sourceRepository: repository,
       pageSize: 1,
+      now: '2026-03-04T09:00:00.000Z',
     });
 
-    expect(result).toEqual([{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }]);
+    expect(result).toEqual([{ sourceId: 'source-a', nextRunAt: '2026-03-04T08:55:00.000Z' }]);
   });
 
   it('throws when repository returns invalid normalized source', async () => {
@@ -95,5 +96,17 @@ describe('listEligibleSources', () => {
         pageSize: 0,
       }),
     ).rejects.toThrow('pageSize must be an integer greater than zero.');
+  });
+
+  it('throws when now is not a valid UTC ISO-8601 timestamp', async () => {
+    const repository = new SpySourceRepository([{ items: [], nextToken: null }]);
+
+    await expect(
+      listEligibleSources({
+        sourceRepository: repository,
+        pageSize: 1,
+        now: '2026-03-04T09:00:00',
+      }),
+    ).rejects.toThrow('Invalid scheduler reference time: now must use ISO-8601 UTC format.');
   });
 });

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
 import type {
   ListActiveSourcesParams,
@@ -24,6 +24,8 @@ class SpySourceRepository implements SourceRepository {
 }
 
 afterEach(() => {
+  jest.restoreAllMocks();
+
   if (ORIGINAL_MAP_MAX_CONCURRENCY === undefined) {
     delete process.env.MAP_MAX_CONCURRENCY;
     return;
@@ -33,8 +35,9 @@ afterEach(() => {
 });
 
 describe('scheduler handler', () => {
-  it('returns expected payload with default max concurrency and paginated sources', async () => {
+  it('returns only eligible sourceIds and logs filtered count with default max concurrency', async () => {
     delete process.env.MAP_MAX_CONCURRENCY;
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
     const repository = new SpySourceRepository([
       {
         items: [
@@ -44,7 +47,7 @@ describe('scheduler handler', () => {
         nextToken: 'page-2',
       },
       {
-        items: [{ sourceId: 'source-c', nextRunAt: '2026-03-04T09:10:00.000Z' }],
+        items: [{ sourceId: 'source-c', nextRunAt: '2026-03-04T08:59:00.000Z' }],
         nextToken: null,
       },
     ]);
@@ -56,24 +59,28 @@ describe('scheduler handler', () => {
     });
 
     const result = await handler({
-      now: '2026-03-04T08:00:00.000Z',
+      now: '2026-03-04T09:01:00.000Z',
     });
 
     expect(repository.calls).toEqual([
       {
         limit: 2,
         nextToken: undefined,
-        now: '2026-03-04T08:00:00.000Z',
+        now: '2026-03-04T09:01:00.000Z',
       },
       {
         limit: 2,
         nextToken: 'page-2',
-        now: '2026-03-04T08:00:00.000Z',
+        now: '2026-03-04T09:01:00.000Z',
       },
     ]);
-    expect(result.sourceIds).toEqual(['source-b', 'source-a', 'source-c']);
+    expect(result.sourceIds).toEqual(['source-b', 'source-c']);
     expect(result.generatedAt).toBe('2026-03-04T10:00:00.000Z');
     expect(result.maxConcurrency).toBe(5);
+    expect(infoSpy).toHaveBeenCalledWith('scheduler.eligible_sources.filtered', {
+      referenceNow: '2026-03-04T09:01:00.000Z',
+      eligibleSources: 2,
+    });
   });
 
   it('returns configured max concurrency from environment', async () => {
@@ -89,6 +96,36 @@ describe('scheduler handler', () => {
     const result = await handler();
 
     expect(result.maxConcurrency).toBe(12);
+  });
+
+  it('uses generatedAt as reference now when event.now is omitted', async () => {
+    delete process.env.MAP_MAX_CONCURRENCY;
+    const repository = new SpySourceRepository([
+      {
+        items: [
+          { sourceId: 'source-a', nextRunAt: '2026-03-04T10:00:00.000Z' },
+          { sourceId: 'source-b', nextRunAt: '2026-03-04T10:01:00.000Z' },
+        ],
+        nextToken: null,
+      },
+    ]);
+    const handler = createHandler({
+      sourceRepository: repository,
+      now: () => '2026-03-04T10:00:00.000Z',
+      activeSourcesPageSize: 10,
+    });
+
+    const result = await handler();
+
+    expect(repository.calls).toEqual([
+      {
+        limit: 10,
+        nextToken: undefined,
+        now: '2026-03-04T10:00:00.000Z',
+      },
+    ]);
+    expect(result.generatedAt).toBe('2026-03-04T10:00:00.000Z');
+    expect(result.sourceIds).toEqual(['source-a']);
   });
 
   it('throws on invalid MAP_MAX_CONCURRENCY', async () => {

--- a/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts
+++ b/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts
@@ -19,7 +19,7 @@ class FakeDynamoClient {
 }
 
 describe('createDynamoDbSchedulerSourceRepository', () => {
-  it('queries only active sources with configured index and returns normalized page', async () => {
+  it('queries only active and eligible sources when now reference is provided', async () => {
     const lastEvaluatedKey = marshall({
       active: 'true',
       nextRunAt: '2026-03-04T10:00:00.000Z',
@@ -46,12 +46,25 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
       client: client as unknown as DynamoDBClient,
     });
 
-    const result = await repository.listActiveSources({ limit: 2 });
+    const result = await repository.listActiveSources({
+      limit: 2,
+      now: '2026-03-04T10:30:00.000Z',
+    });
     const command = client.commands[0];
 
     expect(command.input.TableName).toBe('sources-table');
     expect(command.input.IndexName).toBe('active-nextRunAt-index');
-    expect(command.input.KeyConditionExpression).toBe('#active = :active');
+    expect(command.input.KeyConditionExpression).toBe(
+      '#active = :active AND #nextRunAt <= :nextRunAt',
+    );
+    expect(command.input.ExpressionAttributeNames).toEqual({
+      '#active': 'active',
+      '#nextRunAt': 'nextRunAt',
+    });
+    expect(command.input.ExpressionAttributeValues).toEqual({
+      ':active': { S: 'true' },
+      ':nextRunAt': { S: '2026-03-04T10:30:00.000Z' },
+    });
     expect(command.input.ProjectionExpression).toBe('sourceId, nextRunAt');
     expect(command.input.Limit).toBe(2);
     expect(command.input.ScanIndexForward).toBe(true);
@@ -101,6 +114,24 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
 
     expect(client.commands).toHaveLength(2);
     expect(client.commands[1].input.ExclusiveStartKey).toEqual(firstLastEvaluatedKey);
+  });
+
+  it('keeps base key condition when now reference is not provided', async () => {
+    const client = new FakeDynamoClient([{ Items: [] }]);
+    const repository = createDynamoDbSchedulerSourceRepository({
+      tableName: 'sources-table',
+      client: client as unknown as DynamoDBClient,
+    });
+
+    await repository.listActiveSources({ limit: 1 });
+
+    expect(client.commands[0].input.KeyConditionExpression).toBe('#active = :active');
+    expect(client.commands[0].input.ExpressionAttributeNames).toEqual({
+      '#active': 'active',
+    });
+    expect(client.commands[0].input.ExpressionAttributeValues).toEqual({
+      ':active': { S: 'true' },
+    });
   });
 
   it('throws when nextToken is invalid', async () => {


### PR DESCRIPTION
Closes #48

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Aplicar filtro de elegibilidade no Scheduler para retornar apenas fontes com `nextRunAt <= now` (UTC), reduzindo execuções prematuras e mantendo o contrato com Step Functions.

---

## 🧠 Decisão Técnica

- O domínio (`listEligibleSources`) agora valida `now` em ISO-8601 UTC e aplica `nextRunAt <= now` durante a agregação paginada.
- O handler define `generatedAt` uma única vez e usa esse valor como fallback de referência temporal quando `event.now` não é informado.
- O repositório DynamoDB aproveita o GSI (`active-nextRunAt-index`) com `KeyConditionExpression` por `nextRunAt <= :nextRunAt` quando `now` é fornecido.
- Foi adicionado log com `referenceNow` e `eligibleSources` para rastrear a filtragem.

---

## 🧪 BDD Validado

Dado que existem fontes ativas com `nextRunAt` no passado e no futuro
Quando o Scheduler executa com um `now` de referência
Então apenas as fontes com `nextRunAt <= now` são retornadas para a Step Functions.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

Testes executados:
- `npm run test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts --runInBand`
- `npm run validate:stage-render`

Gaps de baseline (pré-existentes, fora do escopo desta issue):
- `npm run lint` falha em `src/domain/sources/next-run-at.ts`.
- `npm run typecheck`/`npm run build`/`npm run validate:stage-package` falham por ausência de `cron-parser`.

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
