### PR TITLE
feat: validar modelo canônico de cliente na coletora (closes #58)

### DIFF
--- a/.codex/runs/platform_architect-issue-58.md
+++ b/.codex/runs/platform_architect-issue-58.md
@@ -1,0 +1,20 @@
+## Issue #58 — [EPIC 5] Validar modelo canônico Cliente
+
+### Objetivo
+Aplicar validação versionada do modelo canônico de cliente na coletora para separar registros válidos e rejeitados com motivo explícito.
+
+### Decisão arquitetural desta execução
+1. Introduzir componente de domínio dedicado (`validateCanonicalCustomerBatch`) com `schemaVersion` fixo e contrato estável de validação.
+2. Manter transformação por `fieldMap` como etapa anterior e adicionar validação canônica sem interromper execução total por lote parcialmente inválido.
+3. Expor no resultado da coletora apenas registros válidos para próxima etapa de persistência, mantendo rejeições auditáveis no payload/log.
+
+### Evidências técnicas verificadas
+- `src/domain/collector/validate-canonical-customer-batch.ts`
+- `src/handlers/collector.ts`
+- `tests/unit/domain/collector/validate-canonical-customer-batch.test.ts`
+- `tests/unit/handlers/collector.test.ts`
+
+### Critérios técnicos de aceite
+- [x] Schema canônico versionado (`1.0.0`).
+- [x] Registros válidos e inválidos separados com motivo claro.
+- [x] Apenas válidos seguem no resultado processável da coletora.

--- a/.codex/runs/qa-issue-58.md
+++ b/.codex/runs/qa-issue-58.md
@@ -1,0 +1,23 @@
+**QA — Issue #58 (Validação modelo canônico Cliente)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum.
+
+**Checklist de aceite da issue**
+
+- [x] Definido schema canônico versionado.
+- [x] Lote validado com separação de válidos e inválidos.
+- [x] Rejeições retornam motivo explícito por campo/código.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/domain/collector/validate-canonical-customer-batch.test.ts tests/unit/handlers/collector.test.ts --runInBand` ✅
+- `npm run build` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-58.md
+++ b/.codex/runs/worker-issue-58.md
@@ -1,0 +1,19 @@
+**Status de execução — Issue #58**
+
+**Escopo executado**
+
+- Implementada validação canônica versionada para lote de clientes.
+- Integrada validação no handler da coletora com retorno separado entre `records` válidos e `rejectedRecords`.
+- Mantido cursor incremental independente da validade canônica para não travar avanço de janela.
+
+**Verificações executadas**
+
+- `npm ci` ✅
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/domain/collector/validate-canonical-customer-batch.test.ts tests/unit/handlers/collector.test.ts --runInBand` ✅
+- `npm run build` ✅
+
+**Resultado**
+
+Issue #58 implementada com diff funcional e pronta para fechamento via PR com vínculo explícito `Closes #58`.

--- a/src/domain/collector/validate-canonical-customer-batch.ts
+++ b/src/domain/collector/validate-canonical-customer-batch.ts
@@ -1,0 +1,109 @@
+import type { CollectorStandardizedRecord } from './collect-postgres-records';
+
+export const CANONICAL_CUSTOMER_SCHEMA_VERSION = '1.0.0' as const;
+
+export interface CanonicalCustomerValidationIssue {
+  field: string;
+  code: 'REQUIRED' | 'INVALID_TYPE' | 'INVALID_FORMAT';
+  message: string;
+}
+
+export interface CanonicalCustomerRejectedRecord {
+  index: number;
+  record: CollectorStandardizedRecord;
+  issues: CanonicalCustomerValidationIssue[];
+}
+
+export interface CanonicalCustomerBatchValidationResult {
+  schemaVersion: typeof CANONICAL_CUSTOMER_SCHEMA_VERSION;
+  validRecords: CollectorStandardizedRecord[];
+  rejectedRecords: CanonicalCustomerRejectedRecord[];
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const isValidEmail = (value: string): boolean => value.includes('@') && !value.includes(' ');
+
+const validateId = (record: CollectorStandardizedRecord): CanonicalCustomerValidationIssue[] => {
+  const value = record.id;
+  const issues: CanonicalCustomerValidationIssue[] = [];
+
+  if (value === undefined || value === null) {
+    issues.push({
+      field: 'id',
+      code: 'REQUIRED',
+      message: 'id is required in canonical customer record.',
+    });
+    return issues;
+  }
+
+  if (!(isNonEmptyString(value) || isFiniteNumber(value))) {
+    issues.push({
+      field: 'id',
+      code: 'INVALID_TYPE',
+      message: 'id must be a non-empty string or finite number.',
+    });
+  }
+
+  return issues;
+};
+
+const validateEmail = (record: CollectorStandardizedRecord): CanonicalCustomerValidationIssue[] => {
+  const value = record.email;
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (!isNonEmptyString(value)) {
+    return [
+      {
+        field: 'email',
+        code: 'INVALID_TYPE',
+        message: 'email must be a non-empty string when provided.',
+      },
+    ];
+  }
+
+  if (!isValidEmail(value)) {
+    return [
+      {
+        field: 'email',
+        code: 'INVALID_FORMAT',
+        message: 'email must contain "@" and cannot contain spaces.',
+      },
+    ];
+  }
+
+  return [];
+};
+
+export const validateCanonicalCustomerBatch = (
+  records: readonly CollectorStandardizedRecord[],
+): CanonicalCustomerBatchValidationResult => {
+  const validRecords: CollectorStandardizedRecord[] = [];
+  const rejectedRecords: CanonicalCustomerRejectedRecord[] = [];
+
+  records.forEach((record, index) => {
+    const issues = [...validateId(record), ...validateEmail(record)];
+    if (issues.length > 0) {
+      rejectedRecords.push({
+        index,
+        record,
+        issues,
+      });
+      return;
+    }
+
+    validRecords.push(record);
+  });
+
+  return {
+    schemaVersion: CANONICAL_CUSTOMER_SCHEMA_VERSION,
+    validRecords,
+    rejectedRecords,
+  };
+};

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -24,6 +24,10 @@ import {
   type CollectorSourceConfigurationRepository,
 } from '../domain/collector/load-source-configuration';
 import { mapRecordsWithFieldMap } from '../domain/collector/map-records-with-field-map';
+import {
+  validateCanonicalCustomerBatch,
+  type CanonicalCustomerRejectedRecord,
+} from '../domain/collector/validate-canonical-customer-batch';
 import { createMySqlQueryExecutorFactory } from '../infra/collector/mysql-query-executor';
 import { createPostgresQueryExecutorFactory } from '../infra/collector/postgres-query-executor';
 import { createDynamoDbCollectorCursorRepository } from '../infra/cursors/dynamodb-collector-cursor-repository';
@@ -82,6 +86,8 @@ export interface CollectorResult {
   processedAt: string;
   recordsSent: number;
   records: CollectorStandardizedRecord[];
+  schemaVersion: string;
+  rejectedRecords: CanonicalCustomerRejectedRecord[];
 }
 
 export interface CollectorDependencies {
@@ -570,6 +576,19 @@ export const createHandler =
       });
     }
 
+    const canonicalValidationResult = validateCanonicalCustomerBatch(mappingResult.records);
+    if (canonicalValidationResult.rejectedRecords.length > 0) {
+      logger.info('collector.canonical_validation.rejected_records', {
+        sourceId,
+        schemaVersion: canonicalValidationResult.schemaVersion,
+        rejectedRecordsCount: canonicalValidationResult.rejectedRecords.length,
+        rejectedIssues: canonicalValidationResult.rejectedRecords.map((rejectedRecord) => ({
+          index: rejectedRecord.index,
+          issues: rejectedRecord.issues,
+        })),
+      });
+    }
+
     const processedAt = now();
     const candidateCursor = resolveLatestCursorFromRecords({
       records,
@@ -597,8 +616,10 @@ export const createHandler =
     return {
       sourceId,
       processedAt,
-      recordsSent: records.length,
-      records: mappingResult.records,
+      recordsSent: canonicalValidationResult.validRecords.length,
+      records: canonicalValidationResult.validRecords,
+      schemaVersion: canonicalValidationResult.schemaVersion,
+      rejectedRecords: canonicalValidationResult.rejectedRecords,
     };
   };
 

--- a/tests/unit/domain/collector/validate-canonical-customer-batch.test.ts
+++ b/tests/unit/domain/collector/validate-canonical-customer-batch.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { validateCanonicalCustomerBatch } from '../../../../src/domain/collector/validate-canonical-customer-batch';
+
+describe('validateCanonicalCustomerBatch', () => {
+  it('returns versioned schema and keeps only valid canonical records', () => {
+    const result = validateCanonicalCustomerBatch([
+      { id: 1, email: 'valid@example.com' },
+      { id: '2', email: 'also-valid@example.com' },
+    ]);
+
+    expect(result.schemaVersion).toBe('1.0.0');
+    expect(result.validRecords).toEqual([
+      { id: 1, email: 'valid@example.com' },
+      { id: '2', email: 'also-valid@example.com' },
+    ]);
+    expect(result.rejectedRecords).toEqual([]);
+  });
+
+  it('returns explicit rejection reasons for invalid records', () => {
+    const result = validateCanonicalCustomerBatch([
+      { id: null, email: 'valid@example.com' },
+      { id: 2, email: 'invalid email' },
+      { id: true, email: 'x@y.com' },
+    ]);
+
+    expect(result.validRecords).toEqual([]);
+    expect(result.rejectedRecords).toEqual([
+      {
+        index: 0,
+        record: { id: null, email: 'valid@example.com' },
+        issues: [
+          {
+            field: 'id',
+            code: 'REQUIRED',
+            message: 'id is required in canonical customer record.',
+          },
+        ],
+      },
+      {
+        index: 1,
+        record: { id: 2, email: 'invalid email' },
+        issues: [
+          {
+            field: 'email',
+            code: 'INVALID_FORMAT',
+            message: 'email must contain "@" and cannot contain spaces.',
+          },
+        ],
+      },
+      {
+        index: 2,
+        record: { id: true, email: 'x@y.com' },
+        issues: [
+          {
+            field: 'id',
+            code: 'INVALID_TYPE',
+            message: 'id must be a non-empty string or finite number.',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/tests/unit/handlers/collector.test.ts
+++ b/tests/unit/handlers/collector.test.ts
@@ -254,6 +254,8 @@ describe('collector handler', () => {
     expect(result.sourceId).toBe('source-acme');
     expect(result.processedAt).toBe('2026-03-04T11:00:00.000Z');
     expect(result.recordsSent).toBe(2);
+    expect(result.schemaVersion).toBe('1.0.0');
+    expect(result.rejectedRecords).toEqual([]);
     expect(result.records).toEqual([
       {
         id: 10,
@@ -359,6 +361,8 @@ describe('collector handler', () => {
     const result = await handler({ sourceId: VALID_MYSQL_SOURCE.sourceId, cursor: 42 });
 
     expect(result.recordsSent).toBe(1);
+    expect(result.schemaVersion).toBe('1.0.0');
+    expect(result.rejectedRecords).toEqual([]);
     expect(result.records).toEqual([
       {
         id: 99,
@@ -476,6 +480,81 @@ describe('collector handler', () => {
       },
     ]);
     expect(cursorRepository.saveCalls).toEqual([]);
+  });
+
+  it('filters invalid canonical records and keeps explicit rejection reasons', async () => {
+    const sourceWithEmailFieldMap: SourceRegistryRecord = {
+      ...VALID_SOURCE,
+      sourceId: 'source-canonical-validation',
+      fieldMap: {
+        id: 'customer_id',
+        email: 'email',
+      },
+    };
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([
+        [sourceWithEmailFieldMap.sourceId, sourceWithEmailFieldMap],
+      ]),
+    );
+    const secrets = new SpySecretRepository(
+      new Map<string, string | null>([
+        [
+          sourceWithEmailFieldMap.secretArn,
+          JSON.stringify({
+            host: 'db.internal',
+            port: 5432,
+            database: 'crm',
+            username: 'collector_user',
+            password: 'collector_password',
+          }),
+        ],
+      ]),
+    );
+    const postgresFactory = new SpyPostgresQueryExecutorFactory([
+      {
+        customer_id: 41,
+        email: 'valid@example.com',
+        updated_at: new Date('2026-03-04T10:10:00.000Z'),
+      },
+      {
+        customer_id: 42,
+        email: 'invalid email',
+        updated_at: new Date('2026-03-04T10:11:00.000Z'),
+      },
+    ]);
+
+    const handler = createCollectorHandler({
+      sourceRegistryRepository: repository,
+      secretRepository: secrets,
+      postgresQueryExecutorFactory: postgresFactory,
+    });
+
+    const result = await handler({ sourceId: sourceWithEmailFieldMap.sourceId });
+
+    expect(result.schemaVersion).toBe('1.0.0');
+    expect(result.recordsSent).toBe(1);
+    expect(result.records).toEqual([
+      {
+        id: 41,
+        email: 'valid@example.com',
+      },
+    ]);
+    expect(result.rejectedRecords).toEqual([
+      {
+        index: 1,
+        record: {
+          id: 42,
+          email: 'invalid email',
+        },
+        issues: [
+          {
+            field: 'email',
+            code: 'INVALID_FORMAT',
+            message: 'email must contain "@" and cannot contain spaces.',
+          },
+        ],
+      },
+    ]);
   });
 
   it('fails with traceable error when required field mapping is missing', async () => {


### PR DESCRIPTION
Closes #58

## 🎯 Objetivo
Adicionar validação versionada do modelo canônico de cliente na coletora, separando registros válidos e rejeitados com motivo explícito.

## 🧠 Decisão Técnica
Foi criado o domínio `validateCanonicalCustomerBatch` com `schemaVersion` fixo (`1.0.0`) e regras para `id` e `email`. O handler da coletora passou a retornar apenas os registros válidos em `records`, mantendo `rejectedRecords` para auditoria sem interromper o lote inteiro.

## 🧪 BDD Validado
Dado um lote transformado com registros válidos e inválidos
Quando a coletora valida o modelo canônico
Então somente válidos seguem para processamento e rejeições retornam com causas claras

## 🏗 Impacto Arquitetural
- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

## 🔍 Observabilidade
- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
