### PR TITLE
feat(scheduler): atualizar nextRunAt com conditional update

### DIFF
--- a/.codex/runs/platform_architect-issue-49.md
+++ b/.codex/runs/platform_architect-issue-49.md
@@ -1,0 +1,28 @@
+## Issue #49 — [EPIC 4] Atualizar nextRunAt com conditional update
+
+### Objetivo
+Reservar a próxima execução de cada fonte elegível no Scheduler usando update condicional no DynamoDB para eliminar corrida entre execuções paralelas da orquestração.
+
+### Decisões arquiteturais
+1. **Reserva atômica por fonte no repositório de Scheduler**
+- Evoluir o contrato de `SourceRepository` para incluir `reserveNextRun`.
+- Implementar `UpdateItem` condicional no DynamoDB com condição em `active` e `nextRunAt` esperado.
+- Em conflito (`ConditionalCheckFailedException`), retornar status de não-reservado sem lançar erro bloqueante.
+
+2. **Recalcular `nextRunAt` no domínio com regra de schedule da própria fonte**
+- Expandir payload de leitura do Scheduler para incluir `scheduleType`, `intervalMinutes`/`cronExpr`.
+- Calcular próximo `nextRunAt` com `calculateNextRunAt`, usando `referenceNow` UTC da execução.
+
+3. **Resiliência a concorrência sem interromper lote**
+- Se a reserva falhar por conflito, a fonte é descartada da saída (`sourceIds`) e o lote continua.
+- Erros não-concorrentes (ex.: shape inválido) permanecem falhas reais.
+
+4. **Testabilidade da reserva atômica**
+- Cobrir domínio com cenário de conflito concorrente.
+- Cobrir infraestrutura DynamoDB com `UpdateItem` condicional e retorno `false` em conflito.
+
+### Critérios técnicos de aceite
+- `nextRunAt` é atualizado com `ConditionExpression` por fonte elegível.
+- Conflitos de concorrência não quebram a execução total do Scheduler.
+- Somente fontes efetivamente reservadas entram em `sourceIds`.
+- Regras `interval`/`cron` são respeitadas no cálculo do novo `nextRunAt`.

--- a/.codex/runs/qa-issue-49.md
+++ b/.codex/runs/qa-issue-49.md
@@ -1,0 +1,26 @@
+**QA — Issue #49 (Atualizar nextRunAt com conditional update)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante.
+3. Médio: nenhum bloqueante no escopo.
+4. Baixo: `validate:stage-package` executou fallback local por ausência de credenciais AWS no ambiente, sem impacto no escopo funcional da issue.
+
+**Checklist de aceite da issue**
+
+- [x] `nextRunAt` é atualizado com `ConditionExpression` no DynamoDB.
+- [x] Conflito concorrente não causa falha total da execução.
+- [x] Somente fontes reservadas entram no resultado (`sourceIds`).
+- [x] Recalculo de próximo `nextRunAt` respeita regra de schedule (`interval`/`cron`).
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm run test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts --runInBand` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ✅ (fallback esperado)
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-49.md
+++ b/.codex/runs/worker-issue-49.md
@@ -1,0 +1,35 @@
+**Status de execução — Issue #49**
+
+**Escopo implementado**
+
+- Reserva atômica de execução no domínio do Scheduler:
+  - `src/domain/scheduler/list-eligible-sources.ts`
+  - contrato de `SourceRepository` evoluído com `reserveNextRun`;
+  - validação de schedule por fonte (`interval`/`cron`);
+  - recálculo do próximo `nextRunAt` via `calculateNextRunAt` usando `referenceNow` UTC;
+  - conflito de concorrência não interrompe o lote (fonte conflitada é descartada da saída).
+- Implementação de conditional update no DynamoDB:
+  - `src/infra/sources/dynamodb-scheduler-source-repository.ts`
+  - leitura de fontes passou a projetar `scheduleType`, `intervalMinutes`, `cronExpr`;
+  - `reserveNextRun` usa `UpdateItem` com `ConditionExpression` (`active = true` e `nextRunAt` esperado);
+  - conflito (`ConditionalCheckFailedException`) retorna `false` sem erro fatal.
+- Repositório in-memory atualizado para novo contrato:
+  - `src/infra/sources/in-memory-source-repository.ts`
+  - suporte a schedule discriminado e reserva condicional em memória.
+- Testes atualizados/adicionados:
+  - `tests/unit/domain/scheduler/list-eligible-sources.test.ts`
+  - `tests/unit/handlers/scheduler.test.ts`
+  - `tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts`
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm run test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts --runInBand` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ✅ (fallback esperado por ausência de credenciais AWS)
+
+**Resultado**
+
+Implementação concluída no escopo da issue #49, pronta para PR.

--- a/src/domain/scheduler/list-eligible-sources.ts
+++ b/src/domain/scheduler/list-eligible-sources.ts
@@ -1,11 +1,27 @@
+import { calculateNextRunAt, type NextRunSchedule } from '../sources/next-run-at';
+
 /**
  * Domain use-case for loading active sources from the registry in a paginated way.
  * Infrastructure details are hidden behind the repository contract.
  */
-export interface SchedulerSource {
+interface SchedulerSourceBase {
   sourceId: string;
   nextRunAt: string;
 }
+
+interface SchedulerSourceInterval extends SchedulerSourceBase {
+  scheduleType: 'interval';
+  intervalMinutes: number;
+  cronExpr?: undefined;
+}
+
+interface SchedulerSourceCron extends SchedulerSourceBase {
+  scheduleType: 'cron';
+  intervalMinutes?: undefined;
+  cronExpr: string;
+}
+
+export type SchedulerSource = SchedulerSourceInterval | SchedulerSourceCron;
 
 export interface ListActiveSourcesParams {
   limit: number;
@@ -18,8 +34,16 @@ export interface ListActiveSourcesResult {
   nextToken: string | null;
 }
 
+export interface ReserveNextRunParams {
+  sourceId: string;
+  expectedNextRunAt: string;
+  nextRunAt: string;
+  reservedAt: string;
+}
+
 export interface SourceRepository {
   listActiveSources(params: ListActiveSourcesParams): Promise<ListActiveSourcesResult>;
+  reserveNextRun(params: ReserveNextRunParams): Promise<boolean>;
 }
 
 export interface ListEligibleSourcesInput {
@@ -30,6 +54,9 @@ export interface ListEligibleSourcesInput {
 
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0;
+
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value > 0;
 
 const isIsoDateTime = (value: string): boolean =>
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value) &&
@@ -60,9 +87,53 @@ const normalizeSchedulerSource = (source: SchedulerSource): SchedulerSource => {
     );
   }
 
+  const sourceId = source.sourceId.trim();
+  const nextRunAt = source.nextRunAt.trim();
+
+  if (source.scheduleType === 'interval') {
+    if (!isPositiveInteger(source.intervalMinutes)) {
+      throw new Error(
+        'Invalid scheduler source record: intervalMinutes must be a positive integer.',
+      );
+    }
+
+    return {
+      sourceId,
+      nextRunAt,
+      scheduleType: 'interval',
+      intervalMinutes: source.intervalMinutes,
+    };
+  }
+
+  if (source.scheduleType === 'cron') {
+    if (!isNonEmptyString(source.cronExpr)) {
+      throw new Error(
+        'Invalid scheduler source record: cronExpr is required when scheduleType=cron.',
+      );
+    }
+
+    return {
+      sourceId,
+      nextRunAt,
+      scheduleType: 'cron',
+      cronExpr: source.cronExpr.trim(),
+    };
+  }
+
+  throw new Error('Invalid scheduler source record: scheduleType must be "interval" or "cron".');
+};
+
+const toNextRunSchedule = (source: SchedulerSource): NextRunSchedule => {
+  if (source.scheduleType === 'interval') {
+    return {
+      scheduleType: 'interval',
+      intervalMinutes: source.intervalMinutes,
+    };
+  }
+
   return {
-    sourceId: source.sourceId.trim(),
-    nextRunAt: source.nextRunAt.trim(),
+    scheduleType: 'cron',
+    cronExpr: source.cronExpr,
   };
 };
 
@@ -100,6 +171,23 @@ export async function listEligibleSources({
       }
 
       seen.add(normalized.sourceId);
+      const calculatedNextRunAt = calculateNextRunAt(toNextRunSchedule(normalized), referenceNow.iso);
+      if (!calculatedNextRunAt.success) {
+        throw new Error(
+          `Invalid scheduler source record: unable to calculate nextRunAt for source "${normalized.sourceId}".`,
+        );
+      }
+
+      const reserved = await sourceRepository.reserveNextRun({
+        sourceId: normalized.sourceId,
+        expectedNextRunAt: normalized.nextRunAt,
+        nextRunAt: calculatedNextRunAt.value,
+        reservedAt: referenceNow.iso,
+      });
+      if (!reserved) {
+        continue;
+      }
+
       collected.push(normalized);
     }
 

--- a/src/infra/sources/dynamodb-scheduler-source-repository.ts
+++ b/src/infra/sources/dynamodb-scheduler-source-repository.ts
@@ -1,4 +1,10 @@
-import { type AttributeValue, DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import {
+  type AttributeValue,
+  ConditionalCheckFailedException,
+  DynamoDBClient,
+  QueryCommand,
+  UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 
 import type {
@@ -16,6 +22,18 @@ interface SchedulerPaginationTokenPayload {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isConditionalCheckFailed = (error: unknown): boolean => {
+  if (error instanceof ConditionalCheckFailedException) {
+    return true;
+  }
+
+  if (typeof error === 'object' && error !== null && 'name' in error) {
+    return error.name === 'ConditionalCheckFailedException';
+  }
+
+  return false;
+};
 
 const encodeToken = (lastEvaluatedKey?: Record<string, AttributeValue>): string | null => {
   if (!lastEvaluatedKey) {
@@ -55,10 +73,42 @@ const toSchedulerSource = (item: Record<string, AttributeValue>): SchedulerSourc
     throw new Error('Invalid scheduler source item: nextRunAt is required.');
   }
 
-  return {
-    sourceId: sourceId.trim(),
-    nextRunAt: nextRunAt.trim(),
-  };
+  const scheduleType = raw.scheduleType;
+  if (scheduleType === 'interval') {
+    const intervalMinutes = raw.intervalMinutes;
+    if (
+      typeof intervalMinutes !== 'number' ||
+      !Number.isInteger(intervalMinutes) ||
+      intervalMinutes <= 0
+    ) {
+      throw new Error(
+        'Invalid scheduler source item: intervalMinutes must be a positive integer.',
+      );
+    }
+
+    return {
+      sourceId: sourceId.trim(),
+      nextRunAt: nextRunAt.trim(),
+      scheduleType: 'interval',
+      intervalMinutes,
+    };
+  }
+
+  if (scheduleType === 'cron') {
+    const cronExpr = raw.cronExpr;
+    if (typeof cronExpr !== 'string' || cronExpr.trim().length === 0) {
+      throw new Error('Invalid scheduler source item: cronExpr is required.');
+    }
+
+    return {
+      sourceId: sourceId.trim(),
+      nextRunAt: nextRunAt.trim(),
+      scheduleType: 'cron',
+      cronExpr: cronExpr.trim(),
+    };
+  }
+
+  throw new Error('Invalid scheduler source item: scheduleType must be "interval" or "cron".');
 };
 
 export interface DynamoDbSchedulerSourceRepositoryParams {
@@ -118,7 +168,7 @@ export function createDynamoDbSchedulerSourceRepository({
                 S: 'true',
               },
             },
-        ProjectionExpression: 'sourceId, nextRunAt',
+        ProjectionExpression: 'sourceId, nextRunAt, scheduleType, intervalMinutes, cronExpr',
         ExclusiveStartKey: nextToken ? decodeToken(nextToken) : undefined,
         Limit: limit,
         ScanIndexForward: true,
@@ -130,6 +180,40 @@ export function createDynamoDbSchedulerSourceRepository({
         items: (result.Items ?? []).map((item) => toSchedulerSource(item)),
         nextToken: encodeToken(result.LastEvaluatedKey),
       };
+    },
+    async reserveNextRun({ sourceId, expectedNextRunAt, nextRunAt, reservedAt }): Promise<boolean> {
+      const command = new UpdateItemCommand({
+        TableName: resolvedTableName,
+        Key: marshall({ sourceId }),
+        UpdateExpression: 'SET nextRunAt = :nextRunAt, updatedAt = :updatedAt',
+        ConditionExpression:
+          'attribute_exists(sourceId) AND active = :active AND nextRunAt = :expectedNextRunAt',
+        ExpressionAttributeValues: {
+          ':active': {
+            S: 'true',
+          },
+          ':expectedNextRunAt': {
+            S: expectedNextRunAt,
+          },
+          ':nextRunAt': {
+            S: nextRunAt,
+          },
+          ':updatedAt': {
+            S: reservedAt,
+          },
+        },
+      });
+
+      try {
+        await client.send(command);
+        return true;
+      } catch (error) {
+        if (isConditionalCheckFailed(error)) {
+          return false;
+        }
+
+        throw error;
+      }
     },
   };
 }

--- a/src/infra/sources/in-memory-source-repository.ts
+++ b/src/infra/sources/in-memory-source-repository.ts
@@ -1,13 +1,28 @@
 import type {
   ListActiveSourcesResult,
+  SchedulerSource,
   SourceRepository,
 } from '../../domain/scheduler/list-eligible-sources';
 
-export interface InMemorySource {
+interface InMemorySourceBase {
   sourceId: string;
   nextRunAt: string;
   active?: boolean;
 }
+
+interface InMemorySourceInterval extends InMemorySourceBase {
+  scheduleType: 'interval';
+  intervalMinutes: number;
+  cronExpr?: undefined;
+}
+
+interface InMemorySourceCron extends InMemorySourceBase {
+  scheduleType: 'cron';
+  intervalMinutes?: undefined;
+  cronExpr: string;
+}
+
+export type InMemorySource = InMemorySourceInterval | InMemorySourceCron;
 
 interface InMemoryPaginationToken {
   offset: number;
@@ -47,11 +62,26 @@ const resolvePage = (
   const pageItems = items.slice(offset, offset + limit);
   const nextOffset = offset + pageItems.length;
 
-  return {
-    items: pageItems.map((item) => ({
+  const toSchedulerSource = (item: InMemorySource): SchedulerSource => {
+    if (item.scheduleType === 'interval') {
+      return {
+        sourceId: item.sourceId,
+        nextRunAt: item.nextRunAt,
+        scheduleType: 'interval',
+        intervalMinutes: item.intervalMinutes,
+      };
+    }
+
+    return {
       sourceId: item.sourceId,
       nextRunAt: item.nextRunAt,
-    })),
+      scheduleType: 'cron',
+      cronExpr: item.cronExpr,
+    };
+  };
+
+  return {
+    items: pageItems.map((item) => toSchedulerSource(item)),
     nextToken: nextOffset < items.length ? encodeToken(nextOffset) : null,
   };
 };
@@ -59,16 +89,41 @@ const resolvePage = (
 export function createInMemorySourceRepository(seed: InMemorySource[] = []): SourceRepository {
   const activeItems = seed
     .filter((item) => item.active !== false)
-    .map((item) => ({
-      sourceId: item.sourceId,
-      nextRunAt: item.nextRunAt,
-      active: true,
-    }))
+    .map((item) =>
+      item.scheduleType === 'interval'
+        ? {
+            sourceId: item.sourceId,
+            nextRunAt: item.nextRunAt,
+            active: true,
+            scheduleType: 'interval' as const,
+            intervalMinutes: item.intervalMinutes,
+          }
+        : {
+            sourceId: item.sourceId,
+            nextRunAt: item.nextRunAt,
+            active: true,
+            scheduleType: 'cron' as const,
+            cronExpr: item.cronExpr,
+          },
+    )
     .sort((left, right) => left.sourceId.localeCompare(right.sourceId));
 
   return {
     listActiveSources(params): Promise<ListActiveSourcesResult> {
       return Promise.resolve(resolvePage(activeItems, params.limit, params.nextToken));
+    },
+    reserveNextRun(params): Promise<boolean> {
+      const source = activeItems.find((item) => item.sourceId === params.sourceId);
+      if (!source) {
+        return Promise.resolve(false);
+      }
+
+      if (source.nextRunAt !== params.expectedNextRunAt) {
+        return Promise.resolve(false);
+      }
+
+      source.nextRunAt = params.nextRunAt;
+      return Promise.resolve(true);
     },
   };
 }

--- a/tests/unit/domain/scheduler/list-eligible-sources.test.ts
+++ b/tests/unit/domain/scheduler/list-eligible-sources.test.ts
@@ -4,32 +4,56 @@ import {
   listEligibleSources,
   type ListActiveSourcesParams,
   type ListActiveSourcesResult,
+  type ReserveNextRunParams,
   type SourceRepository,
 } from '../../../../src/domain/scheduler/list-eligible-sources';
 
 class SpySourceRepository implements SourceRepository {
   public readonly calls: ListActiveSourcesParams[] = [];
+  public readonly reserveCalls: ReserveNextRunParams[] = [];
   private readonly pages: ListActiveSourcesResult[];
+  private readonly reserveResults: boolean[];
 
-  constructor(pages: ListActiveSourcesResult[]) {
+  constructor(pages: ListActiveSourcesResult[], reserveResults: boolean[] = []) {
     this.pages = pages;
+    this.reserveResults = reserveResults;
   }
 
   listActiveSources(params: ListActiveSourcesParams): Promise<ListActiveSourcesResult> {
     this.calls.push(params);
     return Promise.resolve(this.pages[this.calls.length - 1] ?? { items: [], nextToken: null });
   }
+
+  reserveNextRun(params: ReserveNextRunParams): Promise<boolean> {
+    this.reserveCalls.push(params);
+    const result = this.reserveResults[this.reserveCalls.length - 1];
+    return Promise.resolve(result ?? true);
+  }
 }
 
 describe('listEligibleSources', () => {
-  it('loads all pages, forwards now reference and keeps only nextRunAt <= now', async () => {
+  it('loads all pages, forwards now reference and reserves only nextRunAt <= now', async () => {
     const repository = new SpySourceRepository([
       {
-        items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }],
+        items: [
+          {
+            sourceId: 'source-a',
+            nextRunAt: '2026-03-04T09:00:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
+        ],
         nextToken: 'page-2',
       },
       {
-        items: [{ sourceId: 'source-b', nextRunAt: '2026-03-04T09:05:00.000Z' }],
+        items: [
+          {
+            sourceId: 'source-b',
+            nextRunAt: '2026-03-04T09:05:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
+        ],
         nextToken: null,
       },
     ]);
@@ -44,19 +68,51 @@ describe('listEligibleSources', () => {
       { limit: 1, nextToken: undefined, now: '2026-03-04T09:01:00.000Z' },
       { limit: 1, nextToken: 'page-2', now: '2026-03-04T09:01:00.000Z' },
     ]);
-    expect(result).toEqual([{ sourceId: 'source-a', nextRunAt: '2026-03-04T09:00:00.000Z' }]);
+    expect(repository.reserveCalls).toEqual([
+      {
+        sourceId: 'source-a',
+        expectedNextRunAt: '2026-03-04T09:00:00.000Z',
+        nextRunAt: '2026-03-04T09:06:00.000Z',
+        reservedAt: '2026-03-04T09:01:00.000Z',
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        sourceId: 'source-a',
+        nextRunAt: '2026-03-04T09:00:00.000Z',
+        scheduleType: 'interval',
+        intervalMinutes: 5,
+      },
+    ]);
   });
 
-  it('deduplicates repeated sourceIds across pages after eligibility filtering', async () => {
+  it('deduplicates repeated sourceIds across pages before reservation', async () => {
     const repository = new SpySourceRepository([
       {
-        items: [{ sourceId: 'source-a', nextRunAt: '2026-03-04T08:55:00.000Z' }],
+        items: [
+          {
+            sourceId: 'source-a',
+            nextRunAt: '2026-03-04T08:55:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
+        ],
         nextToken: 'page-2',
       },
       {
         items: [
-          { sourceId: 'source-a', nextRunAt: '2026-03-04T08:55:00.000Z' },
-          { sourceId: 'source-b', nextRunAt: '2026-03-04T09:10:00.000Z' },
+          {
+            sourceId: 'source-a',
+            nextRunAt: '2026-03-04T08:55:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
+          {
+            sourceId: 'source-b',
+            nextRunAt: '2026-03-04T09:10:00.000Z',
+            scheduleType: 'cron',
+            cronExpr: '*/5 * * * *',
+          },
         ],
         nextToken: null,
       },
@@ -68,13 +124,56 @@ describe('listEligibleSources', () => {
       now: '2026-03-04T09:00:00.000Z',
     });
 
-    expect(result).toEqual([{ sourceId: 'source-a', nextRunAt: '2026-03-04T08:55:00.000Z' }]);
+    expect(repository.reserveCalls).toHaveLength(1);
+    expect(result).toEqual([
+      {
+        sourceId: 'source-a',
+        nextRunAt: '2026-03-04T08:55:00.000Z',
+        scheduleType: 'interval',
+        intervalMinutes: 5,
+      },
+    ]);
+  });
+
+  it('skips source when conditional reservation conflicts', async () => {
+    const repository = new SpySourceRepository(
+      [
+        {
+          items: [
+            {
+              sourceId: 'source-a',
+              nextRunAt: '2026-03-04T08:55:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            },
+          ],
+          nextToken: null,
+        },
+      ],
+      [false],
+    );
+
+    const result = await listEligibleSources({
+      sourceRepository: repository,
+      pageSize: 1,
+      now: '2026-03-04T09:00:00.000Z',
+    });
+
+    expect(repository.reserveCalls).toHaveLength(1);
+    expect(result).toEqual([]);
   });
 
   it('throws when repository returns invalid normalized source', async () => {
     const repository = new SpySourceRepository([
       {
-        items: [{ sourceId: '', nextRunAt: '2026-03-04T09:00:00.000Z' }],
+        items: [
+          {
+            sourceId: '',
+            nextRunAt: '2026-03-04T09:00:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
+        ],
         nextToken: null,
       },
     ]);

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import type {
   ListActiveSourcesParams,
   ListActiveSourcesResult,
+  ReserveNextRunParams,
   SourceRepository,
 } from '../../../src/domain/scheduler/list-eligible-sources';
 import { createHandler } from '../../../src/handlers/scheduler';
@@ -11,15 +12,24 @@ const ORIGINAL_MAP_MAX_CONCURRENCY = process.env.MAP_MAX_CONCURRENCY;
 
 class SpySourceRepository implements SourceRepository {
   public readonly calls: ListActiveSourcesParams[] = [];
+  public readonly reserveCalls: ReserveNextRunParams[] = [];
   private readonly pages: ListActiveSourcesResult[];
+  private readonly reserveResults: boolean[];
 
-  constructor(pages: ListActiveSourcesResult[]) {
+  constructor(pages: ListActiveSourcesResult[], reserveResults: boolean[] = []) {
     this.pages = pages;
+    this.reserveResults = reserveResults;
   }
 
   listActiveSources(params: ListActiveSourcesParams): Promise<ListActiveSourcesResult> {
     this.calls.push(params);
     return Promise.resolve(this.pages[this.calls.length - 1] ?? { items: [], nextToken: null });
+  }
+
+  reserveNextRun(params: ReserveNextRunParams): Promise<boolean> {
+    this.reserveCalls.push(params);
+    const result = this.reserveResults[this.reserveCalls.length - 1];
+    return Promise.resolve(result ?? true);
   }
 }
 
@@ -35,19 +45,36 @@ afterEach(() => {
 });
 
 describe('scheduler handler', () => {
-  it('returns only eligible sourceIds and logs filtered count with default max concurrency', async () => {
+  it('returns only reserved sourceIds and logs filtered count with default max concurrency', async () => {
     delete process.env.MAP_MAX_CONCURRENCY;
     const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
     const repository = new SpySourceRepository([
       {
         items: [
-          { sourceId: 'source-b', nextRunAt: '2026-03-04T09:00:00.000Z' },
-          { sourceId: 'source-a', nextRunAt: '2026-03-04T09:05:00.000Z' },
+          {
+            sourceId: 'source-b',
+            nextRunAt: '2026-03-04T09:00:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
+          {
+            sourceId: 'source-a',
+            nextRunAt: '2026-03-04T09:05:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
         ],
         nextToken: 'page-2',
       },
       {
-        items: [{ sourceId: 'source-c', nextRunAt: '2026-03-04T08:59:00.000Z' }],
+        items: [
+          {
+            sourceId: 'source-c',
+            nextRunAt: '2026-03-04T08:59:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
+        ],
         nextToken: null,
       },
     ]);
@@ -74,6 +101,20 @@ describe('scheduler handler', () => {
         now: '2026-03-04T09:01:00.000Z',
       },
     ]);
+    expect(repository.reserveCalls).toEqual([
+      {
+        sourceId: 'source-b',
+        expectedNextRunAt: '2026-03-04T09:00:00.000Z',
+        nextRunAt: '2026-03-04T09:06:00.000Z',
+        reservedAt: '2026-03-04T09:01:00.000Z',
+      },
+      {
+        sourceId: 'source-c',
+        expectedNextRunAt: '2026-03-04T08:59:00.000Z',
+        nextRunAt: '2026-03-04T09:06:00.000Z',
+        reservedAt: '2026-03-04T09:01:00.000Z',
+      },
+    ]);
     expect(result.sourceIds).toEqual(['source-b', 'source-c']);
     expect(result.generatedAt).toBe('2026-03-04T10:00:00.000Z');
     expect(result.maxConcurrency).toBe(5);
@@ -81,6 +122,40 @@ describe('scheduler handler', () => {
       referenceNow: '2026-03-04T09:01:00.000Z',
       eligibleSources: 2,
     });
+  });
+
+  it('skips conflicted reservations and keeps handler successful', async () => {
+    const repository = new SpySourceRepository(
+      [
+        {
+          items: [
+            {
+              sourceId: 'source-a',
+              nextRunAt: '2026-03-04T09:00:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            },
+            {
+              sourceId: 'source-b',
+              nextRunAt: '2026-03-04T09:00:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            },
+          ],
+          nextToken: null,
+        },
+      ],
+      [true, false],
+    );
+    const handler = createHandler({
+      sourceRepository: repository,
+      now: () => '2026-03-04T09:00:00.000Z',
+      activeSourcesPageSize: 10,
+    });
+
+    const result = await handler();
+
+    expect(result.sourceIds).toEqual(['source-a']);
   });
 
   it('returns configured max concurrency from environment', async () => {
@@ -103,8 +178,18 @@ describe('scheduler handler', () => {
     const repository = new SpySourceRepository([
       {
         items: [
-          { sourceId: 'source-a', nextRunAt: '2026-03-04T10:00:00.000Z' },
-          { sourceId: 'source-b', nextRunAt: '2026-03-04T10:01:00.000Z' },
+          {
+            sourceId: 'source-a',
+            nextRunAt: '2026-03-04T10:00:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
+          {
+            sourceId: 'source-b',
+            nextRunAt: '2026-03-04T10:01:00.000Z',
+            scheduleType: 'interval',
+            intervalMinutes: 5,
+          },
         ],
         nextToken: null,
       },
@@ -122,6 +207,14 @@ describe('scheduler handler', () => {
         limit: 10,
         nextToken: undefined,
         now: '2026-03-04T10:00:00.000Z',
+      },
+    ]);
+    expect(repository.reserveCalls).toEqual([
+      {
+        sourceId: 'source-a',
+        expectedNextRunAt: '2026-03-04T10:00:00.000Z',
+        nextRunAt: '2026-03-04T10:05:00.000Z',
+        reservedAt: '2026-03-04T10:00:00.000Z',
       },
     ]);
     expect(result.generatedAt).toBe('2026-03-04T10:00:00.000Z');

--- a/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts
+++ b/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts
@@ -1,20 +1,46 @@
+import {
+  ConditionalCheckFailedException,
+  type DynamoDBClient,
+  QueryCommand,
+  UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb';
 import { describe, expect, it } from '@jest/globals';
-import type { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 
 import { createDynamoDbSchedulerSourceRepository } from '../../../../src/infra/sources/dynamodb-scheduler-source-repository';
 
-class FakeDynamoClient {
-  public readonly commands: QueryCommand[] = [];
-  private readonly responses: Array<Record<string, unknown>>;
+type FakeResponse =
+  | {
+      value: Record<string, unknown>;
+    }
+  | {
+      error: unknown;
+    };
 
-  constructor(responses: Array<Record<string, unknown>>) {
+class FakeDynamoClient {
+  public readonly commands: Array<QueryCommand | UpdateItemCommand> = [];
+  private readonly responses: FakeResponse[];
+
+  constructor(responses: FakeResponse[]) {
     this.responses = responses;
   }
 
-  send(command: QueryCommand): Promise<Record<string, unknown>> {
+  send(command: QueryCommand | UpdateItemCommand): Promise<Record<string, unknown>> {
     this.commands.push(command);
-    return Promise.resolve(this.responses.shift() ?? {});
+    const response = this.responses.shift();
+    if (!response) {
+      return Promise.resolve({});
+    }
+
+    if ('error' in response) {
+      const rejection =
+        response.error instanceof Error
+          ? response.error
+          : new Error(`FakeDynamoClient rejection: ${String(response.error)}`);
+      return Promise.reject(rejection);
+    }
+
+    return Promise.resolve(response.value);
   }
 }
 
@@ -27,17 +53,23 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
     });
     const client = new FakeDynamoClient([
       {
-        Items: [
-          marshall({
-            sourceId: 'source-a',
-            nextRunAt: '2026-03-04T10:00:00.000Z',
-          }),
-          marshall({
-            sourceId: 'source-b',
-            nextRunAt: '2026-03-04T11:00:00.000Z',
-          }),
-        ],
-        LastEvaluatedKey: lastEvaluatedKey,
+        value: {
+          Items: [
+            marshall({
+              sourceId: 'source-a',
+              nextRunAt: '2026-03-04T10:00:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            }),
+            marshall({
+              sourceId: 'source-b',
+              nextRunAt: '2026-03-04T11:00:00.000Z',
+              scheduleType: 'cron',
+              cronExpr: '*/5 * * * *',
+            }),
+          ],
+          LastEvaluatedKey: lastEvaluatedKey,
+        },
       },
     ]);
 
@@ -52,25 +84,39 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
     });
     const command = client.commands[0];
 
-    expect(command.input.TableName).toBe('sources-table');
-    expect(command.input.IndexName).toBe('active-nextRunAt-index');
-    expect(command.input.KeyConditionExpression).toBe(
+    expect(command).toBeInstanceOf(QueryCommand);
+    const queryCommand = command as QueryCommand;
+    expect(queryCommand.input.TableName).toBe('sources-table');
+    expect(queryCommand.input.IndexName).toBe('active-nextRunAt-index');
+    expect(queryCommand.input.KeyConditionExpression).toBe(
       '#active = :active AND #nextRunAt <= :nextRunAt',
     );
-    expect(command.input.ExpressionAttributeNames).toEqual({
+    expect(queryCommand.input.ExpressionAttributeNames).toEqual({
       '#active': 'active',
       '#nextRunAt': 'nextRunAt',
     });
-    expect(command.input.ExpressionAttributeValues).toEqual({
+    expect(queryCommand.input.ExpressionAttributeValues).toEqual({
       ':active': { S: 'true' },
       ':nextRunAt': { S: '2026-03-04T10:30:00.000Z' },
     });
-    expect(command.input.ProjectionExpression).toBe('sourceId, nextRunAt');
-    expect(command.input.Limit).toBe(2);
-    expect(command.input.ScanIndexForward).toBe(true);
+    expect(queryCommand.input.ProjectionExpression).toBe(
+      'sourceId, nextRunAt, scheduleType, intervalMinutes, cronExpr',
+    );
+    expect(queryCommand.input.Limit).toBe(2);
+    expect(queryCommand.input.ScanIndexForward).toBe(true);
     expect(result.items).toEqual([
-      { sourceId: 'source-a', nextRunAt: '2026-03-04T10:00:00.000Z' },
-      { sourceId: 'source-b', nextRunAt: '2026-03-04T11:00:00.000Z' },
+      {
+        sourceId: 'source-a',
+        nextRunAt: '2026-03-04T10:00:00.000Z',
+        scheduleType: 'interval',
+        intervalMinutes: 5,
+      },
+      {
+        sourceId: 'source-b',
+        nextRunAt: '2026-03-04T11:00:00.000Z',
+        scheduleType: 'cron',
+        cronExpr: '*/5 * * * *',
+      },
     ]);
     expect(typeof result.nextToken).toBe('string');
   });
@@ -83,21 +129,29 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
     });
     const client = new FakeDynamoClient([
       {
-        Items: [
-          marshall({
-            sourceId: 'source-a',
-            nextRunAt: '2026-03-04T10:00:00.000Z',
-          }),
-        ],
-        LastEvaluatedKey: firstLastEvaluatedKey,
+        value: {
+          Items: [
+            marshall({
+              sourceId: 'source-a',
+              nextRunAt: '2026-03-04T10:00:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            }),
+          ],
+          LastEvaluatedKey: firstLastEvaluatedKey,
+        },
       },
       {
-        Items: [
-          marshall({
-            sourceId: 'source-c',
-            nextRunAt: '2026-03-04T12:00:00.000Z',
-          }),
-        ],
+        value: {
+          Items: [
+            marshall({
+              sourceId: 'source-c',
+              nextRunAt: '2026-03-04T12:00:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            }),
+          ],
+        },
       },
     ]);
 
@@ -113,11 +167,13 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
     });
 
     expect(client.commands).toHaveLength(2);
-    expect(client.commands[1].input.ExclusiveStartKey).toEqual(firstLastEvaluatedKey);
+    expect(client.commands[1]).toBeInstanceOf(QueryCommand);
+    const queryCommand = client.commands[1] as QueryCommand;
+    expect(queryCommand.input.ExclusiveStartKey).toEqual(firstLastEvaluatedKey);
   });
 
   it('keeps base key condition when now reference is not provided', async () => {
-    const client = new FakeDynamoClient([{ Items: [] }]);
+    const client = new FakeDynamoClient([{ value: { Items: [] } }]);
     const repository = createDynamoDbSchedulerSourceRepository({
       tableName: 'sources-table',
       client: client as unknown as DynamoDBClient,
@@ -125,11 +181,13 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
 
     await repository.listActiveSources({ limit: 1 });
 
-    expect(client.commands[0].input.KeyConditionExpression).toBe('#active = :active');
-    expect(client.commands[0].input.ExpressionAttributeNames).toEqual({
+    expect(client.commands[0]).toBeInstanceOf(QueryCommand);
+    const queryCommand = client.commands[0] as QueryCommand;
+    expect(queryCommand.input.KeyConditionExpression).toBe('#active = :active');
+    expect(queryCommand.input.ExpressionAttributeNames).toEqual({
       '#active': 'active',
     });
-    expect(client.commands[0].input.ExpressionAttributeValues).toEqual({
+    expect(queryCommand.input.ExpressionAttributeValues).toEqual({
       ':active': { S: 'true' },
     });
   });
@@ -152,12 +210,16 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
   it('throws when item does not contain required fields', async () => {
     const client = new FakeDynamoClient([
       {
-        Items: [
-          marshall({
-            sourceId: '',
-            nextRunAt: '2026-03-04T10:00:00.000Z',
-          }),
-        ],
+        value: {
+          Items: [
+            marshall({
+              sourceId: '',
+              nextRunAt: '2026-03-04T10:00:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            }),
+          ],
+        },
       },
     ]);
 
@@ -169,5 +231,61 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
     await expect(repository.listActiveSources({ limit: 1 })).rejects.toThrow(
       'Invalid scheduler source item: sourceId is required.',
     );
+  });
+
+  it('reserves nextRunAt with conditional update', async () => {
+    const client = new FakeDynamoClient([{ value: {} }]);
+    const repository = createDynamoDbSchedulerSourceRepository({
+      tableName: 'sources-table',
+      client: client as unknown as DynamoDBClient,
+    });
+
+    const reserved = await repository.reserveNextRun({
+      sourceId: 'source-a',
+      expectedNextRunAt: '2026-03-04T09:00:00.000Z',
+      nextRunAt: '2026-03-04T09:05:00.000Z',
+      reservedAt: '2026-03-04T09:00:00.000Z',
+    });
+
+    expect(reserved).toBe(true);
+    expect(client.commands[0]).toBeInstanceOf(UpdateItemCommand);
+    const updateCommand = client.commands[0] as UpdateItemCommand;
+    expect(updateCommand.input).toEqual({
+      TableName: 'sources-table',
+      Key: marshall({ sourceId: 'source-a' }),
+      UpdateExpression: 'SET nextRunAt = :nextRunAt, updatedAt = :updatedAt',
+      ConditionExpression:
+        'attribute_exists(sourceId) AND active = :active AND nextRunAt = :expectedNextRunAt',
+      ExpressionAttributeValues: {
+        ':active': { S: 'true' },
+        ':expectedNextRunAt': { S: '2026-03-04T09:00:00.000Z' },
+        ':nextRunAt': { S: '2026-03-04T09:05:00.000Z' },
+        ':updatedAt': { S: '2026-03-04T09:00:00.000Z' },
+      },
+    });
+  });
+
+  it('returns false when conditional update detects concurrency conflict', async () => {
+    const client = new FakeDynamoClient([
+      {
+        error: new ConditionalCheckFailedException({
+          $metadata: {},
+          message: 'conditional failed',
+        }),
+      },
+    ]);
+    const repository = createDynamoDbSchedulerSourceRepository({
+      tableName: 'sources-table',
+      client: client as unknown as DynamoDBClient,
+    });
+
+    const reserved = await repository.reserveNextRun({
+      sourceId: 'source-a',
+      expectedNextRunAt: '2026-03-04T09:00:00.000Z',
+      nextRunAt: '2026-03-04T09:05:00.000Z',
+      reservedAt: '2026-03-04T09:00:00.000Z',
+    });
+
+    expect(reserved).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #49

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Implementar reserva atômica de fontes elegíveis no Scheduler com update condicional de `nextRunAt`, evitando corrida entre execuções simultâneas.

---

## 🧠 Decisão Técnica

- Evolução do contrato de `SourceRepository` com `reserveNextRun`.
- DynamoDB com `UpdateItem` + `ConditionExpression` em `active=true` e `nextRunAt` esperado.
- Recalculo de `nextRunAt` por regra da fonte (`interval`/`cron`) no domínio do scheduler.
- Conflito concorrente (`ConditionalCheckFailed`) não falha lote, apenas remove fonte conflitada do resultado.

---

## 🧪 BDD Validado

Dado que existem fontes elegíveis para execução
Quando o Scheduler tenta reservar cada fonte com update condicional
Então somente fontes efetivamente reservadas entram em `sourceIds` e conflitos de concorrência não interrompem a execução.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

Comandos executados:
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts --runInBand`
- `npm run validate:stage-render`
- `npm run validate:stage-package` (fallback local sem credenciais AWS)

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
