### PR TITLE
feat: aplicar redaction de logs sensiveis

### DIFF
--- a/.codex/runs/platform_architect-issue-73.md
+++ b/.codex/runs/platform_architect-issue-73.md
@@ -1,0 +1,24 @@
+## Issue #73 — [EPIC 7] Remover logs sensíveis e aplicar redaction
+
+### Objetivo
+Impedir exposição de PII e segredos em logs de API, workers e integrações por meio de redaction centralizado.
+
+### Decisão arquitetural
+1. **Redaction no ponto único de logging**
+- Aplicar saneamento recursivo no `createStructuredLogger` antes de serializar JSON.
+
+2. **Mapa de campos sensíveis por chave**
+- Redação por nome de chave (case-insensitive), incluindo variações com `_`, `-` e camelCase.
+- Cobertura de segredos (`password`, `secret`, `token`, `authorization`, `apiKey`, `cookie`) e PII (`email`, `phone`, `cpf`, `cnpj`, `document`, etc.).
+
+3. **Máscara padrão única**
+- Valor padrão de máscara: `[REDACTED]`.
+
+4. **Governança**
+- Política versionada em documentação.
+- Teste de regressão garantindo que valores sensíveis não vazem em logs.
+
+### Critérios técnicos de aceite
+- [x] Campos sensíveis não aparecem em texto puro nos logs estruturados.
+- [x] Máscara segue padrão único definido.
+- [x] Teste automatizado falha se dado sensível não for redigido.

--- a/.codex/runs/qa-issue-73.md
+++ b/.codex/runs/qa-issue-73.md
@@ -1,0 +1,25 @@
+**QA — Issue #73 (Remover logs sensíveis e aplicar redaction)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: `validate:stage-package` executado em fallback local por ausência de credenciais AWS.
+
+**Checklist de aceite da issue**
+
+- [x] Campos sensíveis foram redigidos em logs estruturados.
+- [x] Máscara padronizada (`[REDACTED]`).
+- [x] Teste de regressão adicionado e validado.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- --runInBand` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local esperado
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-73.md
+++ b/.codex/runs/worker-issue-73.md
@@ -1,0 +1,28 @@
+**Status de execução — Issue #73**
+
+**Escopo implementado**
+
+- `src/shared/logging/structured-logger.ts`:
+  - redaction recursiva de contexto antes do `JSON.stringify`.
+  - mapa de campos sensíveis baseado em chave normalizada.
+  - máscara padrão `[REDACTED]`.
+  - tratamento de objetos/listas e suporte a valores `Date`.
+- Testes:
+  - `tests/unit/shared/logging/structured-logger.test.ts`
+  - novo cenário cobrindo payload aninhado, headers de auth, credenciais e PII.
+- Documentação:
+  - `docs/security/log-redaction-policy-v1.md` com política e lista de campos.
+  - README atualizado com referência da política e padrão de máscara.
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- --runInBand` ✅
+- `npm run build` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local esperado (sem credenciais AWS)
+
+**Resultado**
+
+Issue #73 concluída com redaction centralizado e proteção contra regressão para vazamento de dados sensíveis em logs.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
 - Redrive policy habilitada nas filas principais com `maxReceiveCount` versionado por integração.
 - Alarmes de DLQ por integração com métrica `AWS/SQS::ApproximateNumberOfMessagesVisible` e limiar por stage (`salesforceDlqAlarmThreshold` e `hubspotDlqAlarmThreshold`).
 - Ações de notificação dos alarmes direcionadas para tópico SNS operacional `${service}-${stage}-dlq-alarms`.
+- Logger estruturado aplica redaction recursiva de PII e segredos antes da serialização dos eventos.
+  - Máscara padrão: `[REDACTED]`.
+  - Política de campos sensíveis: `docs/security/log-redaction-policy-v1.md`.
 - Alarmes operacionais de ingestão e integração conectados ao tópico SNS `${service}-${stage}-operational-alarms`:
   - Erros de Lambda (`Errors`): scheduler, coletora, consumidora Salesforce e consumidora HubSpot.
   - Latência p95 de Lambda (`Duration`): scheduler, coletora, consumidora Salesforce e consumidora HubSpot.

--- a/docs/security/log-redaction-policy-v1.md
+++ b/docs/security/log-redaction-policy-v1.md
@@ -1,0 +1,36 @@
+# Política de redaction de logs v1
+
+## Objetivo
+
+Evitar exposição de PII e segredos em logs estruturados da plataforma.
+
+## Padrão de máscara
+
+- Valor mascarado padrão: `[REDACTED]`
+- Aplicação: recursiva em payloads (objetos e listas) antes da serialização do log.
+
+## Campos sensíveis mapeados
+
+A redaction é aplicada por nome de chave (case-insensitive), incluindo variações com `_`, `-` e camelCase.
+
+- Segredos e autenticação:
+  - `password`
+  - `passwd`
+  - `secret`
+  - `token`
+  - `apiKey` / `api_key`
+  - `authorization`
+  - `cookie`
+- PII:
+  - `email`
+  - `phone` / `mobile`
+  - `cpf`
+  - `cnpj`
+  - `ssn`
+  - `document`
+  - `birthDate`
+
+## Regra operacional
+
+- Logs novos devem usar o logger estruturado compartilhado para garantir redaction centralizada.
+- Testes unitários devem validar que campos sensíveis não aparecem em texto puro.

--- a/src/shared/logging/structured-logger.ts
+++ b/src/shared/logging/structured-logger.ts
@@ -6,12 +6,62 @@ export interface StructuredLogger {
   info: (event: string, context?: Record<string, unknown>) => void;
 }
 
+const REDACTED_VALUE = '[REDACTED]';
+const SENSITIVE_KEY_TOKENS = [
+  'password',
+  'passwd',
+  'secret',
+  'token',
+  'apikey',
+  'authorization',
+  'cookie',
+  'email',
+  'phone',
+  'mobile',
+  'cpf',
+  'cnpj',
+  'ssn',
+  'document',
+  'birthdate',
+];
+
+const normalizeKey = (key: string): string => key.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const isSensitiveKey = (key: string): boolean => {
+  const normalizedKey = normalizeKey(key);
+  return SENSITIVE_KEY_TOKENS.some((token) => normalizedKey.includes(token));
+};
+
+const sanitizeValue = (value: unknown, key?: string): unknown => {
+  if (key && isSensitiveKey(key)) {
+    return REDACTED_VALUE;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item));
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, nestedValue]) => nestedValue !== undefined)
+        .map(([nestedKey, nestedValue]) => [nestedKey, sanitizeValue(nestedValue, nestedKey)]),
+    );
+  }
+
+  return value;
+};
+
 const normalizeContext = (context: Record<string, unknown> | undefined): Record<string, unknown> => {
   if (!context) {
     return {};
   }
 
-  return Object.fromEntries(Object.entries(context).filter(([, value]) => value !== undefined));
+  return sanitizeValue(context) as Record<string, unknown>;
 };
 
 export const createStructuredLogger = ({

--- a/tests/unit/shared/logging/structured-logger.test.ts
+++ b/tests/unit/shared/logging/structured-logger.test.ts
@@ -31,4 +31,64 @@ describe('createStructuredLogger', () => {
       correlationId: 'exec-123',
     });
   });
+
+  it('redacts sensitive fields in nested payloads', () => {
+    const calls: string[] = [];
+    const logger = createStructuredLogger({
+      component: 'security',
+      now: () => '2026-03-04T12:00:00.000Z',
+      sink: {
+        info: (message: string) => {
+          calls.push(message);
+        },
+      },
+    });
+
+    logger.info('security.redaction.check', {
+      email: 'user@example.com',
+      password: 'super-secret-password',
+      headers: {
+        Authorization: 'Bearer top-secret-token',
+      },
+      payload: {
+        customer: {
+          document: '12345678901',
+          phoneNumber: '+5511999999999',
+          id: 'customer-1',
+        },
+      },
+      records: [
+        {
+          apiKey: 'api-key-value',
+          sourceId: 'source-1',
+        },
+      ],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(calls[0] ?? '{}')).toEqual({
+      level: 'INFO',
+      timestamp: '2026-03-04T12:00:00.000Z',
+      component: 'security',
+      event: 'security.redaction.check',
+      email: '[REDACTED]',
+      password: '[REDACTED]',
+      headers: {
+        Authorization: '[REDACTED]',
+      },
+      payload: {
+        customer: {
+          document: '[REDACTED]',
+          phoneNumber: '[REDACTED]',
+          id: 'customer-1',
+        },
+      },
+      records: [
+        {
+          apiKey: '[REDACTED]',
+          sourceId: 'source-1',
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
Closes #73

---

## 🎯 Objetivo

Remover exposição de dados sensíveis em logs estruturados, aplicando redaction/masking centralizado para PII e segredos.

---

## 🧠 Decisão Técnica

- Redaction implementada no ponto único de logging (`createStructuredLogger`), com saneamento recursivo de objetos/listas.
- Máscara padrão definida como `[REDACTED]`.
- Mapa de campos sensíveis por chave normalizada (case-insensitive), cobrindo credenciais e PII.
- Política versionada em `docs/security/log-redaction-policy-v1.md`.
- Teste de regressão unitário garantindo que dados sensíveis não vazem em texto puro.

---

## 🧪 BDD Validado

Dado um payload de log contendo PII e segredos em campos aninhados
Quando o logger estruturado serializa o evento
Então os campos sensíveis são substituídos por `[REDACTED]`.

Dado um campo não sensível no mesmo payload
Quando o log é serializado
Então o valor não sensível permanece íntegro.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
