### PR TITLE
test(collector): ampliar cobertura de fieldMap

### DIFF
--- a/.codex/runs/platform_architect-issue-75.md
+++ b/.codex/runs/platform_architect-issue-75.md
@@ -1,0 +1,14 @@
+## Issue #75 — [EPIC 8] Testes unitários do fieldMap
+
+### Objetivo
+Cobrir cenários críticos de transformação por `fieldMap` para reduzir regressões em payload canônico.
+
+### Decisões arquiteturais
+1. Expandir suíte de testes para mapping composto (múltiplos campos canônicos no mesmo registro).
+2. Validar estabilidade de tipos escalares canônicos (number/boolean/null).
+3. Preservar cobertura de campos ausentes e erro rastreável de campo obrigatório.
+
+### Critérios técnicos de aceite
+- Casos simples e compostos cobertos.
+- Campos ausentes tratados de forma previsível.
+- Conversão/estabilidade de tipos escalares validada na transformação.

--- a/.codex/runs/qa-issue-75.md
+++ b/.codex/runs/qa-issue-75.md
@@ -1,0 +1,20 @@
+**QA — Issue #75 (Testes unitários do fieldMap)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum bloqueante.
+
+**Checklist de aceite da issue**
+
+- [x] Testes de mapeamento simples e composto implementados.
+- [x] Tratamento de campos ausentes validado.
+- [x] Estabilidade de tipos escalares validada em testes.
+
+**Evidências de validação**
+
+- `tests/unit/domain/collector/map-records-with-field-map.test.ts` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-75.md
+++ b/.codex/runs/worker-issue-75.md
@@ -1,0 +1,15 @@
+**Status de execução — Issue #75**
+
+**Escopo implementado**
+
+- Ampliação de cobertura em `tests/unit/domain/collector/map-records-with-field-map.test.ts`:
+  - cenário de mapping composto com múltiplos campos canônicos;
+  - cenário de estabilidade de tipos escalares (`number`, `boolean`, `null`) e fallback `null` para campo ausente.
+
+**Validações executadas**
+
+- `npm test -- tests/unit/domain/collector/map-records-with-field-map.test.ts --runInBand` ✅
+
+**Resultado**
+
+Issue #75 pronta para fechamento com cobertura crítica de fieldMap reforçada.

--- a/tests/unit/domain/collector/map-records-with-field-map.test.ts
+++ b/tests/unit/domain/collector/map-records-with-field-map.test.ts
@@ -97,4 +97,68 @@ describe('mapRecordsWithFieldMap', () => {
       });
     }
   });
+
+  it('maps composed canonical payload with multiple mapped fields in a single pass', () => {
+    const result = mapRecordsWithFieldMap({
+      sourceId: 'source-acme',
+      records: [
+        {
+          customer_id: 456,
+          first_name: 'Ada',
+          last_name: 'Lovelace',
+          loyalty_level: 'gold',
+          external_meta: 'ignored',
+        },
+      ],
+      fieldMap: {
+        id: 'customer_id',
+        firstName: 'first_name',
+        lastName: 'last_name',
+        loyaltyTier: 'loyalty_level',
+      },
+      requiredCanonicalFields: ['id'],
+    });
+
+    expect(result.records).toEqual([
+      {
+        id: 456,
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        loyaltyTier: 'gold',
+      },
+    ]);
+    expect(result.ignoredSourceColumns).toEqual(['external_meta']);
+  });
+
+  it('keeps canonical scalar types stable when mapping numbers, booleans and nullables', () => {
+    const result = mapRecordsWithFieldMap({
+      sourceId: 'source-acme',
+      records: [
+        {
+          customer_id: 789,
+          is_active: true,
+          vip_score: 98.5,
+          notes: null,
+        },
+      ],
+      fieldMap: {
+        id: 'customer_id',
+        active: 'is_active',
+        score: 'vip_score',
+        notes: 'notes',
+        email: 'email_address',
+      },
+      requiredCanonicalFields: ['id'],
+    });
+
+    expect(result.records).toEqual([
+      {
+        id: 789,
+        active: true,
+        score: 98.5,
+        notes: null,
+        email: null,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #75

---

## 🎯 Objetivo
Expandir a cobertura unitária de `fieldMap` para reduzir regressões na normalização canônica com foco em mapeamento composto, campos ausentes e estabilidade de tipos escalares.

---

## 🧠 Decisão Técnica
- Mantido contrato atual de `mapRecordsWithFieldMap`.
- Adicionados cenários de teste para mapping composto e estabilidade de tipos (`number`, `boolean`, `null`).
- Preservado cenário de erro rastreável para campo obrigatório ausente.

---

## 🧪 BDD Validado
Dado um registro normalizado de origem com múltiplas colunas
Quando `fieldMap` é aplicado para montar o payload canônico
Então os campos mapeados são produzidos corretamente, colunas não mapeadas são identificadas e tipos escalares permanecem consistentes.

---

## 🏗 Impacto Arquitetural
- [x] Domain
- [ ] Application
- [ ] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade
- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
