### PR TITLE
docs(runbook): formalizar resposta a incidentes e replay de dlq

### DIFF
--- a/.codex/runs/platform_architect-issue-82.md
+++ b/.codex/runs/platform_architect-issue-82.md
@@ -1,0 +1,14 @@
+## Issue #82 — [EPIC 8] Runbook operacional (incidentes, DLQ e reprocessamento)
+
+### Objetivo
+Fechar lacunas operacionais do runbook com definicao clara de severidade, donos e fluxo reproduzivel de triagem/replay de DLQ.
+
+### Decisões arquiteturais
+1. Introduzir matriz de severidade com SLA de resposta e escalonamento.
+2. Definir papeis operacionais durante incidentes (Incident Commander, responsavel tecnico, comunicacao).
+3. Adicionar checklist rapido de triagem/replay com evidencias obrigatorias (audit JSON).
+
+### Critérios técnicos de aceite
+- Runbook cobre cenarios principais de falha.
+- Operacao consegue executar replay com passos objetivos.
+- Tempo de resposta e responsaveis ficam explicitamente definidos.

--- a/.codex/runs/qa-issue-82.md
+++ b/.codex/runs/qa-issue-82.md
@@ -1,0 +1,21 @@
+**QA — Issue #82 (Runbook operacional de incidentes e DLQ)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum.
+3. Médio: nenhum.
+4. Baixo: nenhum bloqueante.
+
+**Checklist de aceite da issue**
+
+- [x] Runbook cobre falhas principais de ingestao/integracao.
+- [x] Triagem e replay de DLQ documentados com passos executaveis.
+- [x] Tempos de resposta e responsaveis definidos.
+
+**Evidências de validação**
+
+- `docs/observability/operational-alarms-playbook.md` ✅
+- `docs/integrations/dlq-reprocessing.md` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-82.md
+++ b/.codex/runs/worker-issue-82.md
@@ -1,0 +1,20 @@
+**Status de execução — Issue #82**
+
+**Escopo implementado**
+
+- `docs/observability/operational-alarms-playbook.md` atualizado com:
+  - matriz de severidade (`SEV-1/2/3`) com tempos de reconhecimento e escalonamento;
+  - papeis e responsabilidades no incidente;
+  - checklist rapido de triagem/replay de DLQ;
+  - checklist pos-incidente com owner/prazo de follow-up.
+- `docs/integrations/dlq-reprocessing.md` atualizado com:
+  - vinculo explicito ao playbook operacional;
+  - requisito de anexar auditoria JSON ao incidente.
+
+**Validações executadas**
+
+- Revisao manual de consistencia do fluxo de resposta operacional ✅
+
+**Resultado**
+
+Issue #82 pronta para fechamento com runbook operacional completo para incidentes e DLQ.

--- a/docs/integrations/dlq-reprocessing.md
+++ b/docs/integrations/dlq-reprocessing.md
@@ -47,3 +47,5 @@ Replayed messages receive extra attributes:
 - Prefer `--dry-run` before effective replay in production.
 - Replay deletes from DLQ only after successful send to target queue.
 - Use narrow `--since/--until` windows during incidents to reduce blast radius.
+- Incident workflow and severities are documented in `docs/observability/operational-alarms-playbook.md`.
+- During incident response, attach the generated audit JSON to the incident timeline.

--- a/docs/observability/operational-alarms-playbook.md
+++ b/docs/observability/operational-alarms-playbook.md
@@ -2,6 +2,29 @@
 
 Este playbook cobre a primeira resposta para alarmes operacionais de ingestao e integracoes.
 
+## Responsaveis e tempo de resposta
+
+Matriz operacional minima por severidade:
+
+- `SEV-1` (ingestao parada em `prod` ou falha generalizada em integracoes criticas):
+  - reconhecimento do incidente: ate 5 minutos
+  - dono da resposta inicial: On-call da plataforma
+  - escalonamento: Tech Lead + Product/Operacoes em ate 10 minutos
+- `SEV-2` (degradacao parcial com backlog crescente ou falha recorrente em uma integracao):
+  - reconhecimento do incidente: ate 10 minutos
+  - dono da resposta inicial: On-call da plataforma
+  - escalonamento: Tech Lead em ate 20 minutos
+- `SEV-3` (impacto baixo, sem perda de dados e com contorno operacional):
+  - reconhecimento do incidente: ate 30 minutos
+  - dono da resposta inicial: Engenharia de plataforma (janela comercial)
+  - escalonamento: sob demanda
+
+Responsabilidades durante o incidente:
+
+- Incident Commander (On-call): coordena triagem, decisao de rollback e comunicacao de status.
+- Responsavel tecnico (engenheiro da feature afetada): executa mitigacao tecnica.
+- Comunicacao operacional (Product/Operacoes): atualiza stakeholders sobre impacto e ETA.
+
 ## Escopo de alarmes
 
 - Lambda errors (ingestao e integracoes):
@@ -36,6 +59,23 @@ Todos os alarmes notificam o topico SNS por stage:
 5. Se houver aculo em filas, verificar DLQ e aplicar triagem com:
    - `docs/integrations/dlq-reprocessing.md`
 
+## Triagem DLQ e replay (checklist rapido)
+
+1. Confirmar integracao impactada (`salesforce`, `hubspot` ou ambas) e janela do incidente.
+2. Rodar simulacao sem mutacao:
+   - `npm run dlq:reprocess -- --integration <salesforce|hubspot|all> --since <ISO> --until <ISO> --dry-run`
+3. Validar no resultado:
+   - quantidade elegivel para replay
+   - principais `failure reasons`
+   - risco de replay fora da janela do incidente
+4. Executar replay efetivo com escopo reduzido:
+   - `npm run dlq:reprocess -- --integration <...> --since <ISO> --until <ISO> --max-messages <N>`
+5. Confirmar sucesso:
+   - reducao de mensagens visiveis na DLQ
+   - aumento de consumo na fila principal
+   - estabilizacao dos alarmes de erro/latencia
+6. Anexar o arquivo de auditoria gerado (`.codex/runs/dlq-reprocess-<batch>.json`) no registro do incidente.
+
 ## Diagnostico por tipo
 
 ### Errors (Lambda)
@@ -58,6 +98,7 @@ Todos os alarmes notificam o topico SNS por stage:
 
 ## Pos-incidente
 
-1. Registrar causa raiz e acao corretiva.
-2. Criar issue de follow-up quando houver lacuna estrutural.
-3. Atualizar este playbook se a resposta operacional mudar.
+1. Registrar causa raiz, timeline e acao corretiva.
+2. Definir owner e prazo do follow-up tecnico (issue obrigatoria quando houver lacuna estrutural).
+3. Revisar se alarme, limiar ou playbook precisam ajuste.
+4. Publicar status final com impacto, mitigacao aplicada e pendencias.


### PR DESCRIPTION
Closes #82

---

## 🎯 Objetivo
Completar o runbook operacional para incidentes e DLQ com definição objetiva de severidade, responsáveis, tempos de resposta e procedimento reproduzível de replay.

---

## 🧠 Decisão Técnica
- Adicionada matriz `SEV-1/SEV-2/SEV-3` com SLA de reconhecimento e escalonamento.
- Definidos papéis operacionais durante incidente (Incident Commander, responsável técnico e comunicação).
- Adicionado checklist rápido de triagem/replay de DLQ com evidência obrigatória em auditoria JSON.
- Alinhado guia de reprocessamento manual para uso dentro do fluxo de incidentes.

---

## 🧪 BDD Validado
Dado um incidente com acúmulo em DLQ
Quando a operação segue o playbook atualizado
Então há passos claros para triagem, replay controlado, validação de recuperação e fechamento pós-incidente com responsabilidades definidas.

---

## 🏗 Impacto Arquitetural
- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade
- [x] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

---

## 🧪 Testes
- [ ] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release
- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist
- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
