### PR TITLE
test(step-functions): validar retry exponencial com limite finito

### DIFF
--- a/.codex/runs/platform_architect-issue-35.md
+++ b/.codex/runs/platform_architect-issue-35.md
@@ -1,0 +1,14 @@
+## Issue #35 — [EPIC 2] Configurar Retry com backoff exponencial
+
+### Objetivo
+Consolidar política de retry da orquestração principal com backoff exponencial e teto finito de tentativas para tarefas críticas.
+
+### Decisões arquiteturais
+1. Manter política de retry transitória para `Scheduler` e `InvokeCollector`.
+2. Reforçar contrato de segurança operacional: `MaxAttempts` finito para evitar loops infinitos.
+3. Acrescentar teste objetivo da presença de backoff exponencial e limites de tentativas.
+
+### Critérios técnicos de aceite
+- Falhas transitórias têm retry automático com backoff.
+- Tarefas críticas possuem teto finito de tentativas.
+- Cobertura automatizada valida política de retry.

--- a/.codex/runs/qa-issue-35.md
+++ b/.codex/runs/qa-issue-35.md
@@ -1,0 +1,20 @@
+**QA — Issue #35 (Retry com backoff exponencial)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum bloqueante.
+
+**Checklist de aceite da issue**
+
+- [x] Retry por falhas transitórias configurado para scheduler e coletora.
+- [x] Backoff exponencial validado por teste.
+- [x] Execução sem loop infinito (tentativas finitas) validada por teste/documentação.
+
+**Evidências de validação**
+
+- `tests/unit/state-machines/main-orchestration-v1.test.ts` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-35.md
+++ b/.codex/runs/worker-issue-35.md
@@ -1,0 +1,18 @@
+**Status de execução — Issue #35**
+
+**Escopo implementado**
+
+- Reforço da documentação de retry na orquestração principal:
+  - `docs/step-functions/main-orchestration-v1.md`
+  - explicita tentativas finitas para evitar loop infinito.
+- Novo teste unitário para validar política de retry em `Scheduler` e `InvokeCollector`:
+  - `tests/unit/state-machines/main-orchestration-v1.test.ts`
+  - valida `IntervalSeconds >= 1`, `BackoffRate > 1` e teto finito de `MaxAttempts`.
+
+**Validações executadas**
+
+- `npm test -- tests/unit/state-machines/main-orchestration-v1.test.ts --runInBand` ✅
+
+**Resultado**
+
+Issue #35 pronta para fechamento com retry exponencial e limite de tentativas formalmente cobertos.

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -43,6 +43,7 @@ Payload esperado na execução:
     - `IntervalSeconds: 5`
     - `MaxAttempts: 2`
     - `BackoffRate: 2`
+  - Política limitada: número de tentativas é finito (`MaxAttempts`) para evitar loop infinito.
 - Saída esperada em `schedulerResult`:
   - `contractVersion` (`scheduler-output.v1`)
   - `sourceIds` (array de string)
@@ -58,6 +59,7 @@ Payload esperado na execução:
 - Entrada: `schedulerResult.sourceIds` e `schedulerResult.maxConcurrency`.
 - Ação: itera cada `sourceId` e invoca `CollectorLambdaFunction`.
 - Retry com backoff exponencial na task `InvokeCollector` com os mesmos limites do `Scheduler`.
+- Política limitada também no coletor (`MaxAttempts` finito), com `Catch` por item para manter tolerância a falha parcial.
 - Catch por item no `InvokeCollector` (`States.ALL`) para registrar falha da fonte sem interromper o `Map`.
 - Publica métricas customizadas por item usando `cloudwatch:PutMetricData` (não bloqueante):
   - `SourceProcessed` / `SourceFailed` (dimensão `Stage`);

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -484,4 +484,42 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(summary.schedulerStatus).toBe('SUCCEEDED');
     expect(summary.maxConcurrency).toBe(5);
   });
+
+  it('define retries com backoff exponencial e tentativas limitadas nas tasks críticas', () => {
+    const definition = loadDefinition();
+    const states = asObject(definition.States);
+    const scheduler = asObject(states.Scheduler);
+    const processEligibleSources = asObject(states.ProcessEligibleSources);
+    const iteratorStates = asObject(asObject(processEligibleSources.Iterator).States);
+    const invokeCollector = asObject(iteratorStates.InvokeCollector);
+
+    const retryGroups = [
+      {
+        stateName: 'Scheduler',
+        entries: asArray(scheduler.Retry),
+      },
+      {
+        stateName: 'InvokeCollector',
+        entries: asArray(invokeCollector.Retry),
+      },
+    ];
+
+    for (const group of retryGroups) {
+      expect(group.entries.length).toBeGreaterThan(0);
+
+      for (const entry of group.entries) {
+        const retry = asObject(entry);
+        expect(Number(retry.IntervalSeconds)).toBeGreaterThanOrEqual(1);
+        expect(Number(retry.MaxAttempts)).toBeGreaterThanOrEqual(1);
+        expect(Number(retry.BackoffRate)).toBeGreaterThanOrEqual(1);
+      }
+
+      const hasFiniteCeiling = group.entries.some((entry) => Number(asObject(entry).MaxAttempts) < 10);
+      expect(hasFiniteCeiling).toBe(true);
+      const hasExponentialBackoff = group.entries.some(
+        (entry) => Number(asObject(entry).BackoffRate) > 1,
+      );
+      expect(hasExponentialBackoff).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
Closes #35

---

## 🎯 Objetivo
Garantir que a política de retry da orquestração principal esteja explicitamente validada com backoff exponencial e limite finito de tentativas para evitar loops infinitos.

---

## 🧠 Decisão Técnica
- Mantida política de retry para `Scheduler` e `InvokeCollector`.
- Reforçada documentação para deixar explícito o teto finito (`MaxAttempts`) em ambas as tasks.
- Adicionado teste unitário dedicado para validar propriedades mínimas da política (`IntervalSeconds`, `BackoffRate`, `MaxAttempts`).

---

## 🧪 BDD Validado
Dado que a state machine possui tasks críticas sujeitas a falhas transitórias
Quando as políticas de retry são avaliadas em teste automatizado
Então ambas as tasks (`Scheduler` e `InvokeCollector`) apresentam backoff exponencial e tentativas finitas.

---

## 🏗 Impacto Arquitetural
- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade
- [ ] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

---

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
