### PR TITLE
fix: fallback diagnóstico para falhas não mapeadas dos scripts de stage

### DIFF
--- a/.codex/runs/platform_architect-issue-91.md
+++ b/.codex/runs/platform_architect-issue-91.md
@@ -1,0 +1,28 @@
+## Issue #91 — [TECH-DEBT][LOW] Fallback de diagnóstico para falhas não mapeadas
+
+### Objetivo
+Garantir rastreabilidade mínima quando `validate-stage-render` e `validate-stage-package` falharem por erro não classificado, eliminando cenários de `exit 1` sem diagnóstico objetivo.
+
+### Decisões arquiteturais
+1. **Identificador padronizado para falha não classificada**
+- Introduzir saída explícita `UNCLASSIFIED_STAGE_VALIDATION_ERROR` em ambos os scripts.
+- Incluir contexto mínimo obrigatório: `stage` e `command` executado.
+
+2. **Preservação de comportamento para erros já mapeados**
+- `validate-stage-render`: manter fallback estático quando detectar erro de rede/API.
+- `validate-stage-package`: manter fallback de build local quando detectar erro de credencial/rede.
+
+3. **Testabilidade por injeção de comando via ambiente**
+- Permitir override do comando principal dos scripts por variável de ambiente para testar cenários de erro controlados.
+- Permitir override do comando de fallback no `validate-stage-package` para evitar build pesado em teste.
+
+4. **Cobertura automatizada focada em diagnóstico**
+- Adicionar testes de integração de script para validar:
+  - mensagem padronizada em erro não classificado;
+  - ausência de regressão em fallback de erros mapeados.
+
+### Critérios técnicos de aceite
+- Erro não mapeado em ambos os scripts emite `UNCLASSIFIED_STAGE_VALIDATION_ERROR` com `stage` e `command`.
+- Saída contém orientação objetiva de próxima ação.
+- Casos mapeados continuam com fallback existente.
+- Testes automatizados cobrem os cenários acima.

--- a/.codex/runs/qa-issue-91.md
+++ b/.codex/runs/qa-issue-91.md
@@ -1,0 +1,24 @@
+**QA — Issue #91 (Fallback de diagnóstico para falhas não mapeadas)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum.
+
+**Checklist de aceite da issue**
+
+- [x] `validate-stage-render` emite mensagem de falha não classificada com contexto mínimo.
+- [x] `validate-stage-package` emite mensagem de falha não classificada com contexto mínimo.
+- [x] Saída inclui orientação objetiva de próxima ação.
+- [x] Comportamento de fallback para erros já mapeados foi preservado.
+- [x] Cobertura de testes adicionada para cenários não mapeados e mapeados.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run test -- tests/unit/scripts/stage-validation-fallbacks.test.ts --runInBand` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-91.md
+++ b/.codex/runs/worker-issue-91.md
@@ -1,0 +1,21 @@
+**Status de execução — Issue #91**
+
+**Escopo implementado**
+
+- Diagnóstico padronizado para erro não classificado em `validate-stage-render`:
+  - `scripts/validate-stage-render.mjs`
+  - novo identificador `UNCLASSIFIED_STAGE_VALIDATION_ERROR` com contexto `stage` e `command`.
+  - orientação objetiva de próxima ação (modo verbose + revisão de logs).
+- Diagnóstico padronizado para erro não classificado em `validate-stage-package`:
+  - `scripts/validate-stage-package.mjs`
+  - mesmo identificador e contrato de contexto.
+- Testabilidade dos scripts por injeção de comando:
+  - `VALIDATE_STAGE_RENDER_COMMAND`
+  - `VALIDATE_STAGE_PACKAGE_COMMAND`
+  - `VALIDATE_STAGE_PACKAGE_FALLBACK_COMMAND`
+- Cobertura automatizada de fallback e não-classificado:
+  - `tests/unit/scripts/stage-validation-fallbacks.test.ts`
+
+**Resultado**
+
+Issue #91 concluída com fallback diagnóstico explícito para falhas não mapeadas, sem alterar o fluxo de fallback dos erros já classificados.

--- a/scripts/validate-stage-package.mjs
+++ b/scripts/validate-stage-package.mjs
@@ -1,5 +1,8 @@
 import { execSync } from 'node:child_process';
 
+const DEFAULT_STAGE_PACKAGE_COMMAND = 'npm run sls:package:all';
+const DEFAULT_STAGE_PACKAGE_FALLBACK_COMMAND = 'npm run build';
+
 const run = (command) =>
   execSync(command, {
     encoding: 'utf8',
@@ -15,8 +18,20 @@ const printCapturedOutput = (error) => {
   return `${stdout}\n${stderr}`;
 };
 
+const emitUnclassifiedFailure = ({ stage, command }) => {
+  console.error(`UNCLASSIFIED_STAGE_VALIDATION_ERROR stage=${stage} command="${command}"`);
+  console.error(
+    'Próxima ação: habilite modo verbose (DEBUG=* ou SLS_DEBUG=*) e revise os logs do comando subjacente.',
+  );
+};
+
+const stagePackageCommand =
+  process.env.VALIDATE_STAGE_PACKAGE_COMMAND ?? DEFAULT_STAGE_PACKAGE_COMMAND;
+const stagePackageFallbackCommand =
+  process.env.VALIDATE_STAGE_PACKAGE_FALLBACK_COMMAND ?? DEFAULT_STAGE_PACKAGE_FALLBACK_COMMAND;
+
 try {
-  const output = run('npm run sls:package:all');
+  const output = run(stagePackageCommand);
   if (output) process.stdout.write(output);
   process.exit(0);
 } catch (error) {
@@ -28,11 +43,15 @@ try {
     output.includes('core.serverless.com');
 
   if (!canFallback) {
+    emitUnclassifiedFailure({
+      stage: 'stage-package',
+      command: stagePackageCommand,
+    });
     process.exit(1);
   }
 
   console.warn(
     '\nAviso: empacotamento multi-stage indisponível no ambiente atual (credenciais/rede). Executando fallback com build local.',
   );
-  execSync('npm run build', { stdio: 'inherit', env: process.env });
+  execSync(stagePackageFallbackCommand, { stdio: 'inherit', env: process.env });
 }

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -1,6 +1,8 @@
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
+const DEFAULT_STAGE_RENDER_COMMAND = 'npm run sls:print:all';
+
 const run = (command) =>
   execSync(command, {
     encoding: 'utf8',
@@ -14,6 +16,13 @@ const printCapturedOutput = (error) => {
   if (stdout) process.stdout.write(stdout);
   if (stderr) process.stderr.write(stderr);
   return `${stdout}\n${stderr}`;
+};
+
+const emitUnclassifiedFailure = ({ stage, command }) => {
+  console.error(`UNCLASSIFIED_STAGE_VALIDATION_ERROR stage=${stage} command="${command}"`);
+  console.error(
+    'Próxima ação: habilite modo verbose (DEBUG=* ou SLS_DEBUG=*) e revise os logs do comando subjacente.',
+  );
 };
 
 const staticFallback = () => {
@@ -507,8 +516,10 @@ const staticFallback = () => {
   );
 };
 
+const stageRenderCommand = process.env.VALIDATE_STAGE_RENDER_COMMAND ?? DEFAULT_STAGE_RENDER_COMMAND;
+
 try {
-  const output = run('npm run sls:print:all');
+  const output = run(stageRenderCommand);
   if (output) process.stdout.write(output);
   process.exit(0);
 } catch (error) {
@@ -519,6 +530,10 @@ try {
     output.includes('EAI_AGAIN');
 
   if (!networkIssue) {
+    emitUnclassifiedFailure({
+      stage: 'stage-render',
+      command: stageRenderCommand,
+    });
     process.exit(1);
   }
 

--- a/tests/unit/scripts/stage-validation-fallbacks.test.ts
+++ b/tests/unit/scripts/stage-validation-fallbacks.test.ts
@@ -1,0 +1,81 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const STAGE_RENDER_SCRIPT = path.resolve(REPO_ROOT, 'scripts/validate-stage-render.mjs');
+const STAGE_PACKAGE_SCRIPT = path.resolve(REPO_ROOT, 'scripts/validate-stage-package.mjs');
+
+type ScriptResult = {
+  status: number | null;
+  output: string;
+};
+
+const runScript = (scriptPath: string, env: Record<string, string>): ScriptResult => {
+  const result = spawnSync('node', [scriptPath], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  };
+};
+
+describe('stage validation scripts - fallback diagnostics', () => {
+  it('emits UNCLASSIFIED_STAGE_VALIDATION_ERROR for unmapped render failures', () => {
+    const result = runScript(STAGE_RENDER_SCRIPT, {
+      VALIDATE_STAGE_RENDER_COMMAND:
+        'node -e "process.stderr.write(\'unexpected render failure\\\\n\'); process.exit(1)"',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain('UNCLASSIFIED_STAGE_VALIDATION_ERROR');
+    expect(result.output).toContain('stage=stage-render');
+    expect(result.output).toContain('command="node -e');
+    expect(result.output).toContain('Próxima ação: habilite modo verbose');
+  });
+
+  it('preserves mapped render fallback behavior for network errors', () => {
+    const result = runScript(STAGE_RENDER_SCRIPT, {
+      VALIDATE_STAGE_RENDER_COMMAND:
+        'node -e "process.stderr.write(\'Unable to reach the Serverless API\\\\n\'); process.exit(1)"',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain('Falha no fallback estático');
+    expect(result.output).not.toContain('UNCLASSIFIED_STAGE_VALIDATION_ERROR');
+  });
+
+  it('emits UNCLASSIFIED_STAGE_VALIDATION_ERROR for unmapped package failures', () => {
+    const result = runScript(STAGE_PACKAGE_SCRIPT, {
+      VALIDATE_STAGE_PACKAGE_COMMAND:
+        'node -e "process.stderr.write(\'unexpected package failure\\\\n\'); process.exit(1)"',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain('UNCLASSIFIED_STAGE_VALIDATION_ERROR');
+    expect(result.output).toContain('stage=stage-package');
+    expect(result.output).toContain('command="node -e');
+    expect(result.output).toContain('Próxima ação: habilite modo verbose');
+  });
+
+  it('preserves mapped package fallback behavior for credentials/network errors', () => {
+    const result = runScript(STAGE_PACKAGE_SCRIPT, {
+      VALIDATE_STAGE_PACKAGE_COMMAND:
+        'node -e "process.stderr.write(\'Could not load credentials from any providers\\\\n\'); process.exit(1)"',
+      VALIDATE_STAGE_PACKAGE_FALLBACK_COMMAND:
+        'node -e "process.stdout.write(\'fallback-build-ok\\\\n\')"',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('empacotamento multi-stage indisponível no ambiente atual');
+    expect(result.output).toContain('fallback-build-ok');
+    expect(result.output).not.toContain('UNCLASSIFIED_STAGE_VALIDATION_ERROR');
+  });
+});


### PR DESCRIPTION
Closes #91

---

## 🎯 Objetivo
Adicionar fallback de diagnóstico para falhas não mapeadas nos scripts `validate-stage-render` e `validate-stage-package`, removendo cenários de `exit 1` sem mensagem padronizada.

---

## 🧠 Decisão Técnica
- Introduzido identificador padronizado `UNCLASSIFIED_STAGE_VALIDATION_ERROR` nos dois scripts quando o erro não entra nas categorias mapeadas.
- Adicionado contexto mínimo obrigatório na mensagem: `stage` e `command`.
- Mantido o comportamento atual para erros mapeados (rede/credenciais) com os fallbacks já existentes.
- Incluída injeção de comando via variáveis de ambiente para permitir teste automatizado dos cenários de classificação.

---

## 🧪 BDD Validado
Dado que o comando de validação falha por motivo não classificado
Quando `validate-stage-render` ou `validate-stage-package` trata o erro
Então o script emite `UNCLASSIFIED_STAGE_VALIDATION_ERROR` com contexto e orientação de próxima ação.

Dado que a falha pertence a categoria mapeada (rede/credenciais)
Quando o script trata o erro
Então o fallback existente continua sendo aplicado sem regressão de classificação.

---

## 🏗 Impacto Arquitetural
- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade
- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
