### PR TITLE
fix(collector): corrigir idempotencia de upsert para retries sem perda

### DIFF
--- a/src/domain/collector/collector-idempotency-repository.ts
+++ b/src/domain/collector/collector-idempotency-repository.ts
@@ -1,8 +1,10 @@
 export type CollectorIdempotencyScope = 'upsert' | 'event';
+export type CollectorIdempotencyStatus = 'PENDING' | 'COMPLETED';
 
 export interface CollectorIdempotencyClaim {
   deduplicationKey: string;
   scope: CollectorIdempotencyScope;
+  status?: CollectorIdempotencyStatus;
   sourceId: string;
   recordId: string;
   cursor: string;
@@ -11,6 +13,13 @@ export interface CollectorIdempotencyClaim {
   expiresAtEpochSeconds: number;
 }
 
+export interface CollectorIdempotencyCompletion {
+  deduplicationKey: string;
+  completedAt: string;
+  expiresAtEpochSeconds: number;
+}
+
 export interface CollectorIdempotencyRepository {
   tryClaim(claim: CollectorIdempotencyClaim): Promise<boolean>;
+  markCompleted(params: CollectorIdempotencyCompletion): Promise<void>;
 }

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -845,6 +845,7 @@ export const createHandler =
             cursorToken,
           }),
           scope: 'upsert',
+          status: 'PENDING',
           sourceId,
           recordId,
           cursor: cursorToken,
@@ -881,6 +882,13 @@ export const createHandler =
           DeduplicatedRecords: duplicatedUpsertRecords.length,
         });
       }
+      if (nonDuplicatedUpsertRecords.length > 0) {
+        logger.info('collector.idempotency.upsert_pending_claimed', {
+          sourceId,
+          correlationId,
+          pendingCount: nonDuplicatedUpsertRecords.length,
+        });
+      }
 
       const upsertResult = await upsertCustomersBatchClient({
         sourceId,
@@ -897,6 +905,33 @@ export const createHandler =
       }
 
       const processedAt = now();
+      let completedUpsertClaims = 0;
+      for (const record of upsertResult.persistedRecords) {
+        const recordId = normalizeRecordId(record);
+        if (recordId.length === 0) {
+          continue;
+        }
+
+        await idempotencyRepository.markCompleted({
+          deduplicationKey: buildDeduplicationKey({
+            scope: 'upsert',
+            sourceId,
+            recordId,
+            cursorToken,
+          }),
+          completedAt: processedAt,
+          expiresAtEpochSeconds: claimExpiration,
+        });
+        completedUpsertClaims += 1;
+      }
+      if (completedUpsertClaims > 0) {
+        logger.info('collector.idempotency.upsert_completed', {
+          sourceId,
+          correlationId,
+          completedCount: completedUpsertClaims,
+        });
+      }
+
       const nonDuplicatedEventRecords: CollectorStandardizedRecord[] = [];
       const duplicatedEventRecords: CollectorStandardizedRecord[] = [];
       for (const record of upsertResult.persistedRecords) {

--- a/src/infra/idempotency/dynamodb-collector-idempotency-repository.ts
+++ b/src/infra/idempotency/dynamodb-collector-idempotency-repository.ts
@@ -2,11 +2,13 @@ import {
   ConditionalCheckFailedException,
   DynamoDBClient,
   PutItemCommand,
+  UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 
 import type {
   CollectorIdempotencyClaim,
+  CollectorIdempotencyCompletion,
   CollectorIdempotencyRepository,
 } from '../../domain/collector/collector-idempotency-repository';
 
@@ -48,6 +50,9 @@ export const createDynamoDbCollectorIdempotencyRepository = ({
         throw new Error('createdAt is required for idempotency claim.');
       }
 
+      const status = claim.status ?? 'COMPLETED';
+      const allowRetryWhenPending = status === 'PENDING';
+
       try {
         await client.send(
           new PutItemCommand({
@@ -55,6 +60,7 @@ export const createDynamoDbCollectorIdempotencyRepository = ({
             Item: marshall({
               deduplicationKey,
               scope: claim.scope,
+              status,
               sourceId: claim.sourceId,
               recordId: claim.recordId,
               cursor: claim.cursor,
@@ -62,10 +68,18 @@ export const createDynamoDbCollectorIdempotencyRepository = ({
               createdAt,
               expiresAt: claim.expiresAtEpochSeconds,
             }),
-            ConditionExpression: 'attribute_not_exists(#deduplicationKey)',
+            ConditionExpression: allowRetryWhenPending
+              ? 'attribute_not_exists(#deduplicationKey) OR #status = :pending'
+              : 'attribute_not_exists(#deduplicationKey)',
             ExpressionAttributeNames: {
               '#deduplicationKey': 'deduplicationKey',
+              '#status': 'status',
             },
+            ExpressionAttributeValues: allowRetryWhenPending
+              ? marshall({
+                  ':pending': 'PENDING',
+                })
+              : undefined,
           }),
         );
       } catch (error) {
@@ -77,6 +91,38 @@ export const createDynamoDbCollectorIdempotencyRepository = ({
       }
 
       return true;
+    },
+    async markCompleted(params: CollectorIdempotencyCompletion): Promise<void> {
+      const deduplicationKey = params.deduplicationKey.trim();
+      if (deduplicationKey.length === 0) {
+        throw new Error('deduplicationKey is required for idempotency completion.');
+      }
+
+      const completedAt = params.completedAt.trim();
+      if (completedAt.length === 0) {
+        throw new Error('completedAt is required for idempotency completion.');
+      }
+
+      await client.send(
+        new UpdateItemCommand({
+          TableName: resolvedTableName,
+          Key: marshall({
+            deduplicationKey,
+          }),
+          UpdateExpression:
+            'SET #status = :completed, #completedAt = :completedAt, #expiresAt = :expiresAt',
+          ExpressionAttributeNames: {
+            '#status': 'status',
+            '#completedAt': 'completedAt',
+            '#expiresAt': 'expiresAt',
+          },
+          ExpressionAttributeValues: marshall({
+            ':completed': 'COMPLETED',
+            ':completedAt': completedAt,
+            ':expiresAt': params.expiresAtEpochSeconds,
+          }),
+        }),
+      );
     },
   };
 };

--- a/tests/unit/handlers/collector.test.ts
+++ b/tests/unit/handlers/collector.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
-import type { CollectorIdempotencyClaim } from '../../../src/domain/collector/collector-idempotency-repository';
+import type {
+  CollectorIdempotencyClaim,
+  CollectorIdempotencyCompletion,
+} from '../../../src/domain/collector/collector-idempotency-repository';
 import type { CollectorCursorValue } from '../../../src/domain/collector/collector-cursor-repository';
 import type { CollectorStandardizedRecord } from '../../../src/domain/collector/collect-postgres-records';
 import type { MySqlQueryExecutor } from '../../../src/domain/collector/collect-mysql-records';
@@ -236,21 +239,30 @@ class SpyCustomerEventsPublisher {
 
 class SpyCollectorIdempotencyRepository {
   public readonly tryClaimCalls: CollectorIdempotencyClaim[] = [];
-  private readonly claimedKeys = new Set<string>();
+  public readonly markCompletedCalls: CollectorIdempotencyCompletion[] = [];
+  private readonly statusByKey = new Map<string, 'PENDING' | 'COMPLETED'>();
 
   constructor(private readonly forcedDuplicateKeys: Set<string> = new Set()) {}
 
   tryClaim = (claim: CollectorIdempotencyClaim): Promise<boolean> => {
     this.tryClaimCalls.push(claim);
-    if (
-      this.forcedDuplicateKeys.has(claim.deduplicationKey) ||
-      this.claimedKeys.has(claim.deduplicationKey)
-    ) {
+    if (this.forcedDuplicateKeys.has(claim.deduplicationKey)) {
       return Promise.resolve(false);
     }
 
-    this.claimedKeys.add(claim.deduplicationKey);
+    const currentStatus = this.statusByKey.get(claim.deduplicationKey);
+    if (currentStatus === 'COMPLETED') {
+      return Promise.resolve(false);
+    }
+
+    this.statusByKey.set(claim.deduplicationKey, claim.status ?? 'COMPLETED');
     return Promise.resolve(true);
+  };
+
+  markCompleted = (params: CollectorIdempotencyCompletion): Promise<void> => {
+    this.markCompletedCalls.push(params);
+    this.statusByKey.set(params.deduplicationKey, 'COMPLETED');
+    return Promise.resolve();
   };
 }
 
@@ -400,7 +412,7 @@ describe('collector handler', () => {
         values: ['2026-03-04T09:59:00.000Z'],
       },
     ]);
-    expect(logger.infoCalls).toEqual([
+    expect(logger.infoCalls).toEqual(expect.arrayContaining([
       [
         'collector.cursor.loaded',
         {
@@ -436,6 +448,22 @@ describe('collector handler', () => {
         },
       ],
       [
+        'collector.idempotency.upsert_pending_claimed',
+        {
+          sourceId: 'source-acme',
+          correlationId: 'source-acme-unknown-updated_at',
+          pendingCount: 2,
+        },
+      ],
+      [
+        'collector.idempotency.upsert_completed',
+        {
+          sourceId: 'source-acme',
+          correlationId: 'source-acme-unknown-updated_at',
+          completedCount: 2,
+        },
+      ],
+      [
         'collector.cursor.updated',
         {
           sourceId: 'source-acme',
@@ -444,7 +472,7 @@ describe('collector handler', () => {
           conflictRetries: 0,
         },
       ],
-    ]);
+    ]));
   });
 
   it('loads source config, runs mysql incremental query and returns standardized result', async () => {
@@ -827,6 +855,89 @@ describe('collector handler', () => {
           { id: 10, email: 'first@example.com' },
           { id: 11, email: 'second@example.com' },
         ],
+      },
+    ]);
+  });
+
+  it('retries upsert records after transient failure without false deduplication', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([[VALID_SOURCE.sourceId, VALID_SOURCE]]),
+    );
+    const secrets = new SpySecretRepository(
+      new Map<string, string | null>([
+        [
+          VALID_SOURCE.secretArn,
+          JSON.stringify({
+            host: 'db.internal',
+            port: 5432,
+            database: 'crm',
+            username: 'collector_user',
+            password: 'collector_password',
+          }),
+        ],
+      ]),
+    );
+    const postgresFactory = new SpyPostgresQueryExecutorFactory([
+      {
+        customer_id: 10,
+        email: 'first@example.com',
+        updated_at: new Date('2026-03-04T10:10:00.000Z'),
+      },
+    ]);
+    let upstreamAttempts = 0;
+    const upsertClient = new SpyUpsertCustomersBatchClient((records) => {
+      upstreamAttempts += 1;
+      if (upstreamAttempts === 1) {
+        throw new Error('temporary upstream failure');
+      }
+
+      return {
+        persistedRecords: [...records],
+        rejectedRecords: [],
+        attempts: 1,
+        durationMs: 20,
+      };
+    });
+    const idempotencyRepository = new SpyCollectorIdempotencyRepository();
+
+    const handler = createCollectorHandler({
+      sourceRegistryRepository: repository,
+      secretRepository: secrets,
+      postgresQueryExecutorFactory: postgresFactory,
+      upsertCustomersBatchClient: upsertClient,
+      idempotencyRepository,
+    });
+
+    await expect(handler({ sourceId: VALID_SOURCE.sourceId })).rejects.toThrow(
+      'temporary upstream failure',
+    );
+
+    const result = await handler({ sourceId: VALID_SOURCE.sourceId });
+
+    expect(result.recordsSent).toBe(1);
+    expect(result.deduplicatedUpsertRecords).toBe(0);
+    expect(upsertClient.calls).toEqual([
+      {
+        sourceId: VALID_SOURCE.sourceId,
+        correlationId: `${VALID_SOURCE.sourceId}-unknown-${VALID_SOURCE.cursorField}`,
+        records: [{ id: 10, email: 'first@example.com' }],
+      },
+      {
+        sourceId: VALID_SOURCE.sourceId,
+        correlationId: `${VALID_SOURCE.sourceId}-unknown-${VALID_SOURCE.cursorField}`,
+        records: [{ id: 10, email: 'first@example.com' }],
+      },
+    ]);
+    expect(
+      idempotencyRepository.tryClaimCalls
+        .filter((claim) => claim.scope === 'upsert')
+        .map((claim) => claim.status),
+    ).toEqual(['PENDING', 'PENDING']);
+    expect(idempotencyRepository.markCompletedCalls).toEqual([
+      {
+        deduplicationKey: `upsert:${VALID_SOURCE.sourceId}:2026-03-01T00:00:00.000Z:10`,
+        completedAt: '2026-03-04T11:00:00.000Z',
+        expiresAtEpochSeconds: 3601,
       },
     ]);
   });

--- a/tests/unit/infra/idempotency/dynamodb-collector-idempotency-repository.test.ts
+++ b/tests/unit/infra/idempotency/dynamodb-collector-idempotency-repository.test.ts
@@ -67,4 +67,43 @@ describe('createDynamoDbCollectorIdempotencyRepository', () => {
     expect(result).toBe(false);
     expect(client.sendCalls).toHaveLength(1);
   });
+
+  it('allows reclaim when previous status is pending', async () => {
+    const client = new SpyDynamoDbClient('success');
+    const repository = createDynamoDbCollectorIdempotencyRepository({
+      tableName: 'idempotency-table',
+      client: client as never,
+    });
+
+    const result = await repository.tryClaim({
+      deduplicationKey: 'upsert:source:cursor:1',
+      scope: 'upsert',
+      status: 'PENDING',
+      sourceId: 'source',
+      recordId: '1',
+      cursor: 'cursor',
+      correlationId: 'exec-1',
+      createdAt: '2026-03-04T10:00:00.000Z',
+      expiresAtEpochSeconds: 1_776_000_000,
+    });
+
+    expect(result).toBe(true);
+    expect(client.sendCalls).toHaveLength(1);
+  });
+
+  it('marks claim as completed after successful processing', async () => {
+    const client = new SpyDynamoDbClient('success');
+    const repository = createDynamoDbCollectorIdempotencyRepository({
+      tableName: 'idempotency-table',
+      client: client as never,
+    });
+
+    await repository.markCompleted({
+      deduplicationKey: 'upsert:source:cursor:1',
+      completedAt: '2026-03-04T10:05:00.000Z',
+      expiresAtEpochSeconds: 1_776_000_100,
+    });
+
+    expect(client.sendCalls).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Closes #169

> Obrigatório: referência real de issue aplicada.

---

## 🎯 Objetivo

Corrigir falso positivo de deduplicação no `scope=upsert` quando ocorre falha transitória na API oficial, garantindo que retries reenviem registros ainda pendentes.

---

## 🧠 Decisão Técnica

- Introduzido estado de idempotência (`PENDING`/`COMPLETED`) no contrato da coletora.
- `scope=upsert` passa a:
  - claim em `PENDING` antes do upsert;
  - transição para `COMPLETED` apenas após confirmação em `persistedRecords`.
- Repositório DynamoDB atualizado para:
  - permitir reclaim quando status atual está `PENDING`;
  - persistir conclusão com `markCompleted`.
- `scope=event` mantido sem mudança funcional nesta issue para isolar escopo (issue #170 cobre essa etapa).

---

## 🧪 BDD Validado

Dado que o upsert falha por erro transitório após claim de idempotência em `upsert`
Quando a coletora é reexecutada
Então os registros pendentes não são descartados por deduplicação incorreta e são reenviados.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [x] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
