### PR TITLE
fix(ci): tratar autenticação Serverless v4 no validate-stage-package

### DIFF
--- a/.codex/runs/platform_architect-issue-157.md
+++ b/.codex/runs/platform_architect-issue-157.md
@@ -1,0 +1,26 @@
+## Issue #157 — [BUG][HIGH] Tratar autenticação Serverless v4 no validate-stage-package
+
+### Objetivo
+Eliminar falha não classificada no CI quando `serverless package` exigir login/licença do Serverless Framework v4, mantendo `validate:stage-package` determinístico.
+
+### Decisões arquiteturais
+1. **Classificação explícita do erro de autenticação/licença**
+- Reconhecer mensagens de login/licença do Serverless v4 como erro conhecido de ambiente.
+- Evitar `UNCLASSIFIED_STAGE_VALIDATION_ERROR` nesse cenário.
+
+2. **Fallback controlado para build local**
+- Reutilizar fallback oficial de `validate-stage-package` com `npm run build`.
+- Preservar semântica de sucesso quando o bloqueio for de ambiente (credenciais/rede/autenticação).
+
+3. **Diagnóstico observável no CI**
+- Incluir motivo operacional no aviso (`credenciais AWS`, `rede`, `autenticação/licença do Serverless v4`).
+- Manter saída padronizada para triagem rápida.
+
+4. **Cobertura de regressão orientada ao bug**
+- Adicionar teste dedicado para mensagem `serverless login` no fluxo de package.
+
+### Critérios técnicos de aceite
+- Erro de login/licença do Serverless v4 em `validate-stage-package` não gera `UNCLASSIFIED_STAGE_VALIDATION_ERROR`.
+- Fallback local é executado com `exit 0` para casos mapeados.
+- Teste automatizado cobre o cenário de autenticação/licença.
+- README descreve comportamento esperado no CI.

--- a/.codex/runs/qa-issue-157.md
+++ b/.codex/runs/qa-issue-157.md
@@ -1,0 +1,26 @@
+**QA — Issue #157 (Tratar autenticação Serverless v4 no validate-stage-package)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante.
+3. Médio: nenhum.
+4. Baixo: `validate:stage-package` em ambiente local segue com fallback por ausência de credenciais AWS (comportamento esperado).
+
+**Checklist de aceite da issue**
+
+- [x] Falha de login/licença do Serverless v4 não gera `UNCLASSIFIED_STAGE_VALIDATION_ERROR` em `validate-stage-package`.
+- [x] `validate-stage-package` adota fallback determinístico para erros mapeados.
+- [x] Cenário de autenticação/licença coberto por teste automatizado.
+- [x] README documenta o comportamento esperado no CI.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm test -- tests/unit/scripts/stage-validation-fallbacks.test.ts --runInBand` ✅
+- `npm run validate:stage-package` ✅ (fallback local por credenciais)
+- Execução simulada com mensagem `Please use "serverless login".` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-157.md
+++ b/.codex/runs/worker-issue-157.md
@@ -1,0 +1,27 @@
+**Status de execução — Issue #157**
+
+**Escopo implementado**
+
+- Tratamento explícito de autenticação/licença Serverless v4 em `validate-stage-package`:
+  - `scripts/validate-stage-package.mjs`
+  - erros com mensagem de `serverless login` passam a entrar em fallback conhecido.
+- Classificação do motivo do fallback por causa operacional:
+  - `credenciais AWS`, `rede`, `autenticação/licença do Serverless v4`.
+- Cobertura de regressão adicionada:
+  - `tests/unit/scripts/stage-validation-fallbacks.test.ts`
+  - novo cenário para erro de autenticação/licença no fluxo de package.
+- Documentação atualizada:
+  - `README.md` com comportamento de `validate:stage-package` incluindo ausência de login/licença no Serverless v4.
+
+**Validações executadas**
+
+- `npm run lint` ✅
+- `npm run typecheck` ✅
+- `npm run build` ✅
+- `npm test -- tests/unit/scripts/stage-validation-fallbacks.test.ts --runInBand` ✅
+- `npm run validate:stage-package` ✅ (fallback local esperado por falta de credenciais AWS)
+- Simulação direta de erro `serverless login` via `VALIDATE_STAGE_PACKAGE_COMMAND` ✅ (fallback aplicado)
+
+**Resultado**
+
+Issue #157 concluída com comportamento determinístico no CI para erro de autenticação/licença do Serverless v4 no stage package.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Empacotamento para os 3 ambientes:
 npm run validate:stage-package
 ```
 
-Esse comando tenta executar `sls:package:all`; quando credenciais AWS ou conectividade não estão disponíveis, ele faz fallback para `npm run build` e registra aviso.
+Esse comando tenta executar `sls:package:all`; quando credenciais AWS, conectividade ou autenticação/licença do Serverless Framework v4 (`serverless login`) não estão disponíveis, ele faz fallback para `npm run build` e registra aviso.
 
 Empacotamento estrito (requer credenciais AWS válidas no ambiente):
 

--- a/scripts/validate-stage-package.mjs
+++ b/scripts/validate-stage-package.mjs
@@ -36,11 +36,16 @@ try {
   process.exit(0);
 } catch (error) {
   const output = printCapturedOutput(error);
-  const canFallback =
+  const credentialsIssue =
     output.includes('AWS credentials missing or invalid') ||
-    output.includes('Could not load credentials from any providers') ||
+    output.includes('Could not load credentials from any providers');
+  const networkIssue =
     output.includes('Unable to reach the Serverless API') ||
     output.includes('core.serverless.com');
+  const authIssue =
+    output.includes('You must sign in or use a license key with Serverless Framework V.4') ||
+    output.includes('Please use "serverless login".');
+  const canFallback = credentialsIssue || networkIssue || authIssue;
 
   if (!canFallback) {
     emitUnclassifiedFailure({
@@ -50,8 +55,13 @@ try {
     process.exit(1);
   }
 
+  const fallbackReason = authIssue
+    ? 'autenticação/licença do Serverless v4'
+    : credentialsIssue
+      ? 'credenciais AWS'
+      : 'rede';
   console.warn(
-    '\nAviso: empacotamento multi-stage indisponível no ambiente atual (credenciais/rede). Executando fallback com build local.',
+    `\nAviso: empacotamento multi-stage indisponível no ambiente atual (${fallbackReason}). Executando fallback com build local.`,
   );
   execSync(stagePackageFallbackCommand, { stdio: 'inherit', env: process.env });
 }

--- a/tests/unit/scripts/stage-validation-fallbacks.test.ts
+++ b/tests/unit/scripts/stage-validation-fallbacks.test.ts
@@ -96,4 +96,20 @@ describe('stage validation scripts - fallback diagnostics', () => {
     expect(result.output).toContain('fallback-build-ok');
     expect(result.output).not.toContain('UNCLASSIFIED_STAGE_VALIDATION_ERROR');
   });
+
+  it('preserves mapped package fallback behavior for Serverless v4 authentication errors', () => {
+    const result = runScript(STAGE_PACKAGE_SCRIPT, {
+      VALIDATE_STAGE_PACKAGE_COMMAND:
+        'node -e "process.stderr.write(\'Please use \\\\\\"serverless login\\\\\\".\\\\n\'); process.exit(1)"',
+      VALIDATE_STAGE_PACKAGE_FALLBACK_COMMAND:
+        'node -e "process.stdout.write(\'fallback-build-auth-ok\\\\n\')"',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      'empacotamento multi-stage indisponível no ambiente atual (autenticação/licença do Serverless v4)',
+    );
+    expect(result.output).toContain('fallback-build-auth-ok');
+    expect(result.output).not.toContain('UNCLASSIFIED_STAGE_VALIDATION_ERROR');
+  });
 });


### PR DESCRIPTION
## Summary
- mapear falhas de autenticação/licença do Serverless v4 no `validate-stage-package` como erro conhecido com fallback controlado
- incluir motivo explícito do fallback (`credenciais AWS`, `rede`, `autenticação/licença do Serverless v4`)
- adicionar teste de regressão para cenário `serverless login` e atualizar README
- registrar artefatos de execução (`platform_architect`, `worker`, `qa`)

## Test Plan
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test -- tests/unit/scripts/stage-validation-fallbacks.test.ts --runInBand`
- `npm run validate:stage-package`
- execução simulada de erro `serverless login` via `VALIDATE_STAGE_PACKAGE_COMMAND`

Closes #157