### PR TITLE
feat(scheduler): versionar contrato de saida para Step Functions

### DIFF
--- a/.codex/runs/platform_architect-issue-50.md
+++ b/.codex/runs/platform_architect-issue-50.md
@@ -1,0 +1,31 @@
+## Issue #50 — [EPIC 4] Retornar lista de sourceIds para Step Functions
+
+### Objetivo
+Definir e publicar um contrato versionado de saída da Lambda Scheduler que possa ser consumido diretamente pela Step Functions, incluindo metadados operacionais e comportamento explícito quando não houver fontes elegíveis.
+
+### Decisões arquiteturais
+1. **Contrato versionado no boundary Scheduler -> SFN**
+- Introduzir campo `contractVersion` no resultado da Scheduler.
+- Manter payload estável com `sourceIds`, `eligibleSources`, `hasEligibleSources`, `referenceNow`, `generatedAt` e `maxConcurrency`.
+- Evitar acoplamento da SFN a regras internas do domínio da Scheduler.
+
+2. **Consumo direto no Map State sem etapa de transformação**
+- Remover normalização intermediária (`Pass`) entre `Scheduler` e `Map`.
+- Configurar `ProcessEligibleSources.ItemsPath` para ler diretamente `$.schedulerResult.sourceIds`.
+- Configurar `MaxConcurrencyPath` para `$.schedulerResult.maxConcurrency`.
+
+3. **Comportamento explícito para lote vazio**
+- Garantir que `sourceIds` seja sempre array (inclusive vazio).
+- Publicar `hasEligibleSources=false` e `eligibleSources=0` quando não houver fontes.
+- Preservar execução bem-sucedida da orquestração com `results=[]`.
+
+4. **Documentação de contrato e rastreabilidade**
+- Documentar o contrato v1 da Scheduler em arquivo dedicado.
+- Atualizar doc da state machine principal para refletir o consumo direto.
+- Cobrir cenário vazio e cenário com fontes no teste da Scheduler e no teste de contrato da SFN.
+
+### Critérios técnicos de aceite
+- Scheduler retorna contrato versionado e estável para SFN.
+- Step Functions consome `schedulerResult` diretamente no Map, sem transformação adicional.
+- Caso sem elegíveis é explícito no payload e não gera falha na execução.
+- Contrato documentado e validado por testes automatizados.

--- a/.codex/runs/qa-issue-50.md
+++ b/.codex/runs/qa-issue-50.md
@@ -1,0 +1,27 @@
+**QA — Issue #50 (Retornar lista de sourceIds para Step Functions)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante.
+3. Médio: nenhum bloqueante no escopo.
+4. Baixo: `validate:stage-package` executou fallback local por ausência de credenciais AWS no ambiente, sem impacto no contrato da issue.
+
+**Checklist de aceite da issue**
+
+- [x] Payload do Scheduler expõe `sourceIds` + metadados operacionais (`referenceNow`, `generatedAt`, `maxConcurrency`).
+- [x] Contrato versionado explicitamente (`contractVersion`).
+- [x] Caso sem elegíveis é explícito (`sourceIds=[]`, `eligibleSources=0`, `hasEligibleSources=false`).
+- [x] Step Functions consome `schedulerResult` diretamente no `Map` sem etapa de transformação adicional.
+- [x] Contrato documentado.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm run test -- tests/unit/handlers/scheduler.test.ts tests/unit/state-machines/main-orchestration-v1.test.ts --runInBand` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ✅ (fallback esperado)
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-50.md
+++ b/.codex/runs/worker-issue-50.md
@@ -1,0 +1,35 @@
+**Status de execução — Issue #50**
+
+**Escopo implementado**
+
+- Contrato versionado da Lambda Scheduler para consumo da SFN:
+  - `src/handlers/scheduler.ts`
+  - adicionados campos: `contractVersion`, `eligibleSources`, `hasEligibleSources`, `referenceNow`.
+  - `sourceIds` permanece como lista principal consumida pela orquestração.
+  - caso sem elegíveis agora é explícito (`sourceIds=[]`, `eligibleSources=0`, `hasEligibleSources=false`).
+- Consumo direto do payload da Scheduler no `Map State`:
+  - `state-machines/main-orchestration-v1.asl.json`
+  - removida etapa intermediária `NormalizeSchedulerOutput`.
+  - `ProcessEligibleSources.ItemsPath` atualizado para `$.schedulerResult.sourceIds`.
+  - `ProcessEligibleSources.MaxConcurrencyPath` atualizado para `$.schedulerResult.maxConcurrency`.
+  - `BuildExecutionOutput` atualizado para usar `schedulerResult` diretamente e expor metadados de contrato em `scheduler`.
+- Testes ajustados para o novo contrato:
+  - `tests/unit/handlers/scheduler.test.ts`
+  - `tests/unit/state-machines/main-orchestration-v1.test.ts`
+- Documentação do contrato e da orquestração atualizada:
+  - `docs/step-functions/scheduler-output-v1.md` (novo)
+  - `docs/step-functions/main-orchestration-v1.md`
+  - `README.md`
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm run test -- tests/unit/handlers/scheduler.test.ts tests/unit/state-machines/main-orchestration-v1.test.ts --runInBand` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ✅ (fallback esperado por ausência de credenciais AWS)
+
+**Resultado**
+
+Implementação concluída no escopo da issue #50, pronta para PR.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
     - `403` para token sem escopo exigido.
 - Definição da state machine principal versionada em `state-machines/main-orchestration-v1.asl.json`.
 - Contratos de entrada/saída por estado documentados em `docs/step-functions/main-orchestration-v1.md`.
+- Contrato versionado da saída do scheduler documentado em `docs/step-functions/scheduler-output-v1.md`.
 - Retry com backoff exponencial configurado na state machine para tasks críticas:
   - `Scheduler` e `InvokeCollector` com tentativa para erros transitórios de Lambda:
     - `IntervalSeconds: 2`, `MaxAttempts: 3`, `BackoffRate: 2`.

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -44,13 +44,18 @@ Payload esperado na execução:
     - `MaxAttempts: 2`
     - `BackoffRate: 2`
 - Saída esperada em `schedulerResult`:
+  - `contractVersion` (`scheduler-output.v1`)
   - `sourceIds` (array de string)
+  - `eligibleSources` (number)
+  - `hasEligibleSources` (boolean)
+  - `referenceNow` (string ISO)
   - `generatedAt` (string ISO)
   - `maxConcurrency` (number, inteiro entre 1 e 40)
+  - Contrato detalhado em `docs/step-functions/scheduler-output-v1.md`.
 
 ### ProcessEligibleSources (Map)
 
-- Entrada: `scheduler.sourceIds` e `scheduler.maxConcurrency`.
+- Entrada: `schedulerResult.sourceIds` e `schedulerResult.maxConcurrency`.
 - Ação: itera cada `sourceId` e invoca `CollectorLambdaFunction`.
 - Retry com backoff exponencial na task `InvokeCollector` com os mesmos limites do `Scheduler`.
 - Catch por item no `InvokeCollector` (`States.ALL`) para registrar falha da fonte sem interromper o `Map`.
@@ -61,7 +66,7 @@ Payload esperado na execução:
   - sucesso: `sourceId`, `status=SUCCEEDED`, `processedAt`, `recordsSent`;
   - falha: `sourceId`, `status=FAILED`, `error`, `cause`.
 - Controle de paralelismo:
-  - `MaxConcurrencyPath = $.scheduler.maxConcurrency`.
+  - `MaxConcurrencyPath = $.schedulerResult.maxConcurrency`.
   - Valor configurado por stage via `MAP_MAX_CONCURRENCY`.
 
 ### BuildExecutionOutput (Pass)
@@ -71,6 +76,9 @@ Payload esperado na execução:
   - `meta`
   - `sources` (`schedulerResult.sourceIds`)
   - `results` (lista de itens com sucesso/falha por `sourceId`)
+  - `scheduler.contractVersion`
+  - `scheduler.referenceNow`
+  - `scheduler.hasEligibleSources`
   - `summary.eligibleSources` (tamanho de `sources`)
   - `summary.processedSources` (tamanho de `results`)
   - `summary.generatedAt`

--- a/docs/step-functions/scheduler-output-v1.md
+++ b/docs/step-functions/scheduler-output-v1.md
@@ -1,0 +1,50 @@
+# Scheduler Output Contract v1 (`scheduler-output.v1`)
+
+Contrato versionado da Lambda `scheduler` consumido diretamente pela state machine principal.
+
+## Objetivo
+
+Padronizar a resposta da Scheduler para que o `Map State` consuma `sourceIds` e `maxConcurrency` sem etapa intermediaria de transformacao.
+
+## Estrutura
+
+- `contractVersion` (`string`, obrigatorio): versao do contrato. Valor fixo `scheduler-output.v1`.
+- `sourceIds` (`string[]`, obrigatorio): lista de fontes reservadas para processamento.
+- `eligibleSources` (`number`, obrigatorio): quantidade de itens em `sourceIds`.
+- `hasEligibleSources` (`boolean`, obrigatorio): indica se ha pelo menos uma fonte elegivel.
+- `referenceNow` (`string`, obrigatorio, ISO-8601 UTC): relogio usado para elegibilidade/reserva.
+- `generatedAt` (`string`, obrigatorio, ISO-8601 UTC): timestamp de geracao da resposta.
+- `maxConcurrency` (`number`, obrigatorio): limite de paralelismo para o `Map` (1 a 40).
+
+## Exemplo com fontes elegiveis
+
+```json
+{
+  "contractVersion": "scheduler-output.v1",
+  "sourceIds": ["crm-a", "erp-b"],
+  "eligibleSources": 2,
+  "hasEligibleSources": true,
+  "referenceNow": "2026-03-04T09:01:00.000Z",
+  "generatedAt": "2026-03-04T09:01:00.000Z",
+  "maxConcurrency": 5
+}
+```
+
+## Exemplo sem fontes elegiveis
+
+```json
+{
+  "contractVersion": "scheduler-output.v1",
+  "sourceIds": [],
+  "eligibleSources": 0,
+  "hasEligibleSources": false,
+  "referenceNow": "2026-03-04T09:01:00.000Z",
+  "generatedAt": "2026-03-04T09:01:00.000Z",
+  "maxConcurrency": 5
+}
+```
+
+## Compatibilidade
+
+- A evolucao incompativel deste contrato deve gerar novo identificador de versao (ex.: `scheduler-output.v2`).
+- A state machine que consumir nova versao deve ser versionada em arquivo dedicado (`main-orchestration-v2.asl.json`).

--- a/src/handlers/scheduler.ts
+++ b/src/handlers/scheduler.ts
@@ -15,7 +15,11 @@ export interface SchedulerEvent {
 }
 
 export interface SchedulerResult {
+  contractVersion: string;
   sourceIds: string[];
+  eligibleSources: number;
+  hasEligibleSources: boolean;
+  referenceNow: string;
   generatedAt: string;
   maxConcurrency: number;
 }
@@ -27,6 +31,7 @@ export interface SchedulerDependencies {
 }
 
 let cachedDefaultDependencies: SchedulerDependencies | undefined;
+const SCHEDULER_RESULT_CONTRACT_VERSION = 'scheduler-output.v1';
 
 const resolveMapMaxConcurrency = (rawValue: string | undefined): number => {
   if (!rawValue) {
@@ -100,14 +105,19 @@ export const createHandler =
     });
 
     const sourceIds = sources.map((source) => source.sourceId);
+    const eligibleSources = sourceIds.length;
     const maxConcurrency = resolveMapMaxConcurrency(process.env.MAP_MAX_CONCURRENCY);
     console.info('scheduler.eligible_sources.filtered', {
       referenceNow,
-      eligibleSources: sourceIds.length,
+      eligibleSources,
     });
 
     return {
+      contractVersion: SCHEDULER_RESULT_CONTRACT_VERSION,
       sourceIds,
+      eligibleSources,
+      hasEligibleSources: eligibleSources > 0,
+      referenceNow,
       generatedAt,
       maxConcurrency,
     };

--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -49,7 +49,7 @@
         }
       ],
       "ResultPath": "$.schedulerResult",
-      "Next": "NormalizeSchedulerOutput",
+      "Next": "ProcessEligibleSources",
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
@@ -58,24 +58,10 @@
         }
       ]
     },
-    "NormalizeSchedulerOutput": {
-      "Type": "Pass",
-      "Parameters": {
-        "meta.$": "$.meta",
-        "scheduler": {
-          "sourceIds.$": "$.schedulerResult.sourceIds",
-          "generatedAt.$": "$.schedulerResult.generatedAt",
-          "maxConcurrency.$": "$.schedulerResult.maxConcurrency",
-          "eligibleSources.$": "States.ArrayLength($.schedulerResult.sourceIds)"
-        }
-      },
-      "ResultPath": "$",
-      "Next": "ProcessEligibleSources"
-    },
     "ProcessEligibleSources": {
       "Type": "Map",
-      "ItemsPath": "$.scheduler.sourceIds",
-      "MaxConcurrencyPath": "$.scheduler.maxConcurrency",
+      "ItemsPath": "$.schedulerResult.sourceIds",
+      "MaxConcurrencyPath": "$.schedulerResult.maxConcurrency",
       "Parameters": {
         "sourceId.$": "$$.Map.Item.Value",
         "meta.$": "$.meta"
@@ -278,13 +264,18 @@
       "Type": "Pass",
       "Parameters": {
         "meta.$": "$.meta",
-        "sources.$": "$.scheduler.sourceIds",
+        "sources.$": "$.schedulerResult.sourceIds",
         "results.$": "$.collectorResults",
+        "scheduler": {
+          "contractVersion.$": "$.schedulerResult.contractVersion",
+          "referenceNow.$": "$.schedulerResult.referenceNow",
+          "hasEligibleSources.$": "$.schedulerResult.hasEligibleSources"
+        },
         "summary": {
           "processedSources.$": "States.ArrayLength($.collectorResults)",
-          "eligibleSources.$": "$.scheduler.eligibleSources",
-          "generatedAt.$": "$.scheduler.generatedAt",
-          "maxConcurrency.$": "$.scheduler.maxConcurrency",
+          "eligibleSources.$": "$.schedulerResult.eligibleSources",
+          "generatedAt.$": "$.schedulerResult.generatedAt",
+          "maxConcurrency.$": "$.schedulerResult.maxConcurrency",
           "schedulerStatus": "SUCCEEDED"
         }
       },

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -116,6 +116,10 @@ describe('scheduler handler', () => {
       },
     ]);
     expect(result.sourceIds).toEqual(['source-b', 'source-c']);
+    expect(result.contractVersion).toBe('scheduler-output.v1');
+    expect(result.eligibleSources).toBe(2);
+    expect(result.hasEligibleSources).toBe(true);
+    expect(result.referenceNow).toBe('2026-03-04T09:01:00.000Z');
     expect(result.generatedAt).toBe('2026-03-04T10:00:00.000Z');
     expect(result.maxConcurrency).toBe(5);
     expect(infoSpy).toHaveBeenCalledWith('scheduler.eligible_sources.filtered', {
@@ -156,6 +160,9 @@ describe('scheduler handler', () => {
     const result = await handler();
 
     expect(result.sourceIds).toEqual(['source-a']);
+    expect(result.eligibleSources).toBe(1);
+    expect(result.hasEligibleSources).toBe(true);
+    expect(result.referenceNow).toBe('2026-03-04T09:00:00.000Z');
   });
 
   it('returns configured max concurrency from environment', async () => {
@@ -171,6 +178,11 @@ describe('scheduler handler', () => {
     const result = await handler();
 
     expect(result.maxConcurrency).toBe(12);
+    expect(result.contractVersion).toBe('scheduler-output.v1');
+    expect(result.sourceIds).toEqual([]);
+    expect(result.eligibleSources).toBe(0);
+    expect(result.hasEligibleSources).toBe(false);
+    expect(result.referenceNow).toBe('2026-03-04T10:00:00.000Z');
   });
 
   it('uses generatedAt as reference now when event.now is omitted', async () => {
@@ -219,6 +231,9 @@ describe('scheduler handler', () => {
     ]);
     expect(result.generatedAt).toBe('2026-03-04T10:00:00.000Z');
     expect(result.sourceIds).toEqual(['source-a']);
+    expect(result.eligibleSources).toBe(1);
+    expect(result.hasEligibleSources).toBe(true);
+    expect(result.referenceNow).toBe('2026-03-04T10:00:00.000Z');
   });
 
   it('throws on invalid MAP_MAX_CONCURRENCY', async () => {

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -80,7 +80,6 @@ describe('main-orchestration-v1.asl.json', () => {
     const states = asObject(definition.States);
     const normalizeInput = asObject(states.NormalizeInput);
     const scheduler = asObject(states.Scheduler);
-    const normalizeSchedulerOutput = asObject(states.NormalizeSchedulerOutput);
     const processEligibleSources = asObject(states.ProcessEligibleSources);
     const buildExecutionOutput = asObject(states.BuildExecutionOutput);
     const publishExecutionSuccessMetric = asObject(states.PublishExecutionSuccessMetric);
@@ -106,7 +105,7 @@ describe('main-orchestration-v1.asl.json', () => {
 
     expect(scheduler.Type).toBe('Task');
     expect(scheduler.ResultPath).toBe('$.schedulerResult');
-    expect(scheduler.Next).toBe('NormalizeSchedulerOutput');
+    expect(scheduler.Next).toBe('ProcessEligibleSources');
     const schedulerParameters = asObject(scheduler.Parameters);
     expect(schedulerParameters['now.$']).toBe('$.schedulerInput.now');
     const schedulerRetry = scheduler.Retry as unknown[];
@@ -137,22 +136,9 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(schedulerCatchEntry.ResultPath).toBe('$.schedulerError');
     expect(schedulerCatchEntry.Next).toBe('BuildSchedulerFailureOutput');
 
-    expect(normalizeSchedulerOutput.Type).toBe('Pass');
-    expect(normalizeSchedulerOutput.ResultPath).toBe('$');
-    expect(normalizeSchedulerOutput.Next).toBe('ProcessEligibleSources');
-    const normalizeSchedulerParameters = asObject(normalizeSchedulerOutput.Parameters);
-    expect(normalizeSchedulerParameters['meta.$']).toBe('$.meta');
-    const schedulerPayload = asObject(normalizeSchedulerParameters.scheduler);
-    expect(schedulerPayload['sourceIds.$']).toBe('$.schedulerResult.sourceIds');
-    expect(schedulerPayload['generatedAt.$']).toBe('$.schedulerResult.generatedAt');
-    expect(schedulerPayload['maxConcurrency.$']).toBe('$.schedulerResult.maxConcurrency');
-    expect(schedulerPayload['eligibleSources.$']).toBe(
-      'States.ArrayLength($.schedulerResult.sourceIds)',
-    );
-
     expect(processEligibleSources.Type).toBe('Map');
-    expect(processEligibleSources.ItemsPath).toBe('$.scheduler.sourceIds');
-    expect(processEligibleSources.MaxConcurrencyPath).toBe('$.scheduler.maxConcurrency');
+    expect(processEligibleSources.ItemsPath).toBe('$.schedulerResult.sourceIds');
+    expect(processEligibleSources.MaxConcurrencyPath).toBe('$.schedulerResult.maxConcurrency');
     expect(processEligibleSources.ResultPath).toBe('$.collectorResults');
     expect(processEligibleSources.Next).toBe('BuildExecutionOutput');
     const processEligibleSourcesParameters = asObject(processEligibleSources.Parameters);
@@ -282,13 +268,17 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(buildExecutionOutput.Next).toBe('PublishExecutionSuccessMetric');
     const outputParameters = asObject(buildExecutionOutput.Parameters);
     expect(outputParameters['meta.$']).toBe('$.meta');
-    expect(outputParameters['sources.$']).toBe('$.scheduler.sourceIds');
+    expect(outputParameters['sources.$']).toBe('$.schedulerResult.sourceIds');
     expect(outputParameters['results.$']).toBe('$.collectorResults');
+    const schedulerOutput = asObject(outputParameters.scheduler);
+    expect(schedulerOutput['contractVersion.$']).toBe('$.schedulerResult.contractVersion');
+    expect(schedulerOutput['referenceNow.$']).toBe('$.schedulerResult.referenceNow');
+    expect(schedulerOutput['hasEligibleSources.$']).toBe('$.schedulerResult.hasEligibleSources');
     const summary = asObject(outputParameters.summary);
     expect(summary['processedSources.$']).toBe('States.ArrayLength($.collectorResults)');
-    expect(summary['eligibleSources.$']).toBe('$.scheduler.eligibleSources');
-    expect(summary['generatedAt.$']).toBe('$.scheduler.generatedAt');
-    expect(summary['maxConcurrency.$']).toBe('$.scheduler.maxConcurrency');
+    expect(summary['eligibleSources.$']).toBe('$.schedulerResult.eligibleSources');
+    expect(summary['generatedAt.$']).toBe('$.schedulerResult.generatedAt');
+    expect(summary['maxConcurrency.$']).toBe('$.schedulerResult.maxConcurrency');
     expect(summary.schedulerStatus).toBe('SUCCEEDED');
 
     expect(publishExecutionSuccessMetric.Type).toBe('Task');
@@ -416,8 +406,11 @@ describe('main-orchestration-v1.asl.json', () => {
           executionId: 'exec-123',
           stage: 'dev',
         },
-        scheduler: {
+        schedulerResult: {
           sourceIds: ['source-a', 'source-b', 'source-c'],
+          contractVersion: 'scheduler-output.v1',
+          referenceNow: '2026-03-03T00:00:00.000Z',
+          hasEligibleSources: true,
           eligibleSources: 3,
           generatedAt: '2026-03-03T00:00:00.000Z',
           maxConcurrency: 5,
@@ -441,6 +434,10 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(failedResult?.cause).toContain('source-b');
 
     const summary = asObject(executionOutput.summary);
+    const scheduler = asObject(executionOutput.scheduler);
+    expect(scheduler.contractVersion).toBe('scheduler-output.v1');
+    expect(scheduler.referenceNow).toBe('2026-03-03T00:00:00.000Z');
+    expect(scheduler.hasEligibleSources).toBe(true);
     expect(summary.eligibleSources).toBe(3);
     expect(summary.processedSources).toBe(3);
     expect(summary.schedulerStatus).toBe('SUCCEEDED');


### PR DESCRIPTION
Closes #50

---

## 🎯 Objetivo

Versionar e explicitar o contrato de saída da Lambda Scheduler para consumo direto da Step Functions, incluindo metadados e caso sem fontes elegíveis.

---

## 🧠 Decisão Técnica

- O resultado da Scheduler agora expõe contrato versionado (`contractVersion: scheduler-output.v1`) com:
  - `sourceIds`, `eligibleSources`, `hasEligibleSources`, `referenceNow`, `generatedAt`, `maxConcurrency`.
- A state machine passou a consumir `schedulerResult` diretamente no `Map`:
  - remoção da etapa intermediária `NormalizeSchedulerOutput`.
  - `ItemsPath = $.schedulerResult.sourceIds`.
  - `MaxConcurrencyPath = $.schedulerResult.maxConcurrency`.
- O output final da orquestração preserva metadados do contrato em `scheduler`.

---

## 🧪 BDD Validado

Dado que o Scheduler retorna fontes elegíveis
Quando a orquestração principal executa
Então o Map consome `schedulerResult.sourceIds` sem transformação adicional.

Dado que não há fontes elegíveis
Quando o Scheduler conclui
Então o payload explicita `sourceIds=[]`, `eligibleSources=0` e `hasEligibleSources=false`.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [ ] PATCH
- [x] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
