### PR TITLE
feat(collector): buscar configuracao da fonte na tabela sources

### DIFF
--- a/.codex/runs/platform_architect-issue-52.md
+++ b/.codex/runs/platform_architect-issue-52.md
@@ -1,0 +1,29 @@
+## Issue #52 — [EPIC 5] Buscar configuração da fonte na tabela sources
+
+### Objetivo
+Garantir que a Lambda coletora carregue a configuração da fonte diretamente da tabela `sources`, valide elegibilidade mínima (`active=true` + schema obrigatório) e gere erro controlado quando a fonte for inválida.
+
+### Decisões arquiteturais
+1. **Validação de configuração no domínio da coletora**
+- Criar um caso de uso dedicado (`loadCollectorSourceConfiguration`) em `src/domain/collector` para centralizar lookup e validação.
+- Manter handler enxuto, apenas orquestrando entrada/saída e delegando regra de negócio ao domínio.
+
+2. **Reuso do repositório já padronizado da tabela `sources`**
+- Reutilizar `createDynamoDbSourceRegistryRepository` para leitura por `sourceId` com `ConsistentRead`.
+- Evitar nova implementação de acesso Dynamo para manter consistência de serialização/validação.
+
+3. **Taxonomia de erros rastreáveis para falhas de fonte**
+- Introduzir erros tipados por cenário:
+  - `CollectorSourceNotFoundError`
+  - `CollectorSourceInactiveError`
+  - `CollectorSourceConfigInvalidError`
+- Mensagens devem incluir `sourceId` para facilitar troubleshooting no Step Functions (`Error`/`Cause`).
+
+4. **Preservação de contrato externo da coletora**
+- Manter payload de saída atual (`sourceId`, `processedAt`, `recordsSent`) para não quebrar estados já integrados na SFN.
+
+### Critérios técnicos de aceite
+- Coletora consulta configuração por `sourceId` na tabela `sources`.
+- Fonte inexistente, inativa ou inválida resulta em erro controlado e rastreável.
+- Campos obrigatórios do schema da fonte são validados antes do processamento.
+- Contrato de retorno da coletora permanece estável para a orquestração.

--- a/.codex/runs/qa-issue-52.md
+++ b/.codex/runs/qa-issue-52.md
@@ -1,0 +1,25 @@
+**QA — Issue #52 (Buscar configuração da fonte na tabela sources)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante no escopo.
+3. Médio: nenhum.
+4. Baixo: `validate:stage-package` depende de credenciais AWS; no ambiente local executou fallback com `build`.
+
+**Checklist de aceite da issue**
+
+- [x] Coletora carrega config por `sourceId` na tabela `sources`.
+- [x] Fontes inválidas geram erro controlado e rastreável.
+- [x] Campos obrigatórios do schema são validados antes da coleta.
+
+**Evidências de validação**
+
+- `npm test -- tests/unit/domain/collector/load-source-configuration.test.ts tests/unit/handlers/collector.test.ts --runInBand` ✅
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local por ausência de credenciais AWS
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-52.md
+++ b/.codex/runs/worker-issue-52.md
@@ -1,0 +1,32 @@
+**Status de execução — Issue #52**
+
+**Escopo implementado**
+
+- Lookup e validação de configuração da fonte para a coletora:
+  - `src/domain/collector/load-source-configuration.ts`
+  - inclusão de caso de uso `loadCollectorSourceConfiguration` com validação do schema obrigatório;
+  - validação explícita de `active=true`;
+  - erros tipados e rastreáveis por cenário (`not found`, `inactive`, `invalid config`).
+- Refactor do handler da coletora para usar dependências injetáveis e leitura da tabela `sources`:
+  - `src/handlers/collector.ts`
+  - adição de `createHandler` para testes;
+  - resolução de dependências default com `SOURCES_TABLE_NAME`;
+  - reuso de `createDynamoDbSourceRegistryRepository` para `getById`;
+  - preservação do contrato de saída (`sourceId`, `processedAt`, `recordsSent`).
+- Testes unitários de domínio e handler cobrindo critérios da issue:
+  - `tests/unit/domain/collector/load-source-configuration.test.ts`
+  - `tests/unit/handlers/collector.test.ts`
+  - cenários: sucesso, `sourceId` vazio, fonte ausente, fonte inativa e configuração inválida.
+
+**Validações executadas**
+
+- `npm test -- tests/unit/domain/collector/load-source-configuration.test.ts tests/unit/handlers/collector.test.ts --runInBand` ✅
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local por ausência de credenciais AWS no ambiente
+
+**Resultado**
+
+Escopo da issue #52 concluído com implementação da leitura/validação de configuração da fonte na coletora e cobertura unitária dos cenários de erro controlado.

--- a/src/domain/collector/load-source-configuration.ts
+++ b/src/domain/collector/load-source-configuration.ts
@@ -1,0 +1,69 @@
+import type { SourceRegistryRecord, SourceRegistryRepository } from '../sources/source-registry-repository';
+import { validateSourceSchemaV1 } from '../sources/source-schema';
+
+export type CollectorSourceConfiguration = SourceRegistryRecord;
+export type CollectorSourceConfigurationRepository = Pick<SourceRegistryRepository, 'getById'>;
+
+export class CollectorSourceNotFoundError extends Error {
+  constructor(sourceId: string) {
+    super(`Source "${sourceId}" was not found in sources registry.`);
+    this.name = 'CollectorSourceNotFoundError';
+  }
+}
+
+export class CollectorSourceInactiveError extends Error {
+  constructor(sourceId: string) {
+    super(`Source "${sourceId}" is inactive and cannot be collected.`);
+    this.name = 'CollectorSourceInactiveError';
+  }
+}
+
+export class CollectorSourceConfigInvalidError extends Error {
+  constructor(sourceId: string, reason: string) {
+    super(`Source "${sourceId}" has invalid configuration: ${reason}`);
+    this.name = 'CollectorSourceConfigInvalidError';
+  }
+}
+
+const formatValidationReason = (
+  errors: Array<{ field: string; message: string }>,
+  maxErrors = 3,
+): string =>
+  errors
+    .slice(0, maxErrors)
+    .map((entry) => `${entry.field}: ${entry.message}`)
+    .join('; ');
+
+export interface LoadCollectorSourceConfigurationParams {
+  sourceId: string;
+  sourceRegistryRepository: CollectorSourceConfigurationRepository;
+}
+
+export const loadCollectorSourceConfiguration = async ({
+  sourceId,
+  sourceRegistryRepository,
+}: LoadCollectorSourceConfigurationParams): Promise<CollectorSourceConfiguration> => {
+  const normalizedSourceId = sourceId.trim();
+  if (normalizedSourceId.length === 0) {
+    throw new Error('sourceId is required for collector execution.');
+  }
+
+  const source = await sourceRegistryRepository.getById(normalizedSourceId);
+  if (!source) {
+    throw new CollectorSourceNotFoundError(normalizedSourceId);
+  }
+
+  if (!source.active) {
+    throw new CollectorSourceInactiveError(normalizedSourceId);
+  }
+
+  const validation = validateSourceSchemaV1(source);
+  if (!validation.success) {
+    throw new CollectorSourceConfigInvalidError(
+      normalizedSourceId,
+      formatValidationReason(validation.errors),
+    );
+  }
+
+  return source;
+};

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -1,3 +1,8 @@
+import {
+  loadCollectorSourceConfiguration,
+  type CollectorSourceConfigurationRepository,
+} from '../domain/collector/load-source-configuration';
+import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
 import { nowIso } from '../shared/time/now-iso';
 
 export interface CollectorEvent {
@@ -14,14 +19,51 @@ export interface CollectorResult {
   recordsSent: number;
 }
 
-export function handler(event: CollectorEvent): Promise<CollectorResult> {
-  if (!event?.sourceId || event.sourceId.trim().length === 0) {
-    throw new Error('sourceId is required for collector execution.');
+export interface CollectorDependencies {
+  sourceRegistryRepository: CollectorSourceConfigurationRepository;
+  now: () => string;
+}
+
+let cachedDefaultDependencies: CollectorDependencies | undefined;
+
+const getDefaultDependencies = (): CollectorDependencies => {
+  if (cachedDefaultDependencies) {
+    return cachedDefaultDependencies;
   }
 
-  return Promise.resolve({
-    sourceId: event.sourceId,
-    processedAt: nowIso(),
-    recordsSent: 0,
-  });
+  const tableName = process.env.SOURCES_TABLE_NAME;
+  if (!tableName || tableName.trim().length === 0) {
+    throw new Error('SOURCES_TABLE_NAME is required.');
+  }
+
+  cachedDefaultDependencies = {
+    sourceRegistryRepository: createDynamoDbSourceRegistryRepository({ tableName }),
+    now: nowIso,
+  };
+
+  return cachedDefaultDependencies;
+};
+
+export const createHandler =
+  ({ sourceRegistryRepository, now }: CollectorDependencies) =>
+  async (event: CollectorEvent): Promise<CollectorResult> => {
+    const sourceId = event?.sourceId?.trim() ?? '';
+    if (sourceId.length === 0) {
+      throw new Error('sourceId is required for collector execution.');
+    }
+
+    await loadCollectorSourceConfiguration({
+      sourceId,
+      sourceRegistryRepository,
+    });
+
+    return {
+      sourceId,
+      processedAt: now(),
+      recordsSent: 0,
+    };
+  };
+
+export async function handler(event: CollectorEvent): Promise<CollectorResult> {
+  return createHandler(getDefaultDependencies())(event);
 }

--- a/tests/unit/domain/collector/load-source-configuration.test.ts
+++ b/tests/unit/domain/collector/load-source-configuration.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  CollectorSourceConfigInvalidError,
+  CollectorSourceInactiveError,
+  CollectorSourceNotFoundError,
+  loadCollectorSourceConfiguration,
+} from '../../../../src/domain/collector/load-source-configuration';
+import type { SourceRegistryRecord } from '../../../../src/domain/sources/source-registry-repository';
+
+const VALID_SOURCE: SourceRegistryRecord = {
+  sourceId: 'source-acme',
+  active: true,
+  engine: 'postgres',
+  secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:acme/source-db',
+  query: 'select * from customers where updated_at > {{cursor}}',
+  cursorField: 'updated_at',
+  fieldMap: {
+    id: 'customer_id',
+    email: 'email',
+  },
+  scheduleType: 'interval',
+  intervalMinutes: 30,
+  nextRunAt: '2026-03-04T10:30:00.000Z',
+  schemaVersion: '1.0.0',
+  createdAt: '2026-03-04T10:00:00.000Z',
+  updatedAt: '2026-03-04T10:00:00.000Z',
+};
+
+class SpySourceRegistryRepository {
+  public readonly getByIdCalls: string[] = [];
+
+  constructor(private readonly storage: Map<string, SourceRegistryRecord>) {}
+
+  getById(sourceId: string): Promise<SourceRegistryRecord | null> {
+    this.getByIdCalls.push(sourceId);
+    return Promise.resolve(this.storage.get(sourceId) ?? null);
+  }
+}
+
+describe('loadCollectorSourceConfiguration', () => {
+  it('returns source configuration when source is active and valid', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([[VALID_SOURCE.sourceId, VALID_SOURCE]]),
+    );
+
+    const result = await loadCollectorSourceConfiguration({
+      sourceId: ' source-acme ',
+      sourceRegistryRepository: repository,
+    });
+
+    expect(result.sourceId).toBe('source-acme');
+    expect(result.active).toBe(true);
+    expect(repository.getByIdCalls).toEqual(['source-acme']);
+  });
+
+  it('throws when sourceId is empty', async () => {
+    const repository = new SpySourceRegistryRepository(new Map());
+
+    await expect(
+      loadCollectorSourceConfiguration({
+        sourceId: ' ',
+        sourceRegistryRepository: repository,
+      }),
+    ).rejects.toThrow('sourceId is required for collector execution.');
+  });
+
+  it('throws controlled error when source does not exist', async () => {
+    const repository = new SpySourceRegistryRepository(new Map());
+
+    await expect(
+      loadCollectorSourceConfiguration({
+        sourceId: 'source-missing',
+        sourceRegistryRepository: repository,
+      }),
+    ).rejects.toBeInstanceOf(CollectorSourceNotFoundError);
+  });
+
+  it('throws controlled error when source is inactive', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([
+        [
+          'source-inactive',
+          {
+            ...VALID_SOURCE,
+            sourceId: 'source-inactive',
+            active: false,
+          },
+        ],
+      ]),
+    );
+
+    await expect(
+      loadCollectorSourceConfiguration({
+        sourceId: 'source-inactive',
+        sourceRegistryRepository: repository,
+      }),
+    ).rejects.toBeInstanceOf(CollectorSourceInactiveError);
+  });
+
+  it('throws controlled error when source config is invalid', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([
+        [
+          'source-invalid',
+          {
+            ...VALID_SOURCE,
+            sourceId: 'source-invalid',
+            query: 'select * from customers',
+          },
+        ],
+      ]),
+    );
+
+    await expect(
+      loadCollectorSourceConfiguration({
+        sourceId: 'source-invalid',
+        sourceRegistryRepository: repository,
+      }),
+    ).rejects.toBeInstanceOf(CollectorSourceConfigInvalidError);
+  });
+});

--- a/tests/unit/handlers/collector.test.ts
+++ b/tests/unit/handlers/collector.test.ts
@@ -1,20 +1,135 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { handler } from '../../../src/handlers/collector';
+import {
+  CollectorSourceConfigInvalidError,
+  CollectorSourceInactiveError,
+  CollectorSourceNotFoundError,
+} from '../../../src/domain/collector/load-source-configuration';
+import type { SourceRegistryRecord } from '../../../src/domain/sources/source-registry-repository';
+import { createHandler } from '../../../src/handlers/collector';
+
+const VALID_SOURCE: SourceRegistryRecord = {
+  sourceId: 'source-acme',
+  active: true,
+  engine: 'postgres',
+  secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:acme/source-db',
+  query: 'select * from customers where updated_at > {{cursor}}',
+  cursorField: 'updated_at',
+  fieldMap: {
+    id: 'customer_id',
+    email: 'email',
+  },
+  scheduleType: 'interval',
+  intervalMinutes: 30,
+  nextRunAt: '2026-03-04T10:30:00.000Z',
+  schemaVersion: '1.0.0',
+  createdAt: '2026-03-04T10:00:00.000Z',
+  updatedAt: '2026-03-04T10:00:00.000Z',
+};
+
+class SpySourceRegistryRepository {
+  public readonly getByIdCalls: string[] = [];
+
+  constructor(private readonly storage: Map<string, SourceRegistryRecord>) {}
+
+  getById(sourceId: string): Promise<SourceRegistryRecord | null> {
+    this.getByIdCalls.push(sourceId);
+    return Promise.resolve(this.storage.get(sourceId) ?? null);
+  }
+}
 
 describe('collector handler', () => {
-  it('returns standardized result for a valid sourceId', async () => {
-    const result = await handler({ sourceId: 'source-acme' });
+  it('loads source config and returns standardized result for a valid sourceId', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([[VALID_SOURCE.sourceId, VALID_SOURCE]]),
+    );
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-04T11:00:00.000Z',
+    });
+
+    const result = await handler({ sourceId: ' source-acme ' });
 
     expect(result.sourceId).toBe('source-acme');
     expect(result.recordsSent).toBe(0);
-    expect(typeof result.processedAt).toBe('string');
-    expect(Number.isNaN(Date.parse(result.processedAt))).toBe(false);
+    expect(result.processedAt).toBe('2026-03-04T11:00:00.000Z');
+    expect(repository.getByIdCalls).toEqual(['source-acme']);
   });
 
-  it('throws when sourceId is missing', () => {
-    expect(() => handler({ sourceId: '' })).toThrow(
+  it('throws when sourceId is missing', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(new Map()),
+      now: () => '2026-03-04T11:00:00.000Z',
+    });
+
+    await expect(handler({ sourceId: '' })).rejects.toThrow(
       'sourceId is required for collector execution.',
+    );
+  });
+
+  it('throws controlled error when source does not exist in sources table', async () => {
+    const handler = createHandler({
+      sourceRegistryRepository: new SpySourceRegistryRepository(new Map()),
+      now: () => '2026-03-04T11:00:00.000Z',
+    });
+
+    await expect(handler({ sourceId: 'source-missing' })).rejects.toBeInstanceOf(
+      CollectorSourceNotFoundError,
+    );
+    await expect(handler({ sourceId: 'source-missing' })).rejects.toThrow(
+      'Source "source-missing" was not found in sources registry.',
+    );
+  });
+
+  it('throws controlled error when source is inactive', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([
+        [
+          'source-inactive',
+          {
+            ...VALID_SOURCE,
+            sourceId: 'source-inactive',
+            active: false,
+          },
+        ],
+      ]),
+    );
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-04T11:00:00.000Z',
+    });
+
+    await expect(handler({ sourceId: 'source-inactive' })).rejects.toBeInstanceOf(
+      CollectorSourceInactiveError,
+    );
+    await expect(handler({ sourceId: 'source-inactive' })).rejects.toThrow(
+      'Source "source-inactive" is inactive and cannot be collected.',
+    );
+  });
+
+  it('throws controlled error when source has invalid required fields', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([
+        [
+          'source-invalid',
+          {
+            ...VALID_SOURCE,
+            sourceId: 'source-invalid',
+            query: 'select * from customers',
+          },
+        ],
+      ]),
+    );
+    const handler = createHandler({
+      sourceRegistryRepository: repository,
+      now: () => '2026-03-04T11:00:00.000Z',
+    });
+
+    await expect(handler({ sourceId: 'source-invalid' })).rejects.toBeInstanceOf(
+      CollectorSourceConfigInvalidError,
+    );
+    await expect(handler({ sourceId: 'source-invalid' })).rejects.toThrow(
+      'Source "source-invalid" has invalid configuration:',
     );
   });
 });


### PR DESCRIPTION
Closes #52

---

## 🎯 Objetivo

Implementar lookup da configuração da fonte na tabela `sources` durante a execução da Lambda coletora, com validação de fonte ativa e tratamento de erro controlado para fonte inexistente/inválida.

---

## 🧠 Decisão Técnica

- Foi criado um caso de uso de domínio (`loadCollectorSourceConfiguration`) para encapsular:
  - leitura por `sourceId`;
  - validação de `active=true`;
  - validação do schema obrigatório da fonte.
- O handler da coletora passou a usar injeção de dependências (`createHandler`) e o repositório DynamoDB já existente (`createDynamoDbSourceRegistryRepository`).
- Erros tipados foram introduzidos para rastreabilidade no fluxo da Step Functions:
  - `CollectorSourceNotFoundError`
  - `CollectorSourceInactiveError`
  - `CollectorSourceConfigInvalidError`
- O contrato de saída da coletora foi preservado (`sourceId`, `processedAt`, `recordsSent`).

---

## 🧪 BDD Validado

Dado que a coletora recebe um `sourceId` válido
Quando a configuração existe e está ativa na tabela `sources`
Então a coletora retorna resultado padronizado e segue o fluxo.

Dado que a fonte não existe, está inativa ou possui configuração inválida
Quando a coletora tenta carregar a configuração
Então ela falha com erro controlado e rastreável.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto