### PR TITLE
fix(collector): tornar idempotencia de publicacao SNS resiliente

### DIFF
--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -932,9 +932,28 @@ export const createHandler =
         });
       }
 
+      const eventCandidatesByRecordId = new Map<string, CollectorStandardizedRecord>();
+      for (const record of upsertResult.persistedRecords) {
+        const recordId = normalizeRecordId(record);
+        if (recordId.length === 0) {
+          continue;
+        }
+
+        eventCandidatesByRecordId.set(recordId, record);
+      }
+      for (const record of duplicatedUpsertRecords) {
+        const recordId = normalizeRecordId(record);
+        if (recordId.length === 0) {
+          continue;
+        }
+
+        eventCandidatesByRecordId.set(recordId, record);
+      }
+      const eventCandidateRecords = Array.from(eventCandidatesByRecordId.values());
+
       const nonDuplicatedEventRecords: CollectorStandardizedRecord[] = [];
       const duplicatedEventRecords: CollectorStandardizedRecord[] = [];
-      for (const record of upsertResult.persistedRecords) {
+      for (const record of eventCandidateRecords) {
         const recordId = normalizeRecordId(record);
         if (recordId.length === 0) {
           duplicatedEventRecords.push(record);
@@ -949,6 +968,7 @@ export const createHandler =
             cursorToken,
           }),
           scope: 'event',
+          status: 'PENDING',
           sourceId,
           recordId,
           cursor: cursorToken,
@@ -986,17 +1006,54 @@ export const createHandler =
         });
       }
 
-      const publishResult = await customerEventsPublisher({
-        sourceId,
-        correlationId,
-        records: nonDuplicatedEventRecords,
-        publishedAt: processedAt,
-      });
-      if (publishResult.publishedCount > 0) {
+      if (nonDuplicatedEventRecords.length > 0) {
+        logger.info('collector.idempotency.event_pending_claimed', {
+          sourceId,
+          correlationId,
+          pendingCount: nonDuplicatedEventRecords.length,
+        });
+      }
+
+      let publishedEventsCount = 0;
+      let completedEventClaims = 0;
+      for (const record of nonDuplicatedEventRecords) {
+        await customerEventsPublisher({
+          sourceId,
+          correlationId,
+          records: [record],
+          publishedAt: processedAt,
+        });
+
+        publishedEventsCount += 1;
+        const recordId = normalizeRecordId(record);
+        if (recordId.length === 0) {
+          continue;
+        }
+
+        await idempotencyRepository.markCompleted({
+          deduplicationKey: buildDeduplicationKey({
+            scope: 'event',
+            sourceId,
+            recordId,
+            cursorToken,
+          }),
+          completedAt: processedAt,
+          expiresAtEpochSeconds: claimExpiration,
+        });
+        completedEventClaims += 1;
+      }
+      if (publishedEventsCount > 0) {
         logger.info('collector.sns.events_published', {
           sourceId,
           correlationId,
-          publishedCount: publishResult.publishedCount,
+          publishedCount: publishedEventsCount,
+        });
+      }
+      if (completedEventClaims > 0) {
+        logger.info('collector.idempotency.event_completed', {
+          sourceId,
+          correlationId,
+          completedCount: completedEventClaims,
         });
       }
 
@@ -1032,7 +1089,7 @@ export const createHandler =
         rejectedRecords: canonicalValidationResult.rejectedRecords,
         persistenceRejectedRecords: upsertResult.rejectedRecords,
         upsertAttempts: upsertResult.attempts,
-        eventsPublished: publishResult.publishedCount,
+        eventsPublished: publishedEventsCount,
         deduplicatedUpsertRecords: duplicatedUpsertRecords.length,
         deduplicatedEventRecords: duplicatedEventRecords.length,
       };

--- a/tests/unit/handlers/collector.test.ts
+++ b/tests/unit/handlers/collector.test.ts
@@ -933,9 +933,96 @@ describe('collector handler', () => {
         .filter((claim) => claim.scope === 'upsert')
         .map((claim) => claim.status),
     ).toEqual(['PENDING', 'PENDING']);
-    expect(idempotencyRepository.markCompletedCalls).toEqual([
+    const upsertCompletions = idempotencyRepository.markCompletedCalls.filter((completion) =>
+      completion.deduplicationKey.startsWith('upsert:'),
+    );
+    expect(upsertCompletions).toEqual([
       {
         deduplicationKey: `upsert:${VALID_SOURCE.sourceId}:2026-03-01T00:00:00.000Z:10`,
+        completedAt: '2026-03-04T11:00:00.000Z',
+        expiresAtEpochSeconds: 3601,
+      },
+    ]);
+  });
+
+  it('retries only pending SNS events after partial publish failure', async () => {
+    const repository = new SpySourceRegistryRepository(
+      new Map<string, SourceRegistryRecord>([[VALID_SOURCE.sourceId, VALID_SOURCE]]),
+    );
+    const secrets = new SpySecretRepository(
+      new Map<string, string | null>([
+        [
+          VALID_SOURCE.secretArn,
+          JSON.stringify({
+            host: 'db.internal',
+            port: 5432,
+            database: 'crm',
+            username: 'collector_user',
+            password: 'collector_password',
+          }),
+        ],
+      ]),
+    );
+    const postgresFactory = new SpyPostgresQueryExecutorFactory([
+      {
+        customer_id: 10,
+        email: 'first@example.com',
+        updated_at: new Date('2026-03-04T10:10:00.000Z'),
+      },
+      {
+        customer_id: 11,
+        email: 'second@example.com',
+        updated_at: new Date('2026-03-04T10:20:00.000Z'),
+      },
+    ]);
+    let shouldFailRecord11 = true;
+    const eventsPublisher = new SpyCustomerEventsPublisher((records) => {
+      const [record] = records;
+      if (record?.id === 11 && shouldFailRecord11) {
+        shouldFailRecord11 = false;
+        throw new Error('sns transient failure');
+      }
+
+      return {
+        publishedCount: records.length,
+      };
+    });
+    const idempotencyRepository = new SpyCollectorIdempotencyRepository();
+
+    const handler = createCollectorHandler({
+      sourceRegistryRepository: repository,
+      secretRepository: secrets,
+      postgresQueryExecutorFactory: postgresFactory,
+      customerEventsPublisher: eventsPublisher,
+      idempotencyRepository,
+    });
+
+    await expect(handler({ sourceId: VALID_SOURCE.sourceId })).rejects.toThrow(
+      'sns transient failure',
+    );
+
+    const retryResult = await handler({ sourceId: VALID_SOURCE.sourceId });
+
+    expect(retryResult.recordsSent).toBe(0);
+    expect(retryResult.eventsPublished).toBe(1);
+
+    const publishedRecordIds = eventsPublisher.calls.map((call) => {
+      const [record] = call.records;
+      return record?.id;
+    });
+    expect(publishedRecordIds).toEqual([10, 11, 11]);
+
+    const eventCompletions = idempotencyRepository.markCompletedCalls.filter((completion) =>
+      completion.deduplicationKey.startsWith('event:'),
+    );
+    expect(eventCompletions).toEqual([
+      {
+        deduplicationKey: `event:${VALID_SOURCE.sourceId}:2026-03-01T00:00:00.000Z:10`,
+        completedAt: '2026-03-04T11:00:00.000Z',
+        expiresAtEpochSeconds: 3601,
+      },
+      {
+        deduplicationKey: `event:${VALID_SOURCE.sourceId}:2026-03-01T00:00:00.000Z:11`,
         completedAt: '2026-03-04T11:00:00.000Z',
         expiresAtEpochSeconds: 3601,
       },
@@ -996,7 +1083,7 @@ describe('collector handler', () => {
 
     expect(result.recordsSent).toBe(1);
     expect(result.records).toEqual([{ id: 10, email: 'first@example.com' }]);
-    expect(result.eventsPublished).toBe(0);
+    expect(result.eventsPublished).toBe(1);
     expect(result.deduplicatedUpsertRecords).toBe(1);
     expect(result.deduplicatedEventRecords).toBe(1);
     expect(upsertClient.calls).toEqual([
@@ -1010,7 +1097,7 @@ describe('collector handler', () => {
       {
         sourceId: VALID_SOURCE.sourceId,
         correlationId: `${VALID_SOURCE.sourceId}-dev-${VALID_SOURCE.cursorField}`,
-        records: [],
+        records: [{ id: 11, email: 'second@example.com' }],
         publishedAt: '2026-03-04T11:00:00.000Z',
       },
     ]);


### PR DESCRIPTION
Closes #170

---

## 🎯 Objetivo

Garantir idempotência resiliente para publicação de eventos no SNS, sem perda de eventos pendentes em falha transitória e sem duplicar eventos já confirmados.

---

## 🧠 Decisão Técnica

- `scope=event` passa a usar ciclo `PENDING -> COMPLETED`:
  - claim em `PENDING` antes do publish;
  - conclusão (`markCompleted`) por registro após publish bem-sucedido.
- Publicação SNS foi feita em granularidade por registro na coletora para permitir confirmação individual.
- Eventos candidatos agora incluem:
  - registros persistidos no upsert atual;
  - registros com upsert previamente deduplicado/completo.
- Em falha parcial:
  - eventos já publicados ficam `COMPLETED`;
  - eventos não publicados seguem pendentes para retry.

---

## 🧪 BDD Validado

Dado que a publicação SNS falha após publicar parte dos registros
Quando a coletora é reexecutada
Então os eventos já publicados não são republicados e os eventos pendentes são publicados até sucesso.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [x] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
