### PR TITLE
test(scheduler): validar contrato de saída para sfn

### DIFF
--- a/.codex/runs/platform_architect-issue-77.md
+++ b/.codex/runs/platform_architect-issue-77.md
@@ -1,0 +1,14 @@
+## Issue #77 — [EPIC 8] Testes do Scheduler
+
+### Objetivo
+Fortalecer cobertura do Scheduler para elegibilidade, concorrência e contrato de saída para a Step Functions.
+
+### Decisões arquiteturais
+1. Preservar testes existentes de filtro por `nextRunAt` e conflito concorrente.
+2. Adicionar validação explícita do payload contratual final (`scheduler-output.v1`).
+3. Validar propagação de `executionId` para `correlationId` em logging estruturado.
+
+### Critérios técnicos de aceite
+- Regras de elegibilidade e conflito concorrente cobertas.
+- Saída contratual para SFN validada por teste.
+- `correlationId` propagado no log do scheduler.

--- a/.codex/runs/qa-issue-77.md
+++ b/.codex/runs/qa-issue-77.md
@@ -1,0 +1,21 @@
+**QA — Issue #77 (Testes do Scheduler)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum bloqueante.
+
+**Checklist de aceite da issue**
+
+- [x] Filtro por `nextRunAt` coberto.
+- [x] Conflito concorrente não quebra execução.
+- [x] Payload final para SFN validado.
+- [x] `correlationId` propagado no log estruturado.
+
+**Evidências de validação**
+
+- `tests/unit/handlers/scheduler.test.ts` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-77.md
+++ b/.codex/runs/worker-issue-77.md
@@ -1,0 +1,15 @@
+**Status de execução — Issue #77**
+
+**Escopo implementado**
+
+- Novo teste em `tests/unit/handlers/scheduler.test.ts` para:
+  - validar payload completo retornado ao Step Functions (`contractVersion`, `sourceIds`, `eligibleSources`, `hasEligibleSources`, `referenceNow`, `generatedAt`, `maxConcurrency`);
+  - validar propagação de `meta.executionId` em `correlationId` no log `scheduler.eligible_sources.filtered`.
+
+**Validações executadas**
+
+- `npm test -- tests/unit/handlers/scheduler.test.ts --runInBand` ✅
+
+**Resultado**
+
+Issue #77 pronta para fechamento com contrato de saída e rastreabilidade do Scheduler cobertos.

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -297,4 +297,37 @@ describe('scheduler handler', () => {
       'Invalid MAP_MAX_CONCURRENCY="0". Expected integer between 1 and 40.',
     );
   });
+
+  it('returns stable payload contract for Step Functions and propagates execution correlation id', async () => {
+    const logger = { info: jest.fn() };
+    const repository = new SpySourceRepository([{ items: [], nextToken: null }]);
+    const handler = createHandler({
+      sourceRepository: repository,
+      now: () => '2026-03-04T10:00:00.000Z',
+      activeSourcesPageSize: 10,
+      logger,
+    });
+
+    const result = await handler({
+      now: '2026-03-04T10:01:00.000Z',
+      meta: {
+        executionId: ' exec-123 ',
+      },
+    });
+
+    expect(result).toEqual({
+      contractVersion: 'scheduler-output.v1',
+      sourceIds: [],
+      eligibleSources: 0,
+      hasEligibleSources: false,
+      referenceNow: '2026-03-04T10:01:00.000Z',
+      generatedAt: '2026-03-04T10:00:00.000Z',
+      maxConcurrency: 5,
+    });
+    expect(logger.info).toHaveBeenCalledWith('scheduler.eligible_sources.filtered', {
+      referenceNow: '2026-03-04T10:01:00.000Z',
+      eligibleSources: 0,
+      correlationId: 'exec-123',
+    });
+  });
 });


### PR DESCRIPTION
Closes #77

---

## 🎯 Objetivo
Fortalecer a suíte do Scheduler para garantir estabilidade do contrato de saída consumido pela Step Functions e rastreabilidade com `executionId`.

---

## 🧠 Decisão Técnica
- Mantidos cenários já existentes de elegibilidade e conflito concorrente.
- Adicionado teste explícito do payload contratual final (`scheduler-output.v1`).
- Validada propagação de `meta.executionId` para `correlationId` no log estruturado.

---

## 🧪 BDD Validado
Dado que o Scheduler é executado pela orquestração principal
Quando não há fontes elegíveis e um `executionId` é informado
Então o payload de saída mantém contrato estável para SFN e o `correlationId` é propagado nos logs.

---

## 🏗 Impacto Arquitetural
- [x] Domain
- [x] Application
- [ ] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade
- [x] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes
- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
