### PR TITLE
fix: estabilizar CI do stage-render para Serverless v4 login

### DIFF
--- a/.codex/runs/platform_architect-issue-154.md
+++ b/.codex/runs/platform_architect-issue-154.md
@@ -1,0 +1,26 @@
+## Issue #154 — [BUG][HIGH] Tratar autenticação Serverless v4 no validate-stage-render
+
+### Objetivo
+Eliminar a falha não classificada do CI quando `serverless print` exigir login/licença do Serverless Framework v4, mantendo o check `validate:stage-render` determinístico.
+
+### Decisões arquiteturais
+1. **Classificação explícita de erro de autenticação/licença**
+- Reconhecer mensagens de login/licença do Serverless v4 como erro conhecido de ambiente.
+- Evitar `UNCLASSIFIED_STAGE_VALIDATION_ERROR` para esse caso.
+
+2. **Fallback estático como caminho oficial para ambiente restrito**
+- Reaproveitar a estratégia de fallback estático já adotada para indisponibilidade de rede.
+- Mensagem de aviso deve indicar a causa (`rede` ou `autenticação/licença`) para facilitar diagnóstico em CI.
+
+3. **Alinhar validação estática com ASL atual**
+- Ajustar checks do fallback para refletir a estrutura atual do `main-orchestration-v1.asl.json` (`schedulerResult.maxConcurrency`).
+- Remover validação obsoleta de estado inexistente (`NormalizeSchedulerOutput`).
+
+4. **Cobertura de teste de regressão para login Serverless v4**
+- Adicionar cenário unitário que simula erro `serverless login` e valida fallback sem `UNCLASSIFIED`.
+
+### Critérios técnicos de aceite
+- Erro de login/licença do Serverless v4 é tratado como cenário conhecido no `validate-stage-render`.
+- Fallback estático conclui com saída determinística para rede e autenticação/licença.
+- Testes unitários cobrem os dois cenários mapeados.
+- README explicita o comportamento esperado no CI.

--- a/.codex/runs/qa-issue-154.md
+++ b/.codex/runs/qa-issue-154.md
@@ -1,0 +1,27 @@
+**QA — Issue #154 (Tratar autenticação Serverless v4 no validate-stage-render)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante.
+3. Médio: nenhum.
+4. Baixo: `validate:stage-package` executou fallback local esperado por ausência de credenciais AWS.
+
+**Checklist de aceite da issue**
+
+- [x] Falha de login/licença do Serverless v4 não gera `UNCLASSIFIED_STAGE_VALIDATION_ERROR`.
+- [x] `validate-stage-render` adota comportamento determinístico com fallback estático para erros mapeados.
+- [x] Fallback estático está alinhado ao ASL atual (`schedulerResult.maxConcurrency`).
+- [x] Cenário de autenticação/licença coberto por teste automatizado.
+- [x] README documenta comportamento esperado no CI.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm test -- tests/unit/scripts/stage-validation-fallbacks.test.ts --runInBand` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local (sem credenciais AWS)
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-154.md
+++ b/.codex/runs/worker-issue-154.md
@@ -1,0 +1,30 @@
+**Status de execução — Issue #154**
+
+**Escopo implementado**
+
+- Tratamento explícito de autenticação/licença Serverless v4 no `validate-stage-render`:
+  - `scripts/validate-stage-render.mjs`
+  - erros com mensagem de `serverless login` agora entram em fallback conhecido (não classificado como `UNCLASSIFIED_STAGE_VALIDATION_ERROR`).
+- Correção do fallback estático para refletir a ASL atual:
+  - remoção do check obsoleto de `NormalizeSchedulerOutput`;
+  - ajuste de caminhos para `$.schedulerResult.maxConcurrency` em `MaxConcurrencyPath` e `summary.maxConcurrency`.
+- Mensagem de fallback padronizada por causa operacional:
+  - `rede` ou `autenticação/licença do Serverless v4`.
+- Cobertura de regressão adicionada:
+  - `tests/unit/scripts/stage-validation-fallbacks.test.ts`
+  - novo cenário para erro de login/licença do Serverless v4.
+- Documentação atualizada:
+  - `README.md` com comportamento esperado de `validate:stage-render` em ambiente sem login/licença.
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm test -- tests/unit/scripts/stage-validation-fallbacks.test.ts --runInBand` ✅
+- `npm run validate:stage-render` ✅
+- `npm run validate:stage-package` ⚠️ fallback local esperado por ausência de credenciais AWS
+
+**Resultado**
+
+Issue #154 concluída com fallback determinístico para erro de login/licença do Serverless v4 e sem `UNCLASSIFIED_STAGE_VALIDATION_ERROR` nesse cenário.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Renderização do template por stage:
 npm run validate:stage-render
 ```
 
-Esse comando tenta executar `sls:print:all`; quando a API do Serverless está indisponível por rede, ele aplica fallback estático no `serverless.yml` e registra aviso.
+Esse comando tenta executar `sls:print:all`; quando a API do Serverless está indisponível por rede **ou** quando o ambiente não possui autenticação/licença do Serverless Framework v4 (`serverless login`), ele aplica fallback estático no `serverless.yml` e registra aviso.
 
 Empacotamento para os 3 ambientes:
 

--- a/scripts/validate-stage-render.mjs
+++ b/scripts/validate-stage-render.mjs
@@ -25,7 +25,7 @@ const emitUnclassifiedFailure = ({ stage, command }) => {
   );
 };
 
-const staticFallback = () => {
+const staticFallback = (reason) => {
   const serverless = readFileSync(new URL('../serverless.yml', import.meta.url), 'utf8');
   const stateMachineFile = new URL(
     '../state-machines/main-orchestration-v1.asl.json',
@@ -381,22 +381,15 @@ const staticFallback = () => {
     process.exit(1);
   }
 
-  const normalizeSchedulerOutput = states.NormalizeSchedulerOutput ?? {};
-  const schedulerParams = normalizeSchedulerOutput.Parameters?.scheduler ?? {};
-  if (schedulerParams['maxConcurrency.$'] !== '$.schedulerResult.maxConcurrency') {
-    console.error('Falha no fallback estático: NormalizeSchedulerOutput sem maxConcurrency.');
-    process.exit(1);
-  }
-
   const processEligibleSources = states.ProcessEligibleSources ?? {};
-  if (processEligibleSources.MaxConcurrencyPath !== '$.scheduler.maxConcurrency') {
+  if (processEligibleSources.MaxConcurrencyPath !== '$.schedulerResult.maxConcurrency') {
     console.error('Falha no fallback estático: Map sem MaxConcurrencyPath esperado.');
     process.exit(1);
   }
 
   const buildExecutionOutput = states.BuildExecutionOutput ?? {};
   const summaryParams = buildExecutionOutput.Parameters?.summary ?? {};
-  if (summaryParams['maxConcurrency.$'] !== '$.scheduler.maxConcurrency') {
+  if (summaryParams['maxConcurrency.$'] !== '$.schedulerResult.maxConcurrency') {
     console.error('Falha no fallback estático: summary sem maxConcurrency.');
     process.exit(1);
   }
@@ -512,11 +505,12 @@ const staticFallback = () => {
   }
 
   console.warn(
-    '\nAviso: renderização multi-stage indisponível por rede. Fallback estático no serverless.yml concluído.',
+    `\nAviso: renderização multi-stage indisponível no ambiente atual (${reason}). Fallback estático no serverless.yml concluído.`,
   );
 };
 
-const stageRenderCommand = process.env.VALIDATE_STAGE_RENDER_COMMAND ?? DEFAULT_STAGE_RENDER_COMMAND;
+const stageRenderCommand =
+  process.env.VALIDATE_STAGE_RENDER_COMMAND ?? DEFAULT_STAGE_RENDER_COMMAND;
 
 try {
   const output = run(stageRenderCommand);
@@ -528,8 +522,12 @@ try {
     output.includes('Unable to reach the Serverless API') ||
     output.includes('core.serverless.com') ||
     output.includes('EAI_AGAIN');
+  const authIssue =
+    output.includes('You must sign in or use a license key with Serverless Framework V.4') ||
+    output.includes('Please use "serverless login".');
+  const canFallback = networkIssue || authIssue;
 
-  if (!networkIssue) {
+  if (!canFallback) {
     emitUnclassifiedFailure({
       stage: 'stage-render',
       command: stageRenderCommand,
@@ -537,5 +535,6 @@ try {
     process.exit(1);
   }
 
-  staticFallback();
+  const fallbackReason = authIssue ? 'autenticação/licença do Serverless v4' : 'rede';
+  staticFallback(fallbackReason);
 }

--- a/tests/unit/scripts/stage-validation-fallbacks.test.ts
+++ b/tests/unit/scripts/stage-validation-fallbacks.test.ts
@@ -47,8 +47,26 @@ describe('stage validation scripts - fallback diagnostics', () => {
         'node -e "process.stderr.write(\'Unable to reach the Serverless API\\\\n\'); process.exit(1)"',
     });
 
-    expect(result.status).toBe(1);
-    expect(result.output).toContain('Falha no fallback estático');
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      'renderização multi-stage indisponível no ambiente atual (rede)',
+    );
+    expect(result.output).toContain('Fallback estático no serverless.yml concluído');
+    expect(result.output).not.toContain('Falha no fallback estático');
+    expect(result.output).not.toContain('UNCLASSIFIED_STAGE_VALIDATION_ERROR');
+  });
+
+  it('preserves mapped render fallback behavior for Serverless v4 authentication errors', () => {
+    const result = runScript(STAGE_RENDER_SCRIPT, {
+      VALIDATE_STAGE_RENDER_COMMAND:
+        'node -e "process.stderr.write(\'You must sign in or use a license key with Serverless Framework V.4 and later versions.\\\\n\'); process.exit(1)"',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      'renderização multi-stage indisponível no ambiente atual (autenticação/licença do Serverless v4)',
+    );
+    expect(result.output).toContain('Fallback estático no serverless.yml concluído');
     expect(result.output).not.toContain('UNCLASSIFIED_STAGE_VALIDATION_ERROR');
   });
 


### PR DESCRIPTION
## Contexto
Corrige a falha da CI no `validate:stage-render` quando o Serverless Framework v4 exige login/licença (`serverless login`).

## O que foi feito
- mapeamento explícito de erro de autenticação/licença do Serverless v4;
- fallback estático acionado para erros de rede e de login/licença;
- atualização dos checks do fallback para a ASL atual (`schedulerResult.maxConcurrency`);
- teste unitário para regressão de login Serverless v4;
- atualização do README com comportamento esperado no CI.

## Validação
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- tests/unit/scripts/stage-validation-fallbacks.test.ts --runInBand`
- `npm run validate:stage-render`
- `npm run validate:stage-package` (fallback local esperado)

Closes #154
