### PR TITLE
feat: implementar retry controlado nas integrações (closes #65)

### DIFF
--- a/.codex/runs/platform_architect-issue-65.md
+++ b/.codex/runs/platform_architect-issue-65.md
@@ -1,0 +1,22 @@
+## Issue #65 — [EPIC 6] Implementar retry controlado nas integrações
+
+### Objetivo
+Aplicar política de retry baseada em classificação de erro (transitório x permanente), alinhada ao comportamento de visibilidade/reentrega do SQS.
+
+### Decisão arquitetural desta execução
+1. Evoluir o template de consumidoras com `classifyError` para decidir `retry` vs `discard` por mensagem.
+2. Mapear erros 4xx para permanentes (sem retry) e 5xx para transitórios (com retry) via tipos do cliente externo.
+3. Usar `batchItemFailures` somente para transitórios, delegando reentrega ao mecanismo de visibilidade SQS + redrive para DLQ.
+
+### Evidências técnicas verificadas
+- `src/handlers/shared/create-integration-consumer-handler.ts`
+- `src/handlers/salesforce-consumer.ts`
+- `src/handlers/hubspot-consumer.ts`
+- `tests/unit/handlers/shared/create-integration-consumer-handler.test.ts`
+- `tests/unit/handlers/salesforce-consumer.test.ts`
+- `tests/unit/handlers/hubspot-consumer.test.ts`
+
+### Critérios técnicos de aceite
+- [x] Erros transitórios são retentados dentro do fluxo SQS.
+- [x] Erros permanentes não retornam para retry.
+- [x] Política fica explícita e observável em logs por classificação/ação.

--- a/.codex/runs/qa-issue-65.md
+++ b/.codex/runs/qa-issue-65.md
@@ -1,0 +1,23 @@
+**QA — Issue #65 (Retry controlado nas integrações)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum.
+
+**Checklist de aceite da issue**
+
+- [x] Erros transitórios retornam `batchItemFailures` para retry.
+- [x] Erros permanentes são descartados sem retry.
+- [x] Classificação e ação (`retry`/`discard`) registradas em log.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/handlers/shared/create-integration-consumer-handler.test.ts tests/unit/handlers/salesforce-consumer.test.ts tests/unit/handlers/hubspot-consumer.test.ts tests/unit/infra/integrations/external-api-client.test.ts --runInBand` ✅
+- `npm run build` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-65.md
+++ b/.codex/runs/worker-issue-65.md
@@ -1,0 +1,18 @@
+**Status de execução — Issue #65**
+
+**Escopo executado**
+
+- Implementada política de retry por classificação no template das consumidoras (`transient`/`permanent`).
+- Integrada classificação aos handlers Salesforce/HubSpot usando tipos do cliente externo.
+- Ajustado retorno de `batchItemFailures` para retentar apenas erros transitórios.
+
+**Verificações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/handlers/shared/create-integration-consumer-handler.test.ts tests/unit/handlers/salesforce-consumer.test.ts tests/unit/handlers/hubspot-consumer.test.ts tests/unit/infra/integrations/external-api-client.test.ts --runInBand` ✅
+- `npm run build` ✅
+
+**Resultado**
+
+Issue #65 implementada com diff funcional e pronta para fechamento via PR com vínculo explícito `Closes #65`.

--- a/src/handlers/hubspot-consumer.ts
+++ b/src/handlers/hubspot-consumer.ts
@@ -3,7 +3,11 @@ import {
   type IntegrationConsumerSqsEvent,
   type IntegrationConsumerSqsResult,
 } from './shared/create-integration-consumer-handler';
-import { createIntegrationExternalApiClient } from '../infra/integrations/external-api-client';
+import {
+  IntegrationExternalApiPermanentError,
+  IntegrationExternalApiTransientError,
+  createIntegrationExternalApiClient,
+} from '../infra/integrations/external-api-client';
 import { createFetchIntegrationHttpClient } from '../infra/integrations/fetch-integration-http-client';
 
 const HUBSPOT_INTEGRATION_NAME = 'hubspot';
@@ -53,6 +57,16 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     integrationName: HUBSPOT_INTEGRATION_NAME,
     targetBaseUrl,
     processRecord: ({ messageId, payload }) => sendCustomerEvent({ messageId, payload }),
+    classifyError: (error) => {
+      if (error instanceof IntegrationExternalApiPermanentError) {
+        return 'permanent';
+      }
+      if (error instanceof IntegrationExternalApiTransientError) {
+        return 'transient';
+      }
+
+      return 'transient';
+    },
   });
 
   return cachedHandler;

--- a/src/handlers/salesforce-consumer.ts
+++ b/src/handlers/salesforce-consumer.ts
@@ -3,7 +3,11 @@ import {
   type IntegrationConsumerSqsEvent,
   type IntegrationConsumerSqsResult,
 } from './shared/create-integration-consumer-handler';
-import { createIntegrationExternalApiClient } from '../infra/integrations/external-api-client';
+import {
+  IntegrationExternalApiPermanentError,
+  IntegrationExternalApiTransientError,
+  createIntegrationExternalApiClient,
+} from '../infra/integrations/external-api-client';
 import { createFetchIntegrationHttpClient } from '../infra/integrations/fetch-integration-http-client';
 
 const SALESFORCE_INTEGRATION_NAME = 'salesforce';
@@ -53,6 +57,16 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     integrationName: SALESFORCE_INTEGRATION_NAME,
     targetBaseUrl,
     processRecord: ({ messageId, payload }) => sendCustomerEvent({ messageId, payload }),
+    classifyError: (error) => {
+      if (error instanceof IntegrationExternalApiPermanentError) {
+        return 'permanent';
+      }
+      if (error instanceof IntegrationExternalApiTransientError) {
+        return 'transient';
+      }
+
+      return 'transient';
+    },
   });
 
   return cachedHandler;

--- a/src/handlers/shared/create-integration-consumer-handler.ts
+++ b/src/handlers/shared/create-integration-consumer-handler.ts
@@ -1,6 +1,9 @@
 export interface IntegrationConsumerSqsRecord {
   messageId: string;
   body: string;
+  attributes?: {
+    ApproximateReceiveCount?: string;
+  };
 }
 
 export interface IntegrationConsumerSqsEvent {
@@ -22,6 +25,7 @@ export interface CreateIntegrationConsumerHandlerParams {
     integrationName: string;
     targetBaseUrl: string;
   }) => Promise<void>;
+  classifyError?: (error: unknown) => 'transient' | 'permanent';
   logger?: Pick<typeof console, 'info'>;
 }
 
@@ -86,6 +90,7 @@ export const createIntegrationConsumerHandler = ({
   integrationName,
   targetBaseUrl,
   processRecord = () => Promise.resolve(),
+  classifyError = () => 'transient',
   logger = console,
 }: CreateIntegrationConsumerHandlerParams) => {
   const normalizedIntegrationName = integrationName.trim();
@@ -120,12 +125,20 @@ export const createIntegrationConsumerHandler = ({
           targetBaseUrl: normalizedTargetBaseUrl,
         });
       } catch (error) {
-        batchItemFailures.push({
-          itemIdentifier: record.messageId,
-        });
+        const classification = classifyError(error);
+        const shouldRetry = classification === 'transient';
+        if (shouldRetry) {
+          batchItemFailures.push({
+            itemIdentifier: record.messageId,
+          });
+        }
+
         logger.info('integration.consumer.invalid_record', {
           integrationName: normalizedIntegrationName,
           messageId: record.messageId,
+          receiveCount: record.attributes?.ApproximateReceiveCount ?? null,
+          classification,
+          action: shouldRetry ? 'retry' : 'discard',
           reason: error instanceof Error ? error.message : 'unknown_error',
         });
       }

--- a/tests/unit/handlers/hubspot-consumer.test.ts
+++ b/tests/unit/handlers/hubspot-consumer.test.ts
@@ -47,4 +47,35 @@ describe('hubspot-consumer handler', () => {
       batchItemFailures: [],
     });
   });
+
+  it('retries transient 5xx external errors by returning batch item failure', async () => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      HUBSPOT_INTEGRATION_TARGET_BASE_URL: 'https://hubspot.internal',
+    };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 503,
+        text: () => Promise.resolve('temporary unavailable'),
+      }),
+    ) as never;
+
+    const module = await import('../../../src/handlers/hubspot-consumer');
+    await expect(
+      module.handler({
+        Records: [
+          {
+            messageId: 'msg-1',
+            body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+            attributes: {
+              ApproximateReceiveCount: '1',
+            },
+          },
+        ],
+      }),
+    ).resolves.toEqual({
+      batchItemFailures: [{ itemIdentifier: 'msg-1' }],
+    });
+  });
 });

--- a/tests/unit/handlers/salesforce-consumer.test.ts
+++ b/tests/unit/handlers/salesforce-consumer.test.ts
@@ -47,4 +47,35 @@ describe('salesforce-consumer handler', () => {
       batchItemFailures: [],
     });
   });
+
+  it('discards permanent 4xx external errors without retrying the SQS message', async () => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      SALESFORCE_INTEGRATION_TARGET_BASE_URL: 'https://salesforce.internal',
+    };
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 422,
+        text: () => Promise.resolve('invalid payload'),
+      }),
+    ) as never;
+
+    const module = await import('../../../src/handlers/salesforce-consumer');
+    await expect(
+      module.handler({
+        Records: [
+          {
+            messageId: 'msg-1',
+            body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+            attributes: {
+              ApproximateReceiveCount: '2',
+            },
+          },
+        ],
+      }),
+    ).resolves.toEqual({
+      batchItemFailures: [],
+    });
+  });
 });

--- a/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
+++ b/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
@@ -120,4 +120,46 @@ describe('createIntegrationConsumerHandler', () => {
       logger.infoCalls.filter(([eventName]) => eventName === 'integration.consumer.invalid_record'),
     ).toHaveLength(2);
   });
+
+  it('retries only transient failures and discards permanent failures', async () => {
+    class PermanentError extends Error {}
+    class TransientError extends Error {}
+
+    const handler = createIntegrationConsumerHandler({
+      integrationName: 'salesforce',
+      targetBaseUrl: 'https://salesforce.internal',
+      processRecord: ({ messageId }) => {
+        if (messageId === 'msg-permanent') {
+          return Promise.reject(new PermanentError('permanent_error'));
+        }
+
+        return Promise.reject(new TransientError('transient_error'));
+      },
+      classifyError: (error) => (error instanceof PermanentError ? 'permanent' : 'transient'),
+      logger: new SpyLogger(),
+    });
+
+    const result = await handler({
+      Records: [
+        {
+          messageId: 'msg-permanent',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+          attributes: {
+            ApproximateReceiveCount: '3',
+          },
+        },
+        {
+          messageId: 'msg-transient',
+          body: '{"eventType":"customer.persisted","sourceId":"source-2","correlationId":"exec-2","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":2}}',
+          attributes: {
+            ApproximateReceiveCount: '1',
+          },
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      batchItemFailures: [{ itemIdentifier: 'msg-transient' }],
+    });
+  });
 });


### PR DESCRIPTION
Closes #65

## 🎯 Objetivo
Implementar retry controlado nas consumidoras de integração com política por tipo de erro.

## 🧠 Decisão Técnica
A lógica de consumo em lote agora classifica erros em `transient` e `permanent`:
- `transient` -> retorna em `batchItemFailures` para reprocessamento SQS;
- `permanent` -> não retorna para retry.
A classificação usa os tipos já definidos no cliente externo (`4xx` permanente, `5xx` transitório), com logs de decisão (`retry`/`discard`).

## 🧪 BDD Validado
Dado um erro de integração
Quando a consumidora classifica o erro
Então aplica retry apenas para transitórios e descarta permanentes

## 🏗 Impacto Arquitetural
- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

## 🔍 Observabilidade
- [x] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
