### PR TITLE
test(scheduler): reforcar cobertura de concorrencia e contrato SFN

### DIFF
--- a/.codex/runs/platform_architect-issue-51.md
+++ b/.codex/runs/platform_architect-issue-51.md
@@ -1,0 +1,19 @@
+## Issue #51 — [EPIC 4] Testes de concorrência e elegibilidade do Scheduler
+
+### Objetivo
+Consolidar cobertura de testes do Scheduler nos pontos críticos introduzidos nas issues #49 e #50: regra de elegibilidade temporal, disputa concorrente de reserva e contrato final consumido pela Step Functions.
+
+### Decisões arquiteturais
+1. **Cobertura orientada a comportamento, sem alterar código de produção**
+- Reforçar cenários de fronteira em `listEligibleSources` (incluindo `nextRunAt == now`) para evitar regressão silenciosa na elegibilidade.
+
+2. **Concorrência validada no contrato externo do handler**
+- Garantir que conflitos de `conditional update` resultem em `sourceIds=[]` e `hasEligibleSources=false`, sem falha da Lambda.
+
+3. **Contrato SFN validado por materialização do ASL**
+- Estender teste da state machine para cenário sem fontes elegíveis, validando preservação de `scheduler.contractVersion`, `referenceNow`, `hasEligibleSources`, `summary.eligibleSources` e `summary.processedSources`.
+
+### Critérios técnicos de aceite
+- Testes unitários reproduzem cenários de elegibilidade (incluindo fronteira) e corrida concorrente.
+- Contrato final esperado pela SFN é validado com cenário de zero fontes elegíveis.
+- Execução local dos testes do escopo passa de forma determinística.

--- a/.codex/runs/qa-issue-51.md
+++ b/.codex/runs/qa-issue-51.md
@@ -1,0 +1,26 @@
+**QA — Issue #51 (Testes de concorrência e elegibilidade do Scheduler)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum bloqueante no escopo.
+4. Baixo: `validate:stage-package` depende de credenciais AWS; no ambiente local executou fallback de `build`.
+
+**Checklist de aceite da issue**
+
+- [x] Testes cobrem cenários principais de elegibilidade (incluindo fronteira temporal).
+- [x] Conflito de `conditional update` é simulado e validado sem quebrar o fluxo.
+- [x] Contrato final para SFN é validado com cenário sem fontes elegíveis.
+- [x] Falhas/regras são reproduzíveis localmente via suíte unitária.
+
+**Evidências de validação**
+
+- `npm test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts tests/unit/state-machines/main-orchestration-v1.test.ts --runInBand` ✅
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local por ausência de credenciais AWS
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-51.md
+++ b/.codex/runs/worker-issue-51.md
@@ -1,0 +1,26 @@
+**Status de execução — Issue #51**
+
+**Escopo implementado**
+
+- Reforço de elegibilidade temporal no domínio do Scheduler:
+  - `tests/unit/domain/scheduler/list-eligible-sources.test.ts`
+  - novo cenário de fronteira (`nextRunAt == now`) com fonte `cron` e validação de reserva para próximo ciclo.
+- Reforço de concorrência no contrato do handler:
+  - `tests/unit/handlers/scheduler.test.ts`
+  - novo cenário onde todas as reservas conflitam (`conditional update`), validando saída estável com `sourceIds=[]` e `hasEligibleSources=false`.
+- Reforço do contrato final para Step Functions:
+  - `tests/unit/state-machines/main-orchestration-v1.test.ts`
+  - novo cenário de materialização com zero fontes elegíveis, validando `scheduler.contractVersion`, `referenceNow`, `hasEligibleSources`, `summary.eligibleSources` e `summary.processedSources`.
+
+**Validações executadas**
+
+- `npm test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts tests/unit/state-machines/main-orchestration-v1.test.ts --runInBand` ✅
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local por ausência de credenciais AWS no ambiente
+
+**Resultado**
+
+Escopo da issue #51 concluído com foco exclusivo em testes de elegibilidade, concorrência e contrato final da orquestração.

--- a/tests/unit/domain/scheduler/list-eligible-sources.test.ts
+++ b/tests/unit/domain/scheduler/list-eligible-sources.test.ts
@@ -86,6 +86,45 @@ describe('listEligibleSources', () => {
     ]);
   });
 
+  it('includes source when nextRunAt is exactly equal to now and reserves next run for cron schedule', async () => {
+    const repository = new SpySourceRepository([
+      {
+        items: [
+          {
+            sourceId: 'source-cron',
+            nextRunAt: '2026-03-04T09:00:00.000Z',
+            scheduleType: 'cron',
+            cronExpr: '*/5 * * * *',
+          },
+        ],
+        nextToken: null,
+      },
+    ]);
+
+    const result = await listEligibleSources({
+      sourceRepository: repository,
+      pageSize: 10,
+      now: '2026-03-04T09:00:00.000Z',
+    });
+
+    expect(repository.reserveCalls).toEqual([
+      {
+        sourceId: 'source-cron',
+        expectedNextRunAt: '2026-03-04T09:00:00.000Z',
+        nextRunAt: '2026-03-04T09:05:00.000Z',
+        reservedAt: '2026-03-04T09:00:00.000Z',
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        sourceId: 'source-cron',
+        nextRunAt: '2026-03-04T09:00:00.000Z',
+        scheduleType: 'cron',
+        cronExpr: '*/5 * * * *',
+      },
+    ]);
+  });
+
   it('deduplicates repeated sourceIds across pages before reservation', async () => {
     const repository = new SpySourceRepository([
       {

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -165,6 +165,46 @@ describe('scheduler handler', () => {
     expect(result.referenceNow).toBe('2026-03-04T09:00:00.000Z');
   });
 
+  it('returns empty sourceIds and hasEligibleSources=false when all reservations conflict', async () => {
+    const repository = new SpySourceRepository(
+      [
+        {
+          items: [
+            {
+              sourceId: 'source-a',
+              nextRunAt: '2026-03-04T09:00:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            },
+            {
+              sourceId: 'source-b',
+              nextRunAt: '2026-03-04T09:00:00.000Z',
+              scheduleType: 'interval',
+              intervalMinutes: 5,
+            },
+          ],
+          nextToken: null,
+        },
+      ],
+      [false, false],
+    );
+
+    const handler = createHandler({
+      sourceRepository: repository,
+      now: () => '2026-03-04T09:00:00.000Z',
+      activeSourcesPageSize: 10,
+    });
+
+    const result = await handler();
+
+    expect(result.contractVersion).toBe('scheduler-output.v1');
+    expect(result.sourceIds).toEqual([]);
+    expect(result.eligibleSources).toBe(0);
+    expect(result.hasEligibleSources).toBe(false);
+    expect(result.referenceNow).toBe('2026-03-04T09:00:00.000Z');
+    expect(result.generatedAt).toBe('2026-03-04T09:00:00.000Z');
+  });
+
   it('returns configured max concurrency from environment', async () => {
     process.env.MAP_MAX_CONCURRENCY = '12';
 

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -443,4 +443,45 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(summary.schedulerStatus).toBe('SUCCEEDED');
     expect(summary.maxConcurrency).toBe(5);
   });
+
+  it('materializa contrato final quando scheduler nao encontra fontes elegiveis', () => {
+    const definition = loadDefinition();
+    const states = asObject(definition.States);
+    const buildExecutionOutput = asObject(states.BuildExecutionOutput);
+    const buildExecutionOutputParameters = asObject(buildExecutionOutput.Parameters);
+
+    const executionOutput = asObject(
+      materializeParameters(buildExecutionOutputParameters, {
+        meta: {
+          executionId: 'exec-empty',
+          stage: 'dev',
+        },
+        schedulerResult: {
+          sourceIds: [],
+          contractVersion: 'scheduler-output.v1',
+          referenceNow: '2026-03-04T09:00:00.000Z',
+          hasEligibleSources: false,
+          eligibleSources: 0,
+          generatedAt: '2026-03-04T09:00:00.000Z',
+          maxConcurrency: 5,
+        },
+        collectorResults: [],
+      }),
+    );
+
+    const scheduler = asObject(executionOutput.scheduler);
+    const sources = asArray(executionOutput.sources);
+    const results = asArray(executionOutput.results);
+    const summary = asObject(executionOutput.summary);
+
+    expect(scheduler.contractVersion).toBe('scheduler-output.v1');
+    expect(scheduler.referenceNow).toBe('2026-03-04T09:00:00.000Z');
+    expect(scheduler.hasEligibleSources).toBe(false);
+    expect(sources).toEqual([]);
+    expect(results).toEqual([]);
+    expect(summary.eligibleSources).toBe(0);
+    expect(summary.processedSources).toBe(0);
+    expect(summary.schedulerStatus).toBe('SUCCEEDED');
+    expect(summary.maxConcurrency).toBe(5);
+  });
 });


### PR DESCRIPTION
Closes #51

---

## 🎯 Objetivo

Reforçar a cobertura de testes do Scheduler para cenários de elegibilidade temporal, conflito concorrente de reserva (`conditional update`) e contrato final consumido pela Step Functions.

---

## 🧠 Decisão Técnica

- Mantida a estratégia de **não alterar código de produção** nesta issue.
- Inclusão de cenário de fronteira no domínio (`nextRunAt == now`) com `scheduleType=cron`.
- Inclusão de cenário no handler em que **todas** as reservas entram em conflito, validando contrato externo estável (`sourceIds=[]`, `hasEligibleSources=false`).
- Inclusão de cenário no teste da state machine para materialização do output final com zero fontes elegíveis, preservando contrato `scheduler-output.v1`.

---

## 🧪 BDD Validado

Dado que uma fonte possui `nextRunAt` exatamente igual ao `now` de referência  
Quando o Scheduler avalia elegibilidade e reserva o próximo ciclo  
Então a fonte é considerada elegível e o próximo `nextRunAt` é calculado corretamente.

Dado que todas as reservas concorrentes falham por `conditional update`  
Quando o handler conclui a execução  
Então a resposta permanece bem-formada para SFN, com `sourceIds=[]` e `hasEligibleSources=false`.

Dado que o Scheduler não retorna fontes elegíveis  
Quando o output da state machine é materializado  
Então o contrato final preserva campos de `scheduler` e resumo com contagens zeradas.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [ ] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

Comandos executados:
- `npm test -- tests/unit/domain/scheduler/list-eligible-sources.test.ts tests/unit/handlers/scheduler.test.ts tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts tests/unit/state-machines/main-orchestration-v1.test.ts --runInBand`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run validate:stage-render`
- `npm run validate:stage-package` (fallback local sem credenciais AWS)

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
