### PR TITLE
feat: garantir idempotência da coletora no upsert e SNS (closes #61)

### DIFF
--- a/.codex/runs/platform_architect-issue-61.md
+++ b/.codex/runs/platform_architect-issue-61.md
@@ -1,0 +1,22 @@
+## Issue #61 — [EPIC 5] Garantir idempotência da coletora
+
+### Objetivo
+Evitar duplicidade em upsert e publicação SNS durante retries/reexecuções da mesma janela, com rastreabilidade de deduplicação.
+
+### Decisão arquitetural desta execução
+1. Introduzir repositório de idempotência em DynamoDB com claim condicional por chave (`attribute_not_exists`).
+2. Aplicar deduplicação em dois escopos independentes: `upsert` e `event`, usando chave composta por escopo/fonte/cursor/recordId.
+3. Emitir métrica de deduplicação em formato EMF via logs para monitoramento operacional.
+
+### Evidências técnicas verificadas
+- `src/domain/collector/collector-idempotency-repository.ts`
+- `src/infra/idempotency/dynamodb-collector-idempotency-repository.ts`
+- `src/handlers/collector.ts`
+- `serverless.yml`
+- `tests/unit/infra/idempotency/dynamodb-collector-idempotency-repository.test.ts`
+- `tests/unit/handlers/collector.test.ts`
+
+### Critérios técnicos de aceite
+- [x] Reprocessamento da mesma janela não duplica upsert/publicação.
+- [x] Estratégia cobre upsert e evento.
+- [x] Métrica de deduplicação é emitida.

--- a/.codex/runs/qa-issue-61.md
+++ b/.codex/runs/qa-issue-61.md
@@ -1,0 +1,23 @@
+**QA — Issue #61 (Idempotência da coletora)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum.
+
+**Checklist de aceite da issue**
+
+- [x] Reexecução da mesma janela deduplica upsert.
+- [x] Reexecução da mesma janela deduplica publicação SNS.
+- [x] Métrica de deduplicação emitida para observabilidade.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/infra/idempotency/dynamodb-collector-idempotency-repository.test.ts tests/unit/handlers/collector.test.ts --runInBand` ✅
+- `npm run build` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-61.md
+++ b/.codex/runs/worker-issue-61.md
@@ -1,0 +1,19 @@
+**Status de execução — Issue #61**
+
+**Escopo executado**
+
+- Implementada camada de idempotência com DynamoDB para claims de deduplicação.
+- Integrada deduplicação antes do `upsert-batch` e antes da publicação SNS.
+- Adicionada emissão de métrica de deduplicação por escopo (`upsert`/`event`) via EMF.
+- Provisionada tabela de idempotência e permissões IAM mínimas no `serverless.yml`.
+
+**Verificações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/infra/idempotency/dynamodb-collector-idempotency-repository.test.ts tests/unit/handlers/collector.test.ts --runInBand` ✅
+- `npm run build` ✅
+
+**Resultado**
+
+Issue #61 implementada com diff funcional e pronta para fechamento via PR com vínculo explícito `Closes #61`.

--- a/serverless.yml
+++ b/serverless.yml
@@ -22,6 +22,7 @@ provider:
     SERVICE_NAME: ${self:service}
     SOURCES_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.sourcesTableName}
     CURSORS_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.cursorsTableName}
+    IDEMPOTENCY_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.idempotencyTableName}
     MAP_MAX_CONCURRENCY: ${self:custom.stages.${self:provider.stage}.mapMaxConcurrency}
     COLLECTOR_DEFAULT_CURSOR: ${env:COLLECTOR_DEFAULT_CURSOR, '1970-01-01T00:00:00.000Z'}
     COLLECTOR_POSTGRES_POOL_MAX_CONNECTIONS: ${env:COLLECTOR_POSTGRES_POOL_MAX_CONNECTIONS, '5'}
@@ -36,6 +37,7 @@ provider:
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_MAX_ATTEMPTS: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_MAX_ATTEMPTS, '3'}
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS, '200'}
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE, '2'}
+    COLLECTOR_IDEMPOTENCY_TTL_SECONDS: ${env:COLLECTOR_IDEMPOTENCY_TTL_SECONDS, '604800'}
     CLIENT_EVENTS_TOPIC_ARN:
       Ref: ClientEventsTopic
     SALESFORCE_INTEGRATION_QUEUE_URL:
@@ -97,6 +99,7 @@ custom:
       sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_DEV, 'alert-orchestration-service-dev-source-registry-api'}
       sourcesTableName: ${self:service}-dev-sources
       cursorsTableName: ${self:service}-dev-cursors
+      idempotencyTableName: ${self:service}-dev-idempotency
       clientEventsTopicName: ${self:service}-dev-client-events
       salesforceQueueName: ${self:service}-dev-salesforce-events
       hubspotQueueName: ${self:service}-dev-hubspot-events
@@ -116,6 +119,7 @@ custom:
       sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_STG, 'alert-orchestration-service-stg-source-registry-api'}
       sourcesTableName: ${self:service}-stg-sources
       cursorsTableName: ${self:service}-stg-cursors
+      idempotencyTableName: ${self:service}-stg-idempotency
       clientEventsTopicName: ${self:service}-stg-client-events
       salesforceQueueName: ${self:service}-stg-salesforce-events
       hubspotQueueName: ${self:service}-stg-hubspot-events
@@ -135,6 +139,7 @@ custom:
       sourceRegistryJwtAudience: ${env:SOURCE_REGISTRY_JWT_AUDIENCE_PROD, 'alert-orchestration-service-prod-source-registry-api'}
       sourcesTableName: ${self:service}-prod-sources
       cursorsTableName: ${self:service}-prod-cursors
+      idempotencyTableName: ${self:service}-prod-idempotency
       clientEventsTopicName: ${self:service}-prod-client-events
       salesforceQueueName: ${self:service}-prod-salesforce-events
       hubspotQueueName: ${self:service}-prod-hubspot-events
@@ -439,6 +444,14 @@ resources:
                     - Fn::GetAtt:
                         - CursorsTable
                         - Arn
+                - Sid: WriteIdempotencyClaims
+                  Effect: Allow
+                  Action:
+                    - dynamodb:PutItem
+                  Resource:
+                    - Fn::GetAtt:
+                        - IdempotencyTable
+                        - Arn
                 - Sid: PublishClientEvents
                   Effect: Allow
                   Action:
@@ -585,6 +598,22 @@ resources:
         KeySchema:
           - AttributeName: source
             KeyType: HASH
+        SSESpecification:
+          SSEEnabled: true
+    IdempotencyTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.stages.${self:provider.stage}.idempotencyTableName}
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: deduplicationKey
+            AttributeType: S
+        KeySchema:
+          - AttributeName: deduplicationKey
+            KeyType: HASH
+        TimeToLiveSpecification:
+          AttributeName: expiresAt
+          Enabled: true
         SSESpecification:
           SSEEnabled: true
     ClientEventsTopic:

--- a/src/domain/collector/collector-idempotency-repository.ts
+++ b/src/domain/collector/collector-idempotency-repository.ts
@@ -1,0 +1,16 @@
+export type CollectorIdempotencyScope = 'upsert' | 'event';
+
+export interface CollectorIdempotencyClaim {
+  deduplicationKey: string;
+  scope: CollectorIdempotencyScope;
+  sourceId: string;
+  recordId: string;
+  cursor: string;
+  correlationId: string;
+  createdAt: string;
+  expiresAtEpochSeconds: number;
+}
+
+export interface CollectorIdempotencyRepository {
+  tryClaim(claim: CollectorIdempotencyClaim): Promise<boolean>;
+}

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -13,6 +13,10 @@ import {
   type CollectorCursorRepository,
   type CollectorCursorValue,
 } from '../domain/collector/collector-cursor-repository';
+import type {
+  CollectorIdempotencyRepository,
+  CollectorIdempotencyScope,
+} from '../domain/collector/collector-idempotency-repository';
 import {
   loadCollectorSourceCredentials,
   type CollectorSecretRepository,
@@ -37,6 +41,7 @@ import {
 import { createMySqlQueryExecutorFactory } from '../infra/collector/mysql-query-executor';
 import { createPostgresQueryExecutorFactory } from '../infra/collector/postgres-query-executor';
 import { createDynamoDbCollectorCursorRepository } from '../infra/cursors/dynamodb-collector-cursor-repository';
+import { createDynamoDbCollectorIdempotencyRepository } from '../infra/idempotency/dynamodb-collector-idempotency-repository';
 import { createSecretsManagerSecretRepository } from '../infra/secrets/secrets-manager-secret-repository';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
 import { createSnsCustomerEventsPublisher, type CustomerEventsPublisher } from '../infra/events/sns-customer-events-publisher';
@@ -87,6 +92,9 @@ const OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS_MAX = 5_000;
 const OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE_DEFAULT = 2;
 const OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE_MIN = 1;
 const OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE_MAX = 5;
+const COLLECTOR_IDEMPOTENCY_TTL_SECONDS_DEFAULT = 604_800;
+const COLLECTOR_IDEMPOTENCY_TTL_SECONDS_MIN = 60;
+const COLLECTOR_IDEMPOTENCY_TTL_SECONDS_MAX = 2_592_000;
 
 type PostgresQueryExecutorFactory = (credentials: CollectorSourceCredentials) => PostgresQueryExecutor;
 type MySqlQueryExecutorFactory = (credentials: CollectorSourceCredentials) => MySqlQueryExecutor;
@@ -110,6 +118,8 @@ export interface CollectorResult {
   persistenceRejectedRecords: UpsertCustomersBatchRejectedRecord[];
   upsertAttempts: number;
   eventsPublished: number;
+  deduplicatedUpsertRecords: number;
+  deduplicatedEventRecords: number;
 }
 
 export interface CollectorDependencies {
@@ -125,6 +135,8 @@ export interface CollectorDependencies {
   sleep: (delayMs: number) => Promise<void>;
   upsertCustomersBatchClient: UpsertCustomersBatchClient;
   customerEventsPublisher: CustomerEventsPublisher;
+  idempotencyRepository: CollectorIdempotencyRepository;
+  idempotencyTtlSeconds: number;
   logger: Pick<typeof console, 'info'>;
 }
 
@@ -326,6 +338,15 @@ const resolveOfficialCustomersUpsertRetryBackoffRate = (rawValue: string | undef
   return parsed;
 };
 
+const resolveCollectorIdempotencyTtlSeconds = (rawValue: string | undefined): number =>
+  resolveBoundedIntegerFromEnv({
+    rawValue,
+    envName: 'COLLECTOR_IDEMPOTENCY_TTL_SECONDS',
+    min: COLLECTOR_IDEMPOTENCY_TTL_SECONDS_MIN,
+    max: COLLECTOR_IDEMPOTENCY_TTL_SECONDS_MAX,
+    fallback: COLLECTOR_IDEMPOTENCY_TTL_SECONDS_DEFAULT,
+  });
+
 const resolveCursorValue = (
   eventCursor: CollectorEvent['cursor'],
   persistedCursor: CollectorCursorValue | undefined,
@@ -515,6 +536,28 @@ const createFetchUpsertCustomersBatchHttpClient = (): UpsertCustomersBatchHttpCl
   };
 };
 
+const normalizeRecordId = (record: CollectorStandardizedRecord): string => {
+  if (record.id === undefined || record.id === null) {
+    return '';
+  }
+
+  return String(record.id).trim();
+};
+
+const normalizeCursorToken = (cursor: CollectorCursorValue): string => String(cursor).trim();
+
+const buildDeduplicationKey = ({
+  scope,
+  sourceId,
+  recordId,
+  cursorToken,
+}: {
+  scope: CollectorIdempotencyScope;
+  sourceId: string;
+  recordId: string;
+  cursorToken: string;
+}): string => `${scope}:${sourceId}:${cursorToken}:${recordId}`;
+
 const getDefaultDependencies = (): CollectorDependencies => {
   if (cachedDefaultDependencies) {
     return cachedDefaultDependencies;
@@ -538,6 +581,11 @@ const getDefaultDependencies = (): CollectorDependencies => {
   const customerEventsTopicArn = process.env.CLIENT_EVENTS_TOPIC_ARN;
   if (!customerEventsTopicArn || customerEventsTopicArn.trim().length === 0) {
     throw new Error('CLIENT_EVENTS_TOPIC_ARN is required.');
+  }
+
+  const idempotencyTableName = process.env.IDEMPOTENCY_TABLE_NAME;
+  if (!idempotencyTableName || idempotencyTableName.trim().length === 0) {
+    throw new Error('IDEMPOTENCY_TABLE_NAME is required.');
   }
 
   cachedDefaultDependencies = {
@@ -597,6 +645,12 @@ const getDefaultDependencies = (): CollectorDependencies => {
     customerEventsPublisher: createSnsCustomerEventsPublisher({
       topicArn: customerEventsTopicArn,
     }),
+    idempotencyRepository: createDynamoDbCollectorIdempotencyRepository({
+      tableName: idempotencyTableName,
+    }),
+    idempotencyTtlSeconds: resolveCollectorIdempotencyTtlSeconds(
+      process.env.COLLECTOR_IDEMPOTENCY_TTL_SECONDS,
+    ),
     logger: console,
   };
 
@@ -617,6 +671,8 @@ export const createHandler =
     sleep,
     upsertCustomersBatchClient,
     customerEventsPublisher,
+    idempotencyRepository,
+    idempotencyTtlSeconds,
     logger,
   }: CollectorDependencies) =>
   async (event: CollectorEvent): Promise<CollectorResult> => {
@@ -723,10 +779,68 @@ export const createHandler =
       event?.meta?.executionId?.trim() ??
       `${sourceId}-${event?.meta?.stage ?? 'unknown'}-${sourceConfiguration.cursorField}`;
 
+    const cursorToken = normalizeCursorToken(cursor);
+    const claimCreatedAt = now();
+    const claimExpiration = Math.floor(nowMs() / 1000) + idempotencyTtlSeconds;
+
+    const nonDuplicatedUpsertRecords: CollectorStandardizedRecord[] = [];
+    const duplicatedUpsertRecords: CollectorStandardizedRecord[] = [];
+    for (const record of canonicalValidationResult.validRecords) {
+      const recordId = normalizeRecordId(record);
+      if (recordId.length === 0) {
+        duplicatedUpsertRecords.push(record);
+        continue;
+      }
+
+      const claimed = await idempotencyRepository.tryClaim({
+        deduplicationKey: buildDeduplicationKey({
+          scope: 'upsert',
+          sourceId,
+          recordId,
+          cursorToken,
+        }),
+        scope: 'upsert',
+        sourceId,
+        recordId,
+        cursor: cursorToken,
+        correlationId,
+        createdAt: claimCreatedAt,
+        expiresAtEpochSeconds: claimExpiration,
+      });
+
+      if (claimed) {
+        nonDuplicatedUpsertRecords.push(record);
+      } else {
+        duplicatedUpsertRecords.push(record);
+      }
+    }
+    if (duplicatedUpsertRecords.length > 0) {
+      logger.info('collector.idempotency.upsert_deduplicated', {
+        sourceId,
+        correlationId,
+        deduplicatedCount: duplicatedUpsertRecords.length,
+      });
+      logger.info('collector.idempotency.metric', {
+        _aws: {
+          Timestamp: nowMs(),
+          CloudWatchMetrics: [
+            {
+              Namespace: 'AlertOrchestrationService/Collector',
+              Dimensions: [['Stage', 'Scope']],
+              Metrics: [{ Name: 'DeduplicatedRecords', Unit: 'Count' }],
+            },
+          ],
+        },
+        Stage: event?.meta?.stage ?? process.env.STAGE ?? 'unknown',
+        Scope: 'upsert',
+        DeduplicatedRecords: duplicatedUpsertRecords.length,
+      });
+    }
+
     const upsertResult = await upsertCustomersBatchClient({
       sourceId,
       correlationId,
-      records: canonicalValidationResult.validRecords,
+      records: nonDuplicatedUpsertRecords,
     });
     if (upsertResult.rejectedRecords.length > 0) {
       logger.info('collector.official_api.partial_rejection', {
@@ -738,10 +852,64 @@ export const createHandler =
     }
 
     const processedAt = now();
+    const nonDuplicatedEventRecords: CollectorStandardizedRecord[] = [];
+    const duplicatedEventRecords: CollectorStandardizedRecord[] = [];
+    for (const record of upsertResult.persistedRecords) {
+      const recordId = normalizeRecordId(record);
+      if (recordId.length === 0) {
+        duplicatedEventRecords.push(record);
+        continue;
+      }
+
+      const claimed = await idempotencyRepository.tryClaim({
+        deduplicationKey: buildDeduplicationKey({
+          scope: 'event',
+          sourceId,
+          recordId,
+          cursorToken,
+        }),
+        scope: 'event',
+        sourceId,
+        recordId,
+        cursor: cursorToken,
+        correlationId,
+        createdAt: claimCreatedAt,
+        expiresAtEpochSeconds: claimExpiration,
+      });
+
+      if (claimed) {
+        nonDuplicatedEventRecords.push(record);
+      } else {
+        duplicatedEventRecords.push(record);
+      }
+    }
+    if (duplicatedEventRecords.length > 0) {
+      logger.info('collector.idempotency.event_deduplicated', {
+        sourceId,
+        correlationId,
+        deduplicatedCount: duplicatedEventRecords.length,
+      });
+      logger.info('collector.idempotency.metric', {
+        _aws: {
+          Timestamp: nowMs(),
+          CloudWatchMetrics: [
+            {
+              Namespace: 'AlertOrchestrationService/Collector',
+              Dimensions: [['Stage', 'Scope']],
+              Metrics: [{ Name: 'DeduplicatedRecords', Unit: 'Count' }],
+            },
+          ],
+        },
+        Stage: event?.meta?.stage ?? process.env.STAGE ?? 'unknown',
+        Scope: 'event',
+        DeduplicatedRecords: duplicatedEventRecords.length,
+      });
+    }
+
     const publishResult = await customerEventsPublisher({
       sourceId,
       correlationId,
-      records: upsertResult.persistedRecords,
+      records: nonDuplicatedEventRecords,
       publishedAt: processedAt,
     });
     if (publishResult.publishedCount > 0) {
@@ -785,6 +953,8 @@ export const createHandler =
       persistenceRejectedRecords: upsertResult.rejectedRecords,
       upsertAttempts: upsertResult.attempts,
       eventsPublished: publishResult.publishedCount,
+      deduplicatedUpsertRecords: duplicatedUpsertRecords.length,
+      deduplicatedEventRecords: duplicatedEventRecords.length,
     };
   };
 

--- a/src/infra/idempotency/dynamodb-collector-idempotency-repository.ts
+++ b/src/infra/idempotency/dynamodb-collector-idempotency-repository.ts
@@ -1,0 +1,82 @@
+import {
+  ConditionalCheckFailedException,
+  DynamoDBClient,
+  PutItemCommand,
+} from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+
+import type {
+  CollectorIdempotencyClaim,
+  CollectorIdempotencyRepository,
+} from '../../domain/collector/collector-idempotency-repository';
+
+export interface DynamoDbCollectorIdempotencyRepositoryParams {
+  tableName: string;
+  client?: DynamoDBClient;
+}
+
+const isConditionalCheckFailed = (error: unknown): boolean => {
+  if (error instanceof ConditionalCheckFailedException) {
+    return true;
+  }
+
+  if (typeof error === 'object' && error !== null && 'name' in error) {
+    return error.name === 'ConditionalCheckFailedException';
+  }
+
+  return false;
+};
+
+export const createDynamoDbCollectorIdempotencyRepository = ({
+  tableName,
+  client = new DynamoDBClient({}),
+}: DynamoDbCollectorIdempotencyRepositoryParams): CollectorIdempotencyRepository => {
+  const resolvedTableName = tableName.trim();
+  if (resolvedTableName.length === 0) {
+    throw new Error('tableName is required for collector idempotency repository.');
+  }
+
+  return {
+    async tryClaim(claim: CollectorIdempotencyClaim): Promise<boolean> {
+      const deduplicationKey = claim.deduplicationKey.trim();
+      if (deduplicationKey.length === 0) {
+        throw new Error('deduplicationKey is required for idempotency claim.');
+      }
+
+      const createdAt = claim.createdAt.trim();
+      if (createdAt.length === 0) {
+        throw new Error('createdAt is required for idempotency claim.');
+      }
+
+      try {
+        await client.send(
+          new PutItemCommand({
+            TableName: resolvedTableName,
+            Item: marshall({
+              deduplicationKey,
+              scope: claim.scope,
+              sourceId: claim.sourceId,
+              recordId: claim.recordId,
+              cursor: claim.cursor,
+              correlationId: claim.correlationId,
+              createdAt,
+              expiresAt: claim.expiresAtEpochSeconds,
+            }),
+            ConditionExpression: 'attribute_not_exists(#deduplicationKey)',
+            ExpressionAttributeNames: {
+              '#deduplicationKey': 'deduplicationKey',
+            },
+          }),
+        );
+      } catch (error) {
+        if (isConditionalCheckFailed(error)) {
+          return false;
+        }
+
+        throw error;
+      }
+
+      return true;
+    },
+  };
+};

--- a/tests/unit/handlers/collector.test.ts
+++ b/tests/unit/handlers/collector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
+import type { CollectorIdempotencyClaim } from '../../../src/domain/collector/collector-idempotency-repository';
 import type { CollectorCursorValue } from '../../../src/domain/collector/collector-cursor-repository';
 import type { CollectorStandardizedRecord } from '../../../src/domain/collector/collect-postgres-records';
 import type { MySqlQueryExecutor } from '../../../src/domain/collector/collect-mysql-records';
@@ -233,6 +234,26 @@ class SpyCustomerEventsPublisher {
   };
 }
 
+class SpyCollectorIdempotencyRepository {
+  public readonly tryClaimCalls: CollectorIdempotencyClaim[] = [];
+  private readonly claimedKeys = new Set<string>();
+
+  constructor(private readonly forcedDuplicateKeys: Set<string> = new Set()) {}
+
+  tryClaim = (claim: CollectorIdempotencyClaim): Promise<boolean> => {
+    this.tryClaimCalls.push(claim);
+    if (
+      this.forcedDuplicateKeys.has(claim.deduplicationKey) ||
+      this.claimedKeys.has(claim.deduplicationKey)
+    ) {
+      return Promise.resolve(false);
+    }
+
+    this.claimedKeys.add(claim.deduplicationKey);
+    return Promise.resolve(true);
+  };
+}
+
 const DEFAULT_SECRET_RETRY_POLICY: CollectorSecretRetryPolicy = {
   maxAttempts: 3,
   baseDelayMs: 10,
@@ -247,6 +268,7 @@ const createCollectorHandler = ({
   mySqlQueryExecutorFactory = new SpyMySqlQueryExecutorFactory([]),
   upsertCustomersBatchClient = new SpyUpsertCustomersBatchClient(),
   customerEventsPublisher = new SpyCustomerEventsPublisher(),
+  idempotencyRepository = new SpyCollectorIdempotencyRepository(),
   logger,
 }: {
   sourceRegistryRepository: SpySourceRegistryRepository;
@@ -256,6 +278,7 @@ const createCollectorHandler = ({
   mySqlQueryExecutorFactory?: SpyMySqlQueryExecutorFactory;
   upsertCustomersBatchClient?: SpyUpsertCustomersBatchClient;
   customerEventsPublisher?: SpyCustomerEventsPublisher;
+  idempotencyRepository?: SpyCollectorIdempotencyRepository;
   logger?: SpyLogger;
 }) => {
   let nowMsCalls = 0;
@@ -275,6 +298,8 @@ const createCollectorHandler = ({
     sleep: () => Promise.resolve(),
     upsertCustomersBatchClient: upsertCustomersBatchClient.invoke,
     customerEventsPublisher: customerEventsPublisher.publish,
+    idempotencyRepository,
+    idempotencyTtlSeconds: 3600,
     logger: logger ?? new SpyLogger(),
   };
 
@@ -344,6 +369,8 @@ describe('collector handler', () => {
     expect(result.persistenceRejectedRecords).toEqual([]);
     expect(result.upsertAttempts).toBe(1);
     expect(result.eventsPublished).toBe(2);
+    expect(result.deduplicatedUpsertRecords).toBe(0);
+    expect(result.deduplicatedEventRecords).toBe(0);
     expect(result.records).toEqual([
       {
         id: 10,
@@ -462,6 +489,8 @@ describe('collector handler', () => {
     expect(result.persistenceRejectedRecords).toEqual([]);
     expect(result.upsertAttempts).toBe(1);
     expect(result.eventsPublished).toBe(1);
+    expect(result.deduplicatedUpsertRecords).toBe(0);
+    expect(result.deduplicatedEventRecords).toBe(0);
     expect(result.records).toEqual([
       {
         id: 99,
@@ -645,6 +674,8 @@ describe('collector handler', () => {
     expect(result.persistenceRejectedRecords).toEqual([]);
     expect(result.upsertAttempts).toBe(1);
     expect(result.eventsPublished).toBe(1);
+    expect(result.deduplicatedUpsertRecords).toBe(0);
+    expect(result.deduplicatedEventRecords).toBe(0);
     expect(result.rejectedRecords).toEqual([
       {
         index: 1,
@@ -739,6 +770,8 @@ describe('collector handler', () => {
     ]);
     expect(result.upsertAttempts).toBe(2);
     expect(result.eventsPublished).toBe(1);
+    expect(result.deduplicatedUpsertRecords).toBe(0);
+    expect(result.deduplicatedEventRecords).toBe(0);
     expect(upsertClient.calls).toEqual([
       {
         sourceId: VALID_SOURCE.sourceId,
@@ -749,6 +782,90 @@ describe('collector handler', () => {
         ],
       },
     ]);
+  });
+
+  it('deduplicates upsert and publish operations for repeated records in the same window', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([[VALID_SOURCE.sourceId, VALID_SOURCE]]),
+    );
+    const secrets = new SpySecretRepository(
+      new Map<string, string | null>([
+        [
+          VALID_SOURCE.secretArn,
+          JSON.stringify({
+            host: 'db.internal',
+            port: 5432,
+            database: 'crm',
+            username: 'collector_user',
+            password: 'collector_password',
+          }),
+        ],
+      ]),
+    );
+    const postgresFactory = new SpyPostgresQueryExecutorFactory([
+      {
+        customer_id: 10,
+        email: 'first@example.com',
+        updated_at: new Date('2026-03-04T10:10:00.000Z'),
+      },
+      {
+        customer_id: 11,
+        email: 'second@example.com',
+        updated_at: new Date('2026-03-04T10:20:00.000Z'),
+      },
+    ]);
+    const cursorToken = '2026-03-01T00:00:00.000Z';
+    const forcedDuplicateKeys = new Set<string>([
+      `upsert:${VALID_SOURCE.sourceId}:${cursorToken}:11`,
+      `event:${VALID_SOURCE.sourceId}:${cursorToken}:10`,
+    ]);
+    const idempotencyRepository = new SpyCollectorIdempotencyRepository(forcedDuplicateKeys);
+    const upsertClient = new SpyUpsertCustomersBatchClient();
+    const eventsPublisher = new SpyCustomerEventsPublisher();
+    const logger = new SpyLogger();
+
+    const handler = createCollectorHandler({
+      sourceRegistryRepository: repository,
+      secretRepository: secrets,
+      postgresQueryExecutorFactory: postgresFactory,
+      idempotencyRepository,
+      upsertCustomersBatchClient: upsertClient,
+      customerEventsPublisher: eventsPublisher,
+      logger,
+    });
+
+    const result = await handler({ sourceId: VALID_SOURCE.sourceId, meta: { stage: 'dev' } });
+
+    expect(result.recordsSent).toBe(1);
+    expect(result.records).toEqual([{ id: 10, email: 'first@example.com' }]);
+    expect(result.eventsPublished).toBe(0);
+    expect(result.deduplicatedUpsertRecords).toBe(1);
+    expect(result.deduplicatedEventRecords).toBe(1);
+    expect(upsertClient.calls).toEqual([
+      {
+        sourceId: VALID_SOURCE.sourceId,
+        correlationId: `${VALID_SOURCE.sourceId}-dev-${VALID_SOURCE.cursorField}`,
+        records: [{ id: 10, email: 'first@example.com' }],
+      },
+    ]);
+    expect(eventsPublisher.calls).toEqual([
+      {
+        sourceId: VALID_SOURCE.sourceId,
+        correlationId: `${VALID_SOURCE.sourceId}-dev-${VALID_SOURCE.cursorField}`,
+        records: [],
+        publishedAt: '2026-03-04T11:00:00.000Z',
+      },
+    ]);
+    expect(
+      logger.infoCalls.some(
+        ([eventName]) => eventName === 'collector.idempotency.upsert_deduplicated',
+      ),
+    ).toBe(true);
+    expect(
+      logger.infoCalls.some(
+        ([eventName]) => eventName === 'collector.idempotency.event_deduplicated',
+      ),
+    ).toBe(true);
   });
 
   it('fails with traceable error when required field mapping is missing', async () => {

--- a/tests/unit/infra/idempotency/dynamodb-collector-idempotency-repository.test.ts
+++ b/tests/unit/infra/idempotency/dynamodb-collector-idempotency-repository.test.ts
@@ -1,0 +1,70 @@
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import { describe, expect, it } from '@jest/globals';
+
+import { createDynamoDbCollectorIdempotencyRepository } from '../../../../src/infra/idempotency/dynamodb-collector-idempotency-repository';
+
+class SpyDynamoDbClient {
+  public readonly sendCalls: unknown[] = [];
+
+  constructor(private readonly behavior: 'success' | 'conditional-failed' = 'success') {}
+
+  send(command: unknown): Promise<void> {
+    this.sendCalls.push(command);
+    if (this.behavior === 'conditional-failed') {
+      return Promise.reject(
+        new ConditionalCheckFailedException({
+          $metadata: {},
+          message: 'conditional failed',
+        }),
+      );
+    }
+
+    return Promise.resolve();
+  }
+}
+
+describe('createDynamoDbCollectorIdempotencyRepository', () => {
+  it('claims a deduplication key when it does not exist yet', async () => {
+    const client = new SpyDynamoDbClient('success');
+    const repository = createDynamoDbCollectorIdempotencyRepository({
+      tableName: 'idempotency-table',
+      client: client as never,
+    });
+
+    const result = await repository.tryClaim({
+      deduplicationKey: 'upsert:source:cursor:1',
+      scope: 'upsert',
+      sourceId: 'source',
+      recordId: '1',
+      cursor: 'cursor',
+      correlationId: 'exec-1',
+      createdAt: '2026-03-04T10:00:00.000Z',
+      expiresAtEpochSeconds: 1_776_000_000,
+    });
+
+    expect(result).toBe(true);
+    expect(client.sendCalls).toHaveLength(1);
+  });
+
+  it('returns false when key was already claimed', async () => {
+    const client = new SpyDynamoDbClient('conditional-failed');
+    const repository = createDynamoDbCollectorIdempotencyRepository({
+      tableName: 'idempotency-table',
+      client: client as never,
+    });
+
+    const result = await repository.tryClaim({
+      deduplicationKey: 'upsert:source:cursor:1',
+      scope: 'upsert',
+      sourceId: 'source',
+      recordId: '1',
+      cursor: 'cursor',
+      correlationId: 'exec-1',
+      createdAt: '2026-03-04T10:00:00.000Z',
+      expiresAtEpochSeconds: 1_776_000_000,
+    });
+
+    expect(result).toBe(false);
+    expect(client.sendCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #61

## 🎯 Objetivo
Garantir idempotência no fluxo da coletora para evitar duplicidade de upsert e publicação SNS em cenários de retry/reexecução da mesma janela.

## 🧠 Decisão Técnica
Foi introduzido um repositório de idempotência em DynamoDB com claims condicionais por chave (`scope:source:cursor:recordId`). A coletora agora deduplica antes do `upsert-batch` e antes da publicação SNS. Quando há deduplicação, emite métrica via EMF no namespace `AlertOrchestrationService/Collector`.

## 🧪 BDD Validado
Dado um reprocessamento da mesma janela
Quando a coletora tenta persistir/publicar novamente
Então registros já processados são deduplicados e a métrica de deduplicação é emitida

## 🏗 Impacto Arquitetural
- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

## 🔍 Observabilidade
- [x] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
