### PR TITLE
feat: implementar consumo SQS em lote nas consumidoras (closes #63)

### DIFF
--- a/.codex/runs/platform_architect-issue-63.md
+++ b/.codex/runs/platform_architect-issue-63.md
@@ -1,0 +1,20 @@
+## Issue #63 — [EPIC 6] Implementar consumo SQS nas consumidoras
+
+### Objetivo
+Implementar parser de eventos SQS em lote com validação mínima de schema e retorno granular de `batchItemFailures`.
+
+### Decisão arquitetural desta execução
+1. Evoluir o template compartilhado das consumidoras para parsear payload JSON e validar contrato mínimo do evento (`eventType`, `sourceId`, `correlationId`, `publishedAt`, `customer`).
+2. Processar lote com isolamento por mensagem, marcando apenas itens inválidos em `batchItemFailures`.
+3. Preservar compatibilidade com as consumidoras dedicadas criadas na issue #62.
+
+### Evidências técnicas verificadas
+- `src/handlers/shared/create-integration-consumer-handler.ts`
+- `tests/unit/handlers/shared/create-integration-consumer-handler.test.ts`
+- `tests/unit/handlers/salesforce-consumer.test.ts`
+- `tests/unit/handlers/hubspot-consumer.test.ts`
+
+### Critérios técnicos de aceite
+- [x] Parser de evento SQS em lote implementado.
+- [x] `batchItemFailures` retornado por item inválido.
+- [x] Validação de schema mínimo aplicada sem abortar lote completo.

--- a/.codex/runs/qa-issue-63.md
+++ b/.codex/runs/qa-issue-63.md
@@ -1,0 +1,23 @@
+**QA — Issue #63 (Consumo SQS nas consumidoras)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum.
+
+**Checklist de aceite da issue**
+
+- [x] Parse de lote SQS implementado.
+- [x] Falhas pontuais retornam somente itens inválidos.
+- [x] Mensagens válidas seguem processamento sem perda por erro parcial.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/handlers/shared/create-integration-consumer-handler.test.ts tests/unit/handlers/salesforce-consumer.test.ts tests/unit/handlers/hubspot-consumer.test.ts --runInBand` ✅
+- `npm run build` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-63.md
+++ b/.codex/runs/worker-issue-63.md
@@ -1,0 +1,18 @@
+**Status de execução — Issue #63**
+
+**Escopo executado**
+
+- Implementado parser do payload de mensagens SQS em lote no template compartilhado das consumidoras.
+- Adicionada validação de schema mínimo e tratamento parcial de falhas por mensagem.
+- Ajustadas suítes de testes para cobrir cenários válidos e inválidos com `batchItemFailures`.
+
+**Verificações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/handlers/shared/create-integration-consumer-handler.test.ts tests/unit/handlers/salesforce-consumer.test.ts tests/unit/handlers/hubspot-consumer.test.ts --runInBand` ✅
+- `npm run build` ✅
+
+**Resultado**
+
+Issue #63 implementada com diff funcional e pronta para fechamento via PR com vínculo explícito `Closes #63`.

--- a/src/handlers/shared/create-integration-consumer-handler.ts
+++ b/src/handlers/shared/create-integration-consumer-handler.ts
@@ -16,12 +16,76 @@ export interface IntegrationConsumerSqsResult {
 export interface CreateIntegrationConsumerHandlerParams {
   integrationName: string;
   targetBaseUrl: string;
+  processRecord?: (record: {
+    messageId: string;
+    payload: IntegrationConsumerPayload;
+    integrationName: string;
+    targetBaseUrl: string;
+  }) => Promise<void>;
   logger?: Pick<typeof console, 'info'>;
 }
+
+export interface IntegrationConsumerPayload {
+  eventType: 'customer.persisted';
+  sourceId: string;
+  correlationId: string;
+  publishedAt: string;
+  customer: Record<string, unknown>;
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const parseConsumerPayload = (rawBody: string): IntegrationConsumerPayload => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    throw new Error('invalid_json');
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error('invalid_payload_type');
+  }
+
+  const eventType = parsed.eventType;
+  const sourceId = parsed.sourceId;
+  const correlationId = parsed.correlationId;
+  const publishedAt = parsed.publishedAt;
+  const customer = parsed.customer;
+
+  if (eventType !== 'customer.persisted') {
+    throw new Error('invalid_event_type');
+  }
+  if (!isNonEmptyString(sourceId)) {
+    throw new Error('missing_source_id');
+  }
+  if (!isNonEmptyString(correlationId)) {
+    throw new Error('missing_correlation_id');
+  }
+  if (!isNonEmptyString(publishedAt)) {
+    throw new Error('missing_published_at');
+  }
+  if (!isRecord(customer)) {
+    throw new Error('invalid_customer_payload');
+  }
+
+  return {
+    eventType,
+    sourceId: sourceId.trim(),
+    correlationId: correlationId.trim(),
+    publishedAt: publishedAt.trim(),
+    customer,
+  };
+};
 
 export const createIntegrationConsumerHandler = ({
   integrationName,
   targetBaseUrl,
+  processRecord = () => Promise.resolve(),
   logger = console,
 }: CreateIntegrationConsumerHandlerParams) => {
   const normalizedIntegrationName = integrationName.trim();
@@ -36,7 +100,7 @@ export const createIntegrationConsumerHandler = ({
     );
   }
 
-  return (event: IntegrationConsumerSqsEvent): Promise<IntegrationConsumerSqsResult> => {
+  return async (event: IntegrationConsumerSqsEvent): Promise<IntegrationConsumerSqsResult> => {
     const records = event.Records ?? [];
     logger.info('integration.consumer.received_batch', {
       integrationName: normalizedIntegrationName,
@@ -45,8 +109,30 @@ export const createIntegrationConsumerHandler = ({
       messageIds: records.map((record) => record.messageId),
     });
 
-    return Promise.resolve({
-      batchItemFailures: [],
-    });
+    const batchItemFailures: Array<{ itemIdentifier: string }> = [];
+    for (const record of records) {
+      try {
+        const payload = parseConsumerPayload(record.body);
+        await processRecord({
+          messageId: record.messageId,
+          payload,
+          integrationName: normalizedIntegrationName,
+          targetBaseUrl: normalizedTargetBaseUrl,
+        });
+      } catch (error) {
+        batchItemFailures.push({
+          itemIdentifier: record.messageId,
+        });
+        logger.info('integration.consumer.invalid_record', {
+          integrationName: normalizedIntegrationName,
+          messageId: record.messageId,
+          reason: error instanceof Error ? error.message : 'unknown_error',
+        });
+      }
+    }
+
+    return {
+      batchItemFailures,
+    };
   };
 };

--- a/tests/unit/handlers/hubspot-consumer.test.ts
+++ b/tests/unit/handlers/hubspot-consumer.test.ts
@@ -27,7 +27,7 @@ describe('hubspot-consumer handler', () => {
         Records: [
           {
             messageId: 'msg-1',
-            body: '{"customerId":"1"}',
+            body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
           },
         ],
       }),

--- a/tests/unit/handlers/salesforce-consumer.test.ts
+++ b/tests/unit/handlers/salesforce-consumer.test.ts
@@ -27,7 +27,7 @@ describe('salesforce-consumer handler', () => {
         Records: [
           {
             messageId: 'msg-1',
-            body: '{"customerId":"1"}',
+            body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
           },
         ],
       }),

--- a/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
+++ b/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { createIntegrationConsumerHandler } from '../../../../src/handlers/shared/create-integration-consumer-handler';
+import {
+  createIntegrationConsumerHandler,
+  type IntegrationConsumerPayload,
+} from '../../../../src/handlers/shared/create-integration-consumer-handler';
 
 class SpyLogger {
   public readonly infoCalls: unknown[][] = [];
@@ -10,12 +13,33 @@ class SpyLogger {
   }
 }
 
+class SpyRecordProcessor {
+  public readonly calls: Array<{
+    messageId: string;
+    payload: IntegrationConsumerPayload;
+    integrationName: string;
+    targetBaseUrl: string;
+  }> = [];
+
+  invoke = (params: {
+    messageId: string;
+    payload: IntegrationConsumerPayload;
+    integrationName: string;
+    targetBaseUrl: string;
+  }): Promise<void> => {
+    this.calls.push(params);
+    return Promise.resolve();
+  };
+}
+
 describe('createIntegrationConsumerHandler', () => {
   it('creates reusable consumer handler and returns no batch item failures', async () => {
     const logger = new SpyLogger();
+    const recordProcessor = new SpyRecordProcessor();
     const handler = createIntegrationConsumerHandler({
       integrationName: 'salesforce',
       targetBaseUrl: 'https://salesforce.internal',
+      processRecord: recordProcessor.invoke,
       logger,
     });
 
@@ -23,7 +47,7 @@ describe('createIntegrationConsumerHandler', () => {
       Records: [
         {
           messageId: 'msg-1',
-          body: '{"id":1}',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
         },
       ],
     });
@@ -42,5 +66,58 @@ describe('createIntegrationConsumerHandler', () => {
         },
       ],
     ]);
+    expect(recordProcessor.calls).toEqual([
+      {
+        messageId: 'msg-1',
+        payload: {
+          eventType: 'customer.persisted',
+          sourceId: 'source-1',
+          correlationId: 'exec-1',
+          publishedAt: '2026-03-04T10:00:00.000Z',
+          customer: { id: 1 },
+        },
+        integrationName: 'salesforce',
+        targetBaseUrl: 'https://salesforce.internal',
+      },
+    ]);
+  });
+
+  it('returns batch item failures for invalid records while keeping valid messages', async () => {
+    const logger = new SpyLogger();
+    const recordProcessor = new SpyRecordProcessor();
+    const handler = createIntegrationConsumerHandler({
+      integrationName: 'hubspot',
+      targetBaseUrl: 'https://hubspot.internal',
+      processRecord: recordProcessor.invoke,
+      logger,
+    });
+
+    const result = await handler({
+      Records: [
+        {
+          messageId: 'msg-valid',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+        },
+        {
+          messageId: 'msg-invalid-json',
+          body: '{',
+        },
+        {
+          messageId: 'msg-invalid-schema',
+          body: '{"eventType":"customer.persisted","sourceId":"","correlationId":"exec-2","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":2}}',
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      batchItemFailures: [
+        { itemIdentifier: 'msg-invalid-json' },
+        { itemIdentifier: 'msg-invalid-schema' },
+      ],
+    });
+    expect(recordProcessor.calls).toHaveLength(1);
+    expect(
+      logger.infoCalls.filter(([eventName]) => eventName === 'integration.consumer.invalid_record'),
+    ).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Closes #63

## 🎯 Objetivo
Implementar consumo SQS em lote nas consumidoras com retorno granular de `batchItemFailures` e validação mínima do payload.

## 🧠 Decisão Técnica
O template compartilhado das consumidoras foi evoluído para:
- parsear JSON por mensagem;
- validar schema mínimo do evento de cliente persistido;
- isolar falhas por item e retornar somente mensagens inválidas em `batchItemFailures`.

## 🧪 BDD Validado
Dado um lote SQS com mensagens válidas e inválidas
Quando a consumidora processa o lote
Então apenas itens inválidos retornam em `batchItemFailures` e itens válidos seguem o fluxo

## 🏗 Impacto Arquitetural
- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

## 🔍 Observabilidade
- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
