### PR TITLE
feat(collector): implementar fieldMap para modelo canonico (#57)

### DIFF
--- a/.codex/runs/platform_architect-issue-57.md
+++ b/.codex/runs/platform_architect-issue-57.md
@@ -1,0 +1,32 @@
+## Issue #57 — [EPIC 5] Implementar fieldMap para modelo canônico
+
+### Objetivo
+Aplicar `fieldMap` da fonte para transformar registros brutos coletados (colunas de origem) em registros canônicos de cliente, mantendo rastreabilidade de erro e sem afetar o fluxo incremental de cursor.
+
+### Decisões arquiteturais
+1. **Transformação explícita no domínio da coletora**
+- Introduzir módulo dedicado `map-records-with-field-map` no domínio.
+- Contrato: receber `sourceId`, `records` e `fieldMap` (`canonicalField -> sourceColumn`) e retornar registros canônicos.
+
+2. **Separação entre cursor incremental e payload canônico**
+- Manter cálculo de cursor sobre registros coletados (normalizados por driver), usando `cursorField` original da fonte.
+- Aplicar `fieldMap` apenas para composição do payload de saída (`result.records`), evitando regressão no controle de cursor.
+
+3. **Campos obrigatórios e opcionais**
+- Suportar configuração de campos obrigatórios no transformador (lista explícita).
+- No handler inicial, usar regra conservadora: `id` é obrigatório quando presente no `fieldMap`; demais campos mapeados são opcionais.
+- Campo opcional ausente no registro de origem vira `null` no payload canônico.
+
+4. **Tratamento de campos não mapeados**
+- Colunas retornadas pela query sem mapeamento em `fieldMap` são ignoradas no payload canônico.
+- Publicar log estruturado com contagem de colunas ignoradas por execução para rastreabilidade operacional.
+
+5. **Erros de mapeamento rastreáveis**
+- Criar erro de domínio específico com contexto (`sourceId`, `recordIndex`, `canonicalField`, `sourceColumn`, motivo`).
+- Quando campo obrigatório estiver ausente/nulo, falhar com erro determinístico para facilitar diagnóstico e retry.
+
+### Critérios técnicos de aceite
+- Coletora retorna registros no formato canônico baseado em `fieldMap`.
+- Campos não mapeados não vazam no payload final.
+- Falha de mapeamento obrigatório expõe contexto suficiente para troubleshooting.
+- Fluxo de cursor incremental permanece funcional e coberto por testes.

--- a/.codex/runs/qa-issue-57.md
+++ b/.codex/runs/qa-issue-57.md
@@ -1,0 +1,26 @@
+**QA — Issue #57 (Implementar fieldMap para modelo canônico)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante.
+3. Médio: nenhum.
+4. Baixo: `validate:stage-package` executou fallback local esperado por ausência de credenciais AWS no ambiente.
+
+**Checklist de aceite da issue**
+
+- [x] `fieldMap` é aplicado para retorno canônico da coletora.
+- [x] Campos não mapeados são tratados (ignorados no payload final).
+- [x] Erros de mapeamento obrigatório são rastreáveis por contexto.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/domain/collector/map-records-with-field-map.test.ts tests/unit/handlers/collector.test.ts --runInBand` ✅
+- `npm run test -- --runInBand` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local (sem credenciais AWS)
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-57.md
+++ b/.codex/runs/worker-issue-57.md
@@ -1,0 +1,40 @@
+**Status de execução — Issue #57**
+
+**Escopo implementado**
+
+- Transformação `fieldMap` no domínio da coletora:
+  - `src/domain/collector/map-records-with-field-map.ts`
+  - mapeamento `canonicalField -> sourceColumn` para payload canônico;
+  - suporte a campos obrigatórios e opcionais (`null` quando opcional ausente);
+  - erro rastreável `CollectorFieldMapValidationError` com contexto (`sourceId`, `recordIndex`, `canonicalField`, `sourceColumn`).
+- Integração no handler da coletora:
+  - `src/handlers/collector.ts`
+  - aplicação do `fieldMap` após coleta e antes do retorno;
+  - manutenção do cálculo de cursor incremental nos registros coletados brutos (sem regressão de janela);
+  - log estruturado para colunas ignoradas pelo `fieldMap` (exceto `cursorField`).
+- Documentação operacional:
+  - `README.md` atualizado com comportamento do `fieldMap` e regra de obrigatoriedade do `id` quando mapeado.
+
+**Testes adicionados/atualizados**
+
+- `tests/unit/domain/collector/map-records-with-field-map.test.ts`
+  - mapeamento canônico;
+  - tratamento de campo opcional ausente;
+  - erro rastreável para campo obrigatório ausente.
+- `tests/unit/handlers/collector.test.ts`
+  - assert de retorno canônico da coletora (campos mapeados);
+  - cenário de falha por ausência de campo obrigatório `id`.
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/domain/collector/map-records-with-field-map.test.ts tests/unit/handlers/collector.test.ts --runInBand` ✅
+- `npm run test -- --runInBand` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local por ausência de credenciais AWS no ambiente
+
+**Resultado**
+
+Issue #57 concluída com transformação de saída para modelo canônico via `fieldMap`, tratamento explícito de não mapeados e rastreabilidade de erros de mapeamento obrigatório.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
   - `COLLECTOR_DEFAULT_CURSOR` (fallback inicial quando não existe cursor no evento nem na tabela `cursors`).
   - Precedência do cursor de execução: `event.cursor` > `cursors.last` > `COLLECTOR_DEFAULT_CURSOR`.
   - Atualização do cursor após sucesso da coleta com controle otimista por `updatedAt` (evita regressão em concorrência).
+  - Transformação para payload canônico com `fieldMap` (`canonicalField -> sourceColumn`) antes do retorno da coleta.
+  - Colunas de origem sem mapeamento são ignoradas no payload final e podem ser auditadas por log estruturado.
+  - Campo canônico `id` é tratado como obrigatório quando mapeado em `fieldMap`; ausência gera erro rastreável.
   - `COLLECTOR_POSTGRES_POOL_MAX_CONNECTIONS` (default `5`).
   - `COLLECTOR_POSTGRES_POOL_IDLE_TIMEOUT_MS` (default `10000`).
   - `COLLECTOR_POSTGRES_POOL_CONNECTION_TIMEOUT_MS` (default `5000`).

--- a/src/domain/collector/map-records-with-field-map.ts
+++ b/src/domain/collector/map-records-with-field-map.ts
@@ -1,0 +1,100 @@
+import type { CollectorStandardizedRecord, CollectorStandardizedScalar } from './collect-postgres-records';
+
+export interface CollectorFieldMapValidationDetails {
+  sourceId: string;
+  recordIndex: number;
+  canonicalField: string;
+  sourceColumn: string;
+  reason: 'required_field_missing';
+}
+
+export class CollectorFieldMapValidationError extends Error {
+  public readonly details: CollectorFieldMapValidationDetails;
+
+  constructor(details: CollectorFieldMapValidationDetails) {
+    super(
+      `Invalid fieldMap transformation for source "${details.sourceId}" at record index ${details.recordIndex}: canonical field "${details.canonicalField}" from source column "${details.sourceColumn}" is required.`,
+    );
+    this.name = 'CollectorFieldMapValidationError';
+    this.details = details;
+  }
+}
+
+export interface MapRecordsWithFieldMapParams {
+  sourceId: string;
+  records: readonly CollectorStandardizedRecord[];
+  fieldMap: Record<string, string>;
+  requiredCanonicalFields?: readonly string[];
+}
+
+export interface MapRecordsWithFieldMapResult {
+  records: CollectorStandardizedRecord[];
+  ignoredSourceColumns: string[];
+}
+
+const hasValueForRequiredField = (value: CollectorStandardizedScalar | undefined): boolean => {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  return true;
+};
+
+export const mapRecordsWithFieldMap = ({
+  sourceId,
+  records,
+  fieldMap,
+  requiredCanonicalFields = [],
+}: MapRecordsWithFieldMapParams): MapRecordsWithFieldMapResult => {
+  const normalizedSourceId = sourceId.trim();
+  if (normalizedSourceId.length === 0) {
+    throw new Error('sourceId is required for fieldMap transformation.');
+  }
+
+  const requiredFields = new Set(requiredCanonicalFields);
+  const mappings = Object.entries(fieldMap);
+  const mappedSourceColumns = new Set<string>();
+  const ignoredSourceColumns = new Set<string>();
+
+  for (const [, sourceColumn] of mappings) {
+    mappedSourceColumns.add(sourceColumn);
+  }
+
+  const canonicalRecords = records.map((record, recordIndex) => {
+    for (const sourceColumn of Object.keys(record)) {
+      if (!mappedSourceColumns.has(sourceColumn)) {
+        ignoredSourceColumns.add(sourceColumn);
+      }
+    }
+
+    const mappedRecord: CollectorStandardizedRecord = {};
+
+    for (const [canonicalField, sourceColumn] of mappings) {
+      const rawValue = record[sourceColumn];
+      const mappedValue = rawValue === undefined ? null : rawValue;
+
+      if (requiredFields.has(canonicalField) && !hasValueForRequiredField(rawValue)) {
+        throw new CollectorFieldMapValidationError({
+          sourceId: normalizedSourceId,
+          recordIndex,
+          canonicalField,
+          sourceColumn,
+          reason: 'required_field_missing',
+        });
+      }
+
+      mappedRecord[canonicalField] = mappedValue;
+    }
+
+    return mappedRecord;
+  });
+
+  return {
+    records: canonicalRecords,
+    ignoredSourceColumns: [...ignoredSourceColumns],
+  };
+};

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -23,6 +23,7 @@ import {
   loadCollectorSourceConfiguration,
   type CollectorSourceConfigurationRepository,
 } from '../domain/collector/load-source-configuration';
+import { mapRecordsWithFieldMap } from '../domain/collector/map-records-with-field-map';
 import { createMySqlQueryExecutorFactory } from '../infra/collector/mysql-query-executor';
 import { createPostgresQueryExecutorFactory } from '../infra/collector/postgres-query-executor';
 import { createDynamoDbCollectorCursorRepository } from '../infra/cursors/dynamodb-collector-cursor-repository';
@@ -550,6 +551,25 @@ export const createHandler =
       recordsCollected: records.length,
     });
 
+    const requiredCanonicalFields = sourceConfiguration.fieldMap.id ? ['id'] : [];
+    const mappingResult = mapRecordsWithFieldMap({
+      sourceId,
+      records,
+      fieldMap: sourceConfiguration.fieldMap,
+      requiredCanonicalFields,
+    });
+
+    const ignoredSourceColumns = mappingResult.ignoredSourceColumns.filter(
+      (sourceColumn) => sourceColumn !== sourceConfiguration.cursorField,
+    );
+    if (ignoredSourceColumns.length > 0) {
+      logger.info('collector.field_map.ignored_source_columns', {
+        sourceId,
+        ignoredColumns: ignoredSourceColumns,
+        ignoredColumnsCount: ignoredSourceColumns.length,
+      });
+    }
+
     const processedAt = now();
     const candidateCursor = resolveLatestCursorFromRecords({
       records,
@@ -578,7 +598,7 @@ export const createHandler =
       sourceId,
       processedAt,
       recordsSent: records.length,
-      records,
+      records: mappingResult.records,
     };
   };
 

--- a/tests/unit/domain/collector/map-records-with-field-map.test.ts
+++ b/tests/unit/domain/collector/map-records-with-field-map.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  CollectorFieldMapValidationError,
+  mapRecordsWithFieldMap,
+} from '../../../../src/domain/collector/map-records-with-field-map';
+
+describe('mapRecordsWithFieldMap', () => {
+  it('maps source columns into canonical fields and reports ignored columns', () => {
+    const result = mapRecordsWithFieldMap({
+      sourceId: 'source-acme',
+      records: [
+        {
+          customer_id: 123,
+          email_address: 'customer@example.com',
+          updated_at: '2026-03-04T10:00:00.000Z',
+        },
+      ],
+      fieldMap: {
+        id: 'customer_id',
+        email: 'email_address',
+      },
+      requiredCanonicalFields: ['id'],
+    });
+
+    expect(result.records).toEqual([
+      {
+        id: 123,
+        email: 'customer@example.com',
+      },
+    ]);
+    expect(result.ignoredSourceColumns).toEqual(['updated_at']);
+  });
+
+  it('maps optional fields to null when source column is absent', () => {
+    const result = mapRecordsWithFieldMap({
+      sourceId: 'source-acme',
+      records: [
+        {
+          customer_id: 123,
+        },
+      ],
+      fieldMap: {
+        id: 'customer_id',
+        email: 'email_address',
+      },
+      requiredCanonicalFields: ['id'],
+    });
+
+    expect(result.records).toEqual([
+      {
+        id: 123,
+        email: null,
+      },
+    ]);
+  });
+
+  it('throws traceable error when a required canonical field cannot be mapped', () => {
+    expect(() =>
+      mapRecordsWithFieldMap({
+        sourceId: 'source-acme',
+        records: [
+          {
+            email_address: 'missing-id@example.com',
+          },
+        ],
+        fieldMap: {
+          id: 'customer_id',
+          email: 'email_address',
+        },
+        requiredCanonicalFields: ['id'],
+      }),
+    ).toThrow(CollectorFieldMapValidationError);
+
+    try {
+      mapRecordsWithFieldMap({
+        sourceId: 'source-acme',
+        records: [
+          {
+            email_address: 'missing-id@example.com',
+          },
+        ],
+        fieldMap: {
+          id: 'customer_id',
+          email: 'email_address',
+        },
+        requiredCanonicalFields: ['id'],
+      });
+    } catch (error) {
+      const typedError = error as CollectorFieldMapValidationError;
+      expect(typedError.details).toEqual({
+        sourceId: 'source-acme',
+        recordIndex: 0,
+        canonicalField: 'id',
+        sourceColumn: 'customer_id',
+        reason: 'required_field_missing',
+      });
+    }
+  });
+});

--- a/tests/unit/handlers/collector.test.ts
+++ b/tests/unit/handlers/collector.test.ts
@@ -8,6 +8,7 @@ import {
   CollectorSourceInactiveError,
   CollectorSourceNotFoundError,
 } from '../../../src/domain/collector/load-source-configuration';
+import { CollectorFieldMapValidationError } from '../../../src/domain/collector/map-records-with-field-map';
 import {
   CollectorSecretNotFoundError,
   type CollectorSecretRetryPolicy,
@@ -255,14 +256,12 @@ describe('collector handler', () => {
     expect(result.recordsSent).toBe(2);
     expect(result.records).toEqual([
       {
-        customer_id: 10,
+        id: 10,
         email: 'first@example.com',
-        updated_at: '2026-03-04T10:10:00.000Z',
       },
       {
-        customer_id: 11,
+        id: 11,
         email: 'second@example.com',
-        updated_at: '2026-03-04T10:20:00.000Z',
       },
     ]);
 
@@ -362,9 +361,8 @@ describe('collector handler', () => {
     expect(result.recordsSent).toBe(1);
     expect(result.records).toEqual([
       {
-        customer_id: 99,
+        id: 99,
         email: 'mysql@example.com',
-        updated_at: '2026-03-04T10:25:00.000Z',
       },
     ]);
     expect(postgresFactory.createCalls).toEqual([]);
@@ -478,6 +476,60 @@ describe('collector handler', () => {
       },
     ]);
     expect(cursorRepository.saveCalls).toEqual([]);
+  });
+
+  it('fails with traceable error when required field mapping is missing', async () => {
+    const sourceWithRequiredIdMap: SourceRegistryRecord = {
+      ...VALID_SOURCE,
+      sourceId: 'source-required-id',
+      fieldMap: {
+        id: 'customer_id',
+        email: 'email',
+      },
+    };
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([[sourceWithRequiredIdMap.sourceId, sourceWithRequiredIdMap]]),
+    );
+    const secrets = new SpySecretRepository(
+      new Map<string, string | null>([
+        [
+          sourceWithRequiredIdMap.secretArn,
+          JSON.stringify({
+            host: 'db.internal',
+            port: 5432,
+            database: 'crm',
+            username: 'collector_user',
+            password: 'collector_password',
+          }),
+        ],
+      ]),
+    );
+    const postgresFactory = new SpyPostgresQueryExecutorFactory([
+      {
+        email: 'no-id@example.com',
+        updated_at: new Date('2026-03-04T10:10:00.000Z'),
+      },
+    ]);
+
+    const handler = createCollectorHandler({
+      sourceRegistryRepository: repository,
+      secretRepository: secrets,
+      postgresQueryExecutorFactory: postgresFactory,
+    });
+
+    await expect(handler({ sourceId: sourceWithRequiredIdMap.sourceId })).rejects.toBeInstanceOf(
+      CollectorFieldMapValidationError,
+    );
+
+    await expect(handler({ sourceId: sourceWithRequiredIdMap.sourceId })).rejects.toMatchObject({
+      details: {
+        sourceId: sourceWithRequiredIdMap.sourceId,
+        recordIndex: 0,
+        canonicalField: 'id',
+        sourceColumn: 'customer_id',
+        reason: 'required_field_missing',
+      },
+    });
   });
 
   it('throws when sourceId is missing', async () => {


### PR DESCRIPTION
Closes #57

---

## 🎯 Objetivo

Aplicar `fieldMap` da fonte na Lambda coletora para transformar registros brutos em payload canônico de cliente, tratando campos não mapeados e tornando falhas de mapeamento obrigatório rastreáveis.

---

## 🧠 Decisão Técnica

- Criado módulo de domínio dedicado para transformação: `map-records-with-field-map`.
- Mantido cálculo de cursor incremental sobre os registros coletados (sem depender do payload canônico), evitando regressão de janela.
- Definida regra inicial de obrigatoriedade: campo canônico `id` é obrigatório quando presente no `fieldMap`.
- Campos opcionais ausentes são normalizados para `null`.

---

## 🧪 BDD Validado

Dado que uma fonte retorna colunas de banco de origem
Quando a coletora aplica o `fieldMap`
Então o retorno contém apenas campos canônicos mapeados

Dado que um campo obrigatório mapeado (`id`) não existe no registro
Quando a coletora processa o payload
Então uma exceção de mapeamento com contexto (`sourceId`, índice do registro e coluna) é lançada

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [ ] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
