### PR TITLE
chore: revisar iam minimo da plataforma

### DIFF
--- a/.codex/runs/platform_architect-issue-72.md
+++ b/.codex/runs/platform_architect-issue-72.md
@@ -1,0 +1,20 @@
+## Issue #72 — [EPIC 7] Revisar IAM mínimo da plataforma
+
+### Objetivo
+Auditar e reduzir permissões IAM excedentes, mantendo funcionamento do fluxo serverless e rastreabilidade da decisão.
+
+### Decisão arquitetural
+1. **Hardening direto em políticas críticas**
+- Remover wildcard de invocação Lambda na role da state machine principal.
+- Remover ação DynamoDB não utilizada da role da coletora.
+
+2. **Exceções de wildcard documentadas**
+- Manter somente wildcards estritamente necessários por limitação da AWS (`logs delivery` / `PutMetricData`) ou requisito de plugin dinâmico (`secretArn` variável).
+
+3. **Governança de segurança**
+- Registrar revisão em relatório versionado com evidências técnicas e justificativas explícitas.
+
+### Critérios técnicos de aceite
+- [x] Permissões excedentes removidas.
+- [x] Princípio de menor privilégio reforçado nas roles revisadas.
+- [x] Relatório de revisão publicado em documentação.

--- a/.codex/runs/qa-issue-72.md
+++ b/.codex/runs/qa-issue-72.md
@@ -1,0 +1,25 @@
+**QA — Issue #72 (Revisar IAM mínimo da plataforma)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: `validate:stage-package` executado em fallback local por ausência de credenciais AWS.
+
+**Checklist de aceite da issue**
+
+- [x] Permissões coringa desnecessárias removidas dos pontos auditados.
+- [x] Roles seguem menor privilégio no escopo funcional atual.
+- [x] Relatório de revisão IAM disponível e versionado.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- --runInBand` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local esperado
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-72.md
+++ b/.codex/runs/worker-issue-72.md
@@ -1,0 +1,26 @@
+**Status de execução — Issue #72**
+
+**Escopo implementado**
+
+- `serverless.yml` (IAM hardening):
+  - `MainStateMachineExecutionRole`:
+    - removidos recursos wildcard `:${'*'}` de `InvokeSchedulerLambda` e `InvokeCollectorLambda`.
+    - invocação permanece restrita aos ARNs explícitos das funções.
+  - `CollectorExecutionRole`:
+    - removida ação `dynamodb:Query` em `ReadSourceConfiguration` (não utilizada pela coletora).
+- Documentação:
+  - novo relatório `docs/security/iam-review-2026-03-04.md` com inventário de wildcard remanescente e justificativas.
+  - README atualizado com referência ao relatório de revisão IAM.
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- --runInBand` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local esperado (sem credenciais AWS)
+
+**Resultado**
+
+Issue #72 concluída com redução de permissões desnecessárias e registro formal das exceções de wildcard necessárias.

--- a/README.md
+++ b/README.md
@@ -205,10 +205,12 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
   - `dynamodb:UpdateItem` apenas na tabela `sources`.
   - `logs:CreateLogStream` e `logs:PutLogEvents` apenas no log group `/aws/lambda/${service}-${stage}-scheduler`.
 - A state machine principal usa role dedicada (`${service}-${stage}-state-machine-role`) com permissão apenas de `lambda:InvokeFunction` na Lambda scheduler.
+- A role da state machine principal invoca Lambdas explicitamente por ARN de função (sem wildcard de versão/alias) para reduzir escopo.
 - Roles reservadas para etapas seguintes já provisionadas com escopo mínimo e recursos explícitos:
   - `collector-role` para leitura de config (`sources`), leitura de segredos (`secretsmanager:GetSecretValue`), atualização de cursor (`cursors`) e `sns:Publish` no tópico de eventos.
   - `salesforce-consumer-role` para consumo da fila `SalesforceIntegrationQueue`.
   - `hubspot-consumer-role` para consumo da fila `HubspotIntegrationQueue`.
+- Revisão formal de IAM mínima (inventário de wildcards e justificativas): `docs/security/iam-review-2026-03-04.md`.
 - ARNs das roles exportados via outputs para reuso em stacks/funções futuras:
   - `SchedulerExecutionRoleArn`
   - `MainStateMachineExecutionRoleArn`

--- a/docs/security/iam-review-2026-03-04.md
+++ b/docs/security/iam-review-2026-03-04.md
@@ -1,0 +1,47 @@
+# Revisão IAM mínima — 2026-03-04
+
+Issue: `#72`
+
+Objetivo desta revisão: validar princípio de menor privilégio e remover permissões excedentes identificadas no stack principal.
+
+## Alterações aplicadas
+
+1. `MainStateMachineExecutionRole`
+- Removido wildcard de invocação Lambda:
+  - `Fn::Sub: ${SchedulerLambdaFunction.Arn}:*`
+  - `Fn::Sub: ${CollectorLambdaFunction.Arn}:*`
+- Permissão passou a apontar somente para ARNs explícitos das funções.
+
+2. `CollectorExecutionRole`
+- Removida ação não utilizada em `ReadSourceConfiguration`:
+  - `dynamodb:Query`
+- A coletora usa somente `dynamodb:GetItem` para leitura de `sources`.
+
+## Inventário de permissões wildcard remanescentes (com justificativa)
+
+1. `DeliverStepFunctionsExecutionLogs` (`MainStateMachineExecutionRole`)
+- `Resource: "*"` mantido.
+- Justificativa: ações de `logs:CreateLogDelivery/Get/Update/Delete/List` e políticas de resource do CloudWatch Logs não suportam escopo fino por ARN para esse fluxo.
+
+2. `cloudwatch:PutMetricData` (roles de state machine/coletora/consumidoras)
+- `Resource: "*"` mantido com condição `cloudwatch:namespace`.
+- Justificativa: `PutMetricData` não possui resource-level permission; restrição por namespace está aplicada.
+
+3. `secretsmanager:GetSecretValue` (`CollectorExecutionRole`)
+- `Resource: arn:...:secret:*` mantido.
+- Justificativa: modelo plugin permite cadastro dinâmico de `secretArn` por fonte; sem catálogo estático por stage, não é possível restringir ARNs sem quebrar onboarding dinâmico.
+
+## Evidências técnicas
+
+- Arquivo de infraestrutura auditado: `serverless.yml`.
+- Comandos locais executados:
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test -- --runInBand`
+  - `npm run build`
+  - `npm run validate:stage-render`
+  - `npm run validate:stage-package` (fallback local esperado sem credenciais AWS)
+
+## Resultado
+
+Revisão concluída com redução de permissões desnecessárias e rastreabilidade das exceções de wildcard ainda necessárias por limitação da AWS ou requisito de arquitetura dinâmica.

--- a/serverless.yml
+++ b/serverless.yml
@@ -485,7 +485,6 @@ resources:
                     - Fn::GetAtt:
                         - SchedulerLambdaFunction
                         - Arn
-                    - Fn::Sub: ${SchedulerLambdaFunction.Arn}:*
                 - Sid: InvokeCollectorLambda
                   Effect: Allow
                   Action:
@@ -494,7 +493,6 @@ resources:
                     - Fn::GetAtt:
                         - CollectorLambdaFunction
                         - Arn
-                    - Fn::Sub: ${CollectorLambdaFunction.Arn}:*
                 - Sid: DeliverStepFunctionsExecutionLogs
                   Effect: Allow
                   Action:
@@ -537,7 +535,6 @@ resources:
                   Effect: Allow
                   Action:
                     - dynamodb:GetItem
-                    - dynamodb:Query
                   Resource:
                     - Fn::GetAtt:
                         - SourcesTable


### PR DESCRIPTION
Closes #72

---

## 🎯 Objetivo

Revisar permissões IAM da plataforma para remover excessos e registrar evidências de menor privilégio.

---

## 🧠 Decisão Técnica

- Hardening em permissões efetivamente excedentes:
  - removido wildcard de `lambda:InvokeFunction` na role da state machine principal;
  - removida ação `dynamodb:Query` não utilizada na role da coletora.
- Manutenção de wildcards necessários com justificativa técnica (limitação de escopo por recurso ou requisito de segredo dinâmico).
- Relatório formal de revisão em `docs/security/iam-review-2026-03-04.md`.

---

## 🧪 BDD Validado

Dado o fluxo de orquestração principal
Quando a state machine invoca scheduler e coletora
Então as permissões IAM necessárias continuam válidas com ARNs explícitos e sem wildcard desnecessário.

Dado o fluxo da coletora
Quando carrega configuração da fonte
Então usa apenas `dynamodb:GetItem`, sem necessidade de `dynamodb:Query`.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [ ] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
