### PR TITLE
feat(consumers): adicionar idempotencia nas consumidoras SQS

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -38,6 +38,7 @@ provider:
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS, '200'}
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE, '2'}
     COLLECTOR_IDEMPOTENCY_TTL_SECONDS: ${env:COLLECTOR_IDEMPOTENCY_TTL_SECONDS, '604800'}
+    CONSUMER_IDEMPOTENCY_TTL_SECONDS: ${env:CONSUMER_IDEMPOTENCY_TTL_SECONDS, '604800'}
     INTEGRATION_API_TIMEOUT_MS: ${env:INTEGRATION_API_TIMEOUT_MS, '5000'}
     METRICS_NAMESPACE: ${env:METRICS_NAMESPACE, 'AlertOrchestrationService/Runtime'}
     INTEGRATION_TARGETS: ${env:INTEGRATION_TARGETS, 'salesforce|hubspot'}
@@ -675,6 +676,15 @@ resources:
                     - logs:PutLogEvents
                   Resource:
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.salesforceConsumerFunctionName}:*
+                - Sid: WriteSalesforceConsumerIdempotencyClaims
+                  Effect: Allow
+                  Action:
+                    - dynamodb:PutItem
+                    - dynamodb:UpdateItem
+                  Resource:
+                    - Fn::GetAtt:
+                        - IdempotencyTable
+                        - Arn
                 - Sid: PublishSalesforceRuntimeMetrics
                   Effect: Allow
                   Action:
@@ -719,6 +729,15 @@ resources:
                     - logs:PutLogEvents
                   Resource:
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.hubspotConsumerFunctionName}:*
+                - Sid: WriteHubspotConsumerIdempotencyClaims
+                  Effect: Allow
+                  Action:
+                    - dynamodb:PutItem
+                    - dynamodb:UpdateItem
+                  Resource:
+                    - Fn::GetAtt:
+                        - IdempotencyTable
+                        - Arn
                 - Sid: PublishHubspotRuntimeMetrics
                   Effect: Allow
                   Action:

--- a/src/domain/collector/collector-idempotency-repository.ts
+++ b/src/domain/collector/collector-idempotency-repository.ts
@@ -1,4 +1,4 @@
-export type CollectorIdempotencyScope = 'upsert' | 'event';
+export type CollectorIdempotencyScope = 'upsert' | 'event' | 'consumer';
 export type CollectorIdempotencyStatus = 'PENDING' | 'COMPLETED';
 
 export interface CollectorIdempotencyClaim {

--- a/src/handlers/hubspot-consumer.ts
+++ b/src/handlers/hubspot-consumer.ts
@@ -8,6 +8,7 @@ import {
   IntegrationExternalApiTransientError,
   createIntegrationExternalApiClient,
 } from '../infra/integrations/external-api-client';
+import { createDynamoDbCollectorIdempotencyRepository } from '../infra/idempotency/dynamodb-collector-idempotency-repository';
 import { createFetchIntegrationHttpClient } from '../infra/integrations/fetch-integration-http-client';
 import { createCloudWatchMetricsPublisher } from '../infra/observability/cloudwatch-metrics-publisher';
 import { createIntegrationDeliveryMetricsPublisher } from '../infra/observability/integration-delivery-metrics-publisher';
@@ -15,6 +16,8 @@ import { createIntegrationDeliveryMetricsPublisher } from '../infra/observabilit
 const HUBSPOT_INTEGRATION_NAME = 'hubspot';
 const HUBSPOT_TARGET_BASE_URL_ENV = 'HUBSPOT_INTEGRATION_TARGET_BASE_URL';
 const INTEGRATION_API_TIMEOUT_MS_ENV = 'INTEGRATION_API_TIMEOUT_MS';
+const IDEMPOTENCY_TABLE_NAME_ENV = 'IDEMPOTENCY_TABLE_NAME';
+const CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV = 'CONSUMER_IDEMPOTENCY_TTL_SECONDS';
 const METRICS_NAMESPACE_ENV = 'METRICS_NAMESPACE';
 const METRICS_NAMESPACE_DEFAULT = 'AlertOrchestrationService/Runtime';
 const STAGE_ENV = 'STAGE';
@@ -22,6 +25,9 @@ const SERVICE_NAME_ENV = 'SERVICE_NAME';
 const INTEGRATION_API_TIMEOUT_MS_DEFAULT = 5000;
 const INTEGRATION_API_TIMEOUT_MS_MIN = 100;
 const INTEGRATION_API_TIMEOUT_MS_MAX = 60000;
+const CONSUMER_IDEMPOTENCY_TTL_SECONDS_DEFAULT = 604_800;
+const CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN = 60;
+const CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX = 2_592_000;
 
 let cachedHandler:
   | ((event: IntegrationConsumerSqsEvent) => Promise<IntegrationConsumerSqsResult>)
@@ -52,6 +58,26 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     }
   }
 
+  const idempotencyTableName = process.env[IDEMPOTENCY_TABLE_NAME_ENV];
+  if (!idempotencyTableName || idempotencyTableName.trim().length === 0) {
+    throw new Error(`${IDEMPOTENCY_TABLE_NAME_ENV} is required.`);
+  }
+
+  let idempotencyTtlSeconds = CONSUMER_IDEMPOTENCY_TTL_SECONDS_DEFAULT;
+  const idempotencyTtlRawValue = process.env[CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV];
+  if (idempotencyTtlRawValue) {
+    idempotencyTtlSeconds = Number.parseInt(idempotencyTtlRawValue, 10);
+    if (
+      !Number.isInteger(idempotencyTtlSeconds) ||
+      idempotencyTtlSeconds < CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN ||
+      idempotencyTtlSeconds > CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX
+    ) {
+      throw new Error(
+        `${CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV} must be an integer between ${CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN} and ${CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX}.`,
+      );
+    }
+  }
+
   const sendCustomerEvent = createIntegrationExternalApiClient({
     integrationName: HUBSPOT_INTEGRATION_NAME,
     targetBaseUrl,
@@ -69,6 +95,10 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
   cachedHandler = createIntegrationConsumerHandler({
     integrationName: HUBSPOT_INTEGRATION_NAME,
     targetBaseUrl,
+    idempotencyRepository: createDynamoDbCollectorIdempotencyRepository({
+      tableName: idempotencyTableName,
+    }),
+    idempotencyTtlSeconds,
     processRecord: ({ messageId, payload }) => sendCustomerEvent({ messageId, payload }),
     classifyError: (error) => {
       if (error instanceof IntegrationExternalApiPermanentError) {

--- a/src/handlers/salesforce-consumer.ts
+++ b/src/handlers/salesforce-consumer.ts
@@ -8,6 +8,7 @@ import {
   IntegrationExternalApiTransientError,
   createIntegrationExternalApiClient,
 } from '../infra/integrations/external-api-client';
+import { createDynamoDbCollectorIdempotencyRepository } from '../infra/idempotency/dynamodb-collector-idempotency-repository';
 import { createFetchIntegrationHttpClient } from '../infra/integrations/fetch-integration-http-client';
 import { createCloudWatchMetricsPublisher } from '../infra/observability/cloudwatch-metrics-publisher';
 import { createIntegrationDeliveryMetricsPublisher } from '../infra/observability/integration-delivery-metrics-publisher';
@@ -15,6 +16,8 @@ import { createIntegrationDeliveryMetricsPublisher } from '../infra/observabilit
 const SALESFORCE_INTEGRATION_NAME = 'salesforce';
 const SALESFORCE_TARGET_BASE_URL_ENV = 'SALESFORCE_INTEGRATION_TARGET_BASE_URL';
 const INTEGRATION_API_TIMEOUT_MS_ENV = 'INTEGRATION_API_TIMEOUT_MS';
+const IDEMPOTENCY_TABLE_NAME_ENV = 'IDEMPOTENCY_TABLE_NAME';
+const CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV = 'CONSUMER_IDEMPOTENCY_TTL_SECONDS';
 const METRICS_NAMESPACE_ENV = 'METRICS_NAMESPACE';
 const METRICS_NAMESPACE_DEFAULT = 'AlertOrchestrationService/Runtime';
 const STAGE_ENV = 'STAGE';
@@ -22,6 +25,9 @@ const SERVICE_NAME_ENV = 'SERVICE_NAME';
 const INTEGRATION_API_TIMEOUT_MS_DEFAULT = 5000;
 const INTEGRATION_API_TIMEOUT_MS_MIN = 100;
 const INTEGRATION_API_TIMEOUT_MS_MAX = 60000;
+const CONSUMER_IDEMPOTENCY_TTL_SECONDS_DEFAULT = 604_800;
+const CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN = 60;
+const CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX = 2_592_000;
 
 let cachedHandler:
   | ((event: IntegrationConsumerSqsEvent) => Promise<IntegrationConsumerSqsResult>)
@@ -52,6 +58,26 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     }
   }
 
+  const idempotencyTableName = process.env[IDEMPOTENCY_TABLE_NAME_ENV];
+  if (!idempotencyTableName || idempotencyTableName.trim().length === 0) {
+    throw new Error(`${IDEMPOTENCY_TABLE_NAME_ENV} is required.`);
+  }
+
+  let idempotencyTtlSeconds = CONSUMER_IDEMPOTENCY_TTL_SECONDS_DEFAULT;
+  const idempotencyTtlRawValue = process.env[CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV];
+  if (idempotencyTtlRawValue) {
+    idempotencyTtlSeconds = Number.parseInt(idempotencyTtlRawValue, 10);
+    if (
+      !Number.isInteger(idempotencyTtlSeconds) ||
+      idempotencyTtlSeconds < CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN ||
+      idempotencyTtlSeconds > CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX
+    ) {
+      throw new Error(
+        `${CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV} must be an integer between ${CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN} and ${CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX}.`,
+      );
+    }
+  }
+
   const sendCustomerEvent = createIntegrationExternalApiClient({
     integrationName: SALESFORCE_INTEGRATION_NAME,
     targetBaseUrl,
@@ -69,6 +95,10 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
   cachedHandler = createIntegrationConsumerHandler({
     integrationName: SALESFORCE_INTEGRATION_NAME,
     targetBaseUrl,
+    idempotencyRepository: createDynamoDbCollectorIdempotencyRepository({
+      tableName: idempotencyTableName,
+    }),
+    idempotencyTtlSeconds,
     processRecord: ({ messageId, payload }) => sendCustomerEvent({ messageId, payload }),
     classifyError: (error) => {
       if (error instanceof IntegrationExternalApiPermanentError) {

--- a/src/handlers/shared/create-integration-consumer-handler.ts
+++ b/src/handlers/shared/create-integration-consumer-handler.ts
@@ -1,4 +1,5 @@
 import { createStructuredLogger } from '../../shared/logging/structured-logger';
+import type { CollectorIdempotencyRepository } from '../../domain/collector/collector-idempotency-repository';
 
 export interface IntegrationConsumerSqsRecord {
   messageId: string;
@@ -21,6 +22,10 @@ export interface IntegrationConsumerSqsResult {
 export interface CreateIntegrationConsumerHandlerParams {
   integrationName: string;
   targetBaseUrl: string;
+  idempotencyRepository?: CollectorIdempotencyRepository;
+  idempotencyTtlSeconds?: number;
+  now?: () => string;
+  nowMs?: () => number;
   processRecord?: (record: {
     messageId: string;
     payload: IntegrationConsumerPayload;
@@ -44,6 +49,45 @@ const isNonEmptyString = (value: unknown): value is string =>
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const DEFAULT_IDEMPOTENCY_TTL_SECONDS = 604_800;
+
+const noopIdempotencyRepository: CollectorIdempotencyRepository = {
+  tryClaim: () => Promise.resolve(true),
+  markCompleted: () => Promise.resolve(),
+};
+
+const resolveDeduplicationRecordId = ({
+  messageId,
+  payload,
+}: {
+  messageId: string;
+  payload: IntegrationConsumerPayload;
+}): string => {
+  const customerId = payload.customer.id;
+  if (typeof customerId === 'string') {
+    const normalizedCustomerId = customerId.trim();
+    if (normalizedCustomerId.length > 0) {
+      return normalizedCustomerId;
+    }
+  }
+
+  if (typeof customerId === 'number' && Number.isFinite(customerId)) {
+    return String(customerId);
+  }
+
+  return messageId.trim();
+};
+
+const buildDeduplicationKey = ({
+  integrationName,
+  correlationId,
+  recordId,
+}: {
+  integrationName: string;
+  correlationId: string;
+  recordId: string;
+}): string => `consumer:${integrationName}:${correlationId}:${recordId}`;
 
 const parseConsumerPayload = (rawBody: string): IntegrationConsumerPayload => {
   let parsed: unknown;
@@ -91,6 +135,10 @@ const parseConsumerPayload = (rawBody: string): IntegrationConsumerPayload => {
 export const createIntegrationConsumerHandler = ({
   integrationName,
   targetBaseUrl,
+  idempotencyRepository = noopIdempotencyRepository,
+  idempotencyTtlSeconds = DEFAULT_IDEMPOTENCY_TTL_SECONDS,
+  now = () => new Date().toISOString(),
+  nowMs = Date.now,
   processRecord = () => Promise.resolve(),
   classifyError = () => 'transient',
   logger = createStructuredLogger({
@@ -108,6 +156,9 @@ export const createIntegrationConsumerHandler = ({
       `targetBaseUrl is required for integration consumer "${normalizedIntegrationName}".`,
     );
   }
+  if (!Number.isInteger(idempotencyTtlSeconds) || idempotencyTtlSeconds <= 0) {
+    throw new Error('idempotencyTtlSeconds must be a positive integer.');
+  }
 
   return async (event: IntegrationConsumerSqsEvent): Promise<IntegrationConsumerSqsResult> => {
     const records = event.Records ?? [];
@@ -119,16 +170,59 @@ export const createIntegrationConsumerHandler = ({
     });
 
     const batchItemFailures: Array<{ itemIdentifier: string }> = [];
+    let processedCount = 0;
+    let retriedCount = 0;
+    let deduplicatedCount = 0;
+    let discardedCount = 0;
     for (const record of records) {
       let payload: IntegrationConsumerPayload | null = null;
       try {
         payload = parseConsumerPayload(record.body);
+        const deduplicationRecordId = resolveDeduplicationRecordId({
+          messageId: record.messageId,
+          payload,
+        });
+        const deduplicationKey = buildDeduplicationKey({
+          integrationName: normalizedIntegrationName,
+          correlationId: payload.correlationId,
+          recordId: deduplicationRecordId,
+        });
+        const claimCreatedAt = now();
+        const claimExpiration = Math.floor(nowMs() / 1000) + idempotencyTtlSeconds;
+        const claimed = await idempotencyRepository.tryClaim({
+          deduplicationKey,
+          scope: 'consumer',
+          status: 'PENDING',
+          sourceId: payload.sourceId,
+          recordId: deduplicationRecordId,
+          cursor: payload.publishedAt,
+          correlationId: payload.correlationId,
+          createdAt: claimCreatedAt,
+          expiresAtEpochSeconds: claimExpiration,
+        });
+        if (!claimed) {
+          deduplicatedCount += 1;
+          logger.info('integration.consumer.deduplicated', {
+            integrationName: normalizedIntegrationName,
+            messageId: record.messageId,
+            correlationId: payload.correlationId,
+            deduplicationKey,
+          });
+          continue;
+        }
+
         await processRecord({
           messageId: record.messageId,
           payload,
           integrationName: normalizedIntegrationName,
           targetBaseUrl: normalizedTargetBaseUrl,
         });
+        await idempotencyRepository.markCompleted({
+          deduplicationKey,
+          completedAt: now(),
+          expiresAtEpochSeconds: claimExpiration,
+        });
+        processedCount += 1;
       } catch (error) {
         const classification = classifyError(error);
         const shouldRetry = classification === 'transient';
@@ -136,6 +230,9 @@ export const createIntegrationConsumerHandler = ({
           batchItemFailures.push({
             itemIdentifier: record.messageId,
           });
+          retriedCount += 1;
+        } else {
+          discardedCount += 1;
         }
 
         logger.info('integration.consumer.invalid_record', {
@@ -149,6 +246,14 @@ export const createIntegrationConsumerHandler = ({
         });
       }
     }
+    logger.info('integration.consumer.batch_summary', {
+      integrationName: normalizedIntegrationName,
+      recordsCount: records.length,
+      processedCount,
+      retriedCount,
+      deduplicatedCount,
+      discardedCount,
+    });
 
     return {
       batchItemFailures,

--- a/tests/unit/handlers/hubspot-consumer.test.ts
+++ b/tests/unit/handlers/hubspot-consumer.test.ts
@@ -3,14 +3,23 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 describe('hubspot-consumer handler', () => {
   const originalEnv = process.env;
   const originalFetch = global.fetch;
+  const mockIdempotencyRepositoryFactory = () => ({
+    tryClaim: jest.fn(() => Promise.resolve(true)),
+    markCompleted: jest.fn(() => Promise.resolve()),
+  });
 
   afterEach(() => {
     process.env = { ...originalEnv };
     global.fetch = originalFetch;
+    jest.resetModules();
   });
 
   it('fails when target URL env var is missing', async () => {
     jest.resetModules();
+    const idempotencyRepository = mockIdempotencyRepositoryFactory();
+    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
+      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
+    }));
     process.env = { ...originalEnv };
     delete process.env.HUBSPOT_INTEGRATION_TARGET_BASE_URL;
 
@@ -22,9 +31,14 @@ describe('hubspot-consumer handler', () => {
 
   it('initializes with integration-specific configuration', async () => {
     jest.resetModules();
+    const idempotencyRepository = mockIdempotencyRepositoryFactory();
+    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
+      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
+    }));
     process.env = {
       ...originalEnv,
       HUBSPOT_INTEGRATION_TARGET_BASE_URL: 'https://hubspot.internal',
+      IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
     };
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -50,9 +64,14 @@ describe('hubspot-consumer handler', () => {
 
   it('retries transient 5xx external errors by returning batch item failure', async () => {
     jest.resetModules();
+    const idempotencyRepository = mockIdempotencyRepositoryFactory();
+    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
+      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
+    }));
     process.env = {
       ...originalEnv,
       HUBSPOT_INTEGRATION_TARGET_BASE_URL: 'https://hubspot.internal',
+      IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
     };
     global.fetch = jest.fn(() =>
       Promise.resolve({

--- a/tests/unit/handlers/salesforce-consumer.test.ts
+++ b/tests/unit/handlers/salesforce-consumer.test.ts
@@ -3,14 +3,23 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 describe('salesforce-consumer handler', () => {
   const originalEnv = process.env;
   const originalFetch = global.fetch;
+  const mockIdempotencyRepositoryFactory = () => ({
+    tryClaim: jest.fn(() => Promise.resolve(true)),
+    markCompleted: jest.fn(() => Promise.resolve()),
+  });
 
   afterEach(() => {
     process.env = { ...originalEnv };
     global.fetch = originalFetch;
+    jest.resetModules();
   });
 
   it('fails when target URL env var is missing', async () => {
     jest.resetModules();
+    const idempotencyRepository = mockIdempotencyRepositoryFactory();
+    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
+      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
+    }));
     process.env = { ...originalEnv };
     delete process.env.SALESFORCE_INTEGRATION_TARGET_BASE_URL;
 
@@ -22,9 +31,14 @@ describe('salesforce-consumer handler', () => {
 
   it('initializes with integration-specific configuration', async () => {
     jest.resetModules();
+    const idempotencyRepository = mockIdempotencyRepositoryFactory();
+    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
+      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
+    }));
     process.env = {
       ...originalEnv,
       SALESFORCE_INTEGRATION_TARGET_BASE_URL: 'https://salesforce.internal',
+      IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
     };
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -50,9 +64,14 @@ describe('salesforce-consumer handler', () => {
 
   it('discards permanent 4xx external errors without retrying the SQS message', async () => {
     jest.resetModules();
+    const idempotencyRepository = mockIdempotencyRepositoryFactory();
+    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
+      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
+    }));
     process.env = {
       ...originalEnv,
       SALESFORCE_INTEGRATION_TARGET_BASE_URL: 'https://salesforce.internal',
+      IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
     };
     global.fetch = jest.fn(() =>
       Promise.resolve({

--- a/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
+++ b/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
+import type {
+  CollectorIdempotencyClaim,
+  CollectorIdempotencyCompletion,
+} from '../../../../src/domain/collector/collector-idempotency-repository';
 import {
   createIntegrationConsumerHandler,
   type IntegrationConsumerPayload,
@@ -32,15 +36,48 @@ class SpyRecordProcessor {
   };
 }
 
+class SpyIntegrationConsumerIdempotencyRepository {
+  public readonly tryClaimCalls: CollectorIdempotencyClaim[] = [];
+  public readonly markCompletedCalls: CollectorIdempotencyCompletion[] = [];
+  private readonly statusByKey = new Map<string, 'PENDING' | 'COMPLETED'>();
+
+  constructor(preCompletedKeys: string[] = []) {
+    for (const key of preCompletedKeys) {
+      this.statusByKey.set(key, 'COMPLETED');
+    }
+  }
+
+  tryClaim = (claim: CollectorIdempotencyClaim): Promise<boolean> => {
+    this.tryClaimCalls.push(claim);
+    const currentStatus = this.statusByKey.get(claim.deduplicationKey);
+    if (currentStatus === 'COMPLETED') {
+      return Promise.resolve(false);
+    }
+
+    this.statusByKey.set(claim.deduplicationKey, claim.status ?? 'COMPLETED');
+    return Promise.resolve(true);
+  };
+
+  markCompleted = (params: CollectorIdempotencyCompletion): Promise<void> => {
+    this.markCompletedCalls.push(params);
+    this.statusByKey.set(params.deduplicationKey, 'COMPLETED');
+    return Promise.resolve();
+  };
+}
+
 describe('createIntegrationConsumerHandler', () => {
   it('creates reusable consumer handler and returns no batch item failures', async () => {
     const logger = new SpyLogger();
     const recordProcessor = new SpyRecordProcessor();
+    const idempotencyRepository = new SpyIntegrationConsumerIdempotencyRepository();
     const handler = createIntegrationConsumerHandler({
       integrationName: 'salesforce',
       targetBaseUrl: 'https://salesforce.internal',
+      idempotencyRepository,
       processRecord: recordProcessor.invoke,
       logger,
+      now: () => '2026-03-04T11:00:00.000Z',
+      nowMs: () => 1000,
     });
 
     const result = await handler({
@@ -55,7 +92,7 @@ describe('createIntegrationConsumerHandler', () => {
     expect(result).toEqual({
       batchItemFailures: [],
     });
-    expect(logger.infoCalls).toEqual([
+    expect(logger.infoCalls).toEqual(expect.arrayContaining([
       [
         'integration.consumer.received_batch',
         {
@@ -65,7 +102,18 @@ describe('createIntegrationConsumerHandler', () => {
           messageIds: ['msg-1'],
         },
       ],
-    ]);
+      [
+        'integration.consumer.batch_summary',
+        {
+          integrationName: 'salesforce',
+          recordsCount: 1,
+          processedCount: 1,
+          retriedCount: 0,
+          deduplicatedCount: 0,
+          discardedCount: 0,
+        },
+      ],
+    ]));
     expect(recordProcessor.calls).toEqual([
       {
         messageId: 'msg-1',
@@ -78,6 +126,26 @@ describe('createIntegrationConsumerHandler', () => {
         },
         integrationName: 'salesforce',
         targetBaseUrl: 'https://salesforce.internal',
+      },
+    ]);
+    expect(idempotencyRepository.tryClaimCalls).toEqual([
+      {
+        deduplicationKey: 'consumer:salesforce:exec-1:1',
+        scope: 'consumer',
+        status: 'PENDING',
+        sourceId: 'source-1',
+        recordId: '1',
+        cursor: '2026-03-04T10:00:00.000Z',
+        correlationId: 'exec-1',
+        createdAt: '2026-03-04T11:00:00.000Z',
+        expiresAtEpochSeconds: 604801,
+      },
+    ]);
+    expect(idempotencyRepository.markCompletedCalls).toEqual([
+      {
+        deduplicationKey: 'consumer:salesforce:exec-1:1',
+        completedAt: '2026-03-04T11:00:00.000Z',
+        expiresAtEpochSeconds: 604801,
       },
     ]);
   });
@@ -160,6 +228,103 @@ describe('createIntegrationConsumerHandler', () => {
 
     expect(result).toEqual({
       batchItemFailures: [{ itemIdentifier: 'msg-transient' }],
+    });
+  });
+
+  it('deduplicates redelivered message already completed for the same customer event', async () => {
+    const logger = new SpyLogger();
+    const recordProcessor = new SpyRecordProcessor();
+    const idempotencyRepository = new SpyIntegrationConsumerIdempotencyRepository([
+      'consumer:hubspot:exec-1:1',
+    ]);
+    const handler = createIntegrationConsumerHandler({
+      integrationName: 'hubspot',
+      targetBaseUrl: 'https://hubspot.internal',
+      idempotencyRepository,
+      processRecord: recordProcessor.invoke,
+      logger,
+    });
+
+    const result = await handler({
+      Records: [
+        {
+          messageId: 'msg-redelivery',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      batchItemFailures: [],
+    });
+    expect(recordProcessor.calls).toEqual([]);
+    expect(
+      logger.infoCalls.some(([eventName]) => eventName === 'integration.consumer.deduplicated'),
+    ).toBe(true);
+    expect(logger.infoCalls).toEqual(expect.arrayContaining([
+      [
+        'integration.consumer.batch_summary',
+        {
+          integrationName: 'hubspot',
+          recordsCount: 1,
+          processedCount: 0,
+          retriedCount: 0,
+          deduplicatedCount: 1,
+          discardedCount: 0,
+        },
+      ],
+    ]));
+  });
+
+  it('keeps failed delivery pending and retries successfully on next attempt', async () => {
+    class TransientError extends Error {}
+
+    const idempotencyRepository = new SpyIntegrationConsumerIdempotencyRepository();
+    let shouldFail = true;
+    const handler = createIntegrationConsumerHandler({
+      integrationName: 'salesforce',
+      targetBaseUrl: 'https://salesforce.internal',
+      idempotencyRepository,
+      processRecord: () => {
+        if (shouldFail) {
+          shouldFail = false;
+          return Promise.reject(new TransientError('temporary_failure'));
+        }
+
+        return Promise.resolve();
+      },
+      classifyError: () => 'transient',
+    });
+
+    const event = {
+      Records: [
+        {
+          messageId: 'msg-1',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+          attributes: {
+            ApproximateReceiveCount: '1',
+          },
+        },
+      ],
+    };
+
+    const firstAttempt = await handler(event);
+    const secondAttempt = await handler(event);
+
+    expect(firstAttempt).toEqual({
+      batchItemFailures: [{ itemIdentifier: 'msg-1' }],
+    });
+    expect(secondAttempt).toEqual({
+      batchItemFailures: [],
+    });
+    expect(
+      idempotencyRepository.tryClaimCalls
+        .filter((claim) => claim.scope === 'consumer')
+        .map((claim) => claim.status),
+    ).toEqual(['PENDING', 'PENDING']);
+    expect(idempotencyRepository.markCompletedCalls).toHaveLength(1);
+    expect(idempotencyRepository.markCompletedCalls[0]).toMatchObject({
+      deduplicationKey: 'consumer:salesforce:exec-1:1',
     });
   });
 });


### PR DESCRIPTION
Closes #171

---

## 🎯 Objetivo

Adicionar idempotência nas consumidoras SQS para evitar entrega externa duplicada em redelivery e replay de DLQ, sem quebrar retry transitório.

---

## 🧠 Decisão Técnica

- Idempotência aplicada no handler compartilhado das integrações:
  - `tryClaim` em `PENDING` antes da chamada externa;
  - `markCompleted` após sucesso da chamada externa.
- Chave de deduplicação definida como:
  - `consumer:<integration>:<correlationId>:<customerId|messageId>`.
- TTL configurável por ambiente com `CONSUMER_IDEMPOTENCY_TTL_SECONDS`.
- Consumidoras Salesforce/HubSpot conectadas ao repositório DynamoDB de idempotência.
- IAM das consumidoras ajustado para `dynamodb:PutItem`/`dynamodb:UpdateItem` na `IdempotencyTable`.
- Logs de lote padronizados com contadores de `processed/retried/deduplicated/discarded`.

---

## 🧪 BDD Validado

Dado que uma mensagem SQS é redeliverada ou replayada
Quando a consumidora processa um evento já confirmado
Então a chamada externa não é repetida e o item é deduplicado.

Dado que ocorre falha transitória na chamada externa
Quando a mensagem é reprocessada
Então o item permanece elegível para retry até sucesso.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [x] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
