### PR TITLE
docs(step-functions): consolidar configuração de max concurrency

### DIFF
--- a/.codex/runs/platform_architect-issue-34.md
+++ b/.codex/runs/platform_architect-issue-34.md
@@ -1,0 +1,14 @@
+## Issue #34 — [EPIC 2] Configurar MaxConcurrency
+
+### Objetivo
+Consolidar contrato operacional do `MaxConcurrency` do Map da SFN por stage, com limites e override sem alteração de código-fonte.
+
+### Decisões arquiteturais
+1. Manter `MaxConcurrencyPath` dinâmico (`$.schedulerResult.maxConcurrency`) na ASL.
+2. Formalizar defaults por stage (`dev=2`, `stg=5`, `prod=10`) e limites de runtime (`1..40`).
+3. Documentar override operacional via variável `MAP_MAX_CONCURRENCY` no ambiente de execução.
+
+### Critérios técnicos de aceite
+- Map respeita limite configurável por stage.
+- Valor pode ser ajustado por configuração de ambiente.
+- Documentação explicita defaults, limites e override.

--- a/.codex/runs/qa-issue-34.md
+++ b/.codex/runs/qa-issue-34.md
@@ -1,0 +1,21 @@
+**QA — Issue #34 (Configurar MaxConcurrency)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum bloqueante.
+
+**Checklist de aceite da issue**
+
+- [x] Map respeita limite de concorrência configurado.
+- [x] Valor pode ser alterado por configuração de ambiente sem alteração de código-fonte.
+- [x] Configuração está documentada.
+
+**Evidências de validação**
+
+- `tests/unit/handlers/scheduler.test.ts` ✅
+- `tests/unit/state-machines/main-orchestration-v1.test.ts` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-34.md
+++ b/.codex/runs/worker-issue-34.md
@@ -1,0 +1,15 @@
+**Status de execução — Issue #34**
+
+**Escopo implementado**
+
+- Atualizada documentação da orquestração com defaults por stage e mecanismo de override sem código para `MAP_MAX_CONCURRENCY`:
+  - `docs/step-functions/main-orchestration-v1.md`
+  - `README.md`
+
+**Validações executadas**
+
+- `npm test -- tests/unit/handlers/scheduler.test.ts tests/unit/state-machines/main-orchestration-v1.test.ts --runInBand` ✅
+
+**Resultado**
+
+Issue #34 pronta para fechamento com critérios de parametrização, limites e documentação atendidos.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ O `serverless.yml` usa configuração explícita por stage e naming strategy par
   - Stage `prod`: `10`
   - Limites aceitos em runtime: inteiro entre `1` e `40`.
   - Fallback no scheduler quando ausente: `5`.
+  - Override sem alteração de código: ajuste `MAP_MAX_CONCURRENCY` no ambiente de execução (pipeline/deploy).
 - Coletora SQL (Postgres/MySQL) com pool controlado e cursor incremental:
   - `COLLECTOR_DEFAULT_CURSOR` (fallback inicial quando não existe cursor no evento nem na tabela `cursors`).
   - Precedência do cursor de execução: `event.cursor` > `cursors.last` > `COLLECTOR_DEFAULT_CURSOR`.

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -67,7 +67,11 @@ Payload esperado na execução:
   - falha: `sourceId`, `status=FAILED`, `error`, `cause`.
 - Controle de paralelismo:
   - `MaxConcurrencyPath = $.schedulerResult.maxConcurrency`.
-  - Valor configurado por stage via `MAP_MAX_CONCURRENCY`.
+  - Valor configurado por stage via `custom.stages.<stage>.mapMaxConcurrency`:
+    - `dev=2`
+    - `stg=5`
+    - `prod=10`
+  - O valor é injetado em runtime no Scheduler por `MAP_MAX_CONCURRENCY` e pode ser ajustado sem alteração de código-fonte (ex.: variável de ambiente no deploy/pipeline).
 
 ### BuildExecutionOutput (Pass)
 


### PR DESCRIPTION
Closes #34

---

## 🎯 Objetivo
Documentar de forma explícita como o `MaxConcurrency` do Map State é configurado por stage, quais são os limites válidos e como aplicar override operacional sem alterar código-fonte.

---

## 🧠 Decisão Técnica
- Mantido contrato dinâmico com `MaxConcurrencyPath = $.schedulerResult.maxConcurrency`.
- Consolidada documentação dos valores por stage (`dev=2`, `stg=5`, `prod=10`) e limites em runtime (`1..40`).
- Formalizado uso de `MAP_MAX_CONCURRENCY` como ponto de ajuste operacional no ambiente de execução.

---

## 🧪 BDD Validado
Dado que o Scheduler retorna `maxConcurrency` no contrato `scheduler-output.v1`
Quando a SFN executa o Map `ProcessEligibleSources`
Então o limite aplicado segue `$.schedulerResult.maxConcurrency`, respeitando configuração por stage e limites documentados.

---

## 🏗 Impacto Arquitetural
- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade
- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
