### PR TITLE
feat(security): autenticar chamadas de saida com secrets manager

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,7 @@ provider:
     COLLECTOR_MYSQL_POOL_CONNECTION_TIMEOUT_MS: ${env:COLLECTOR_MYSQL_POOL_CONNECTION_TIMEOUT_MS, '5000'}
     COLLECTOR_MYSQL_QUERY_TIMEOUT_MS: ${env:COLLECTOR_MYSQL_QUERY_TIMEOUT_MS, '5000'}
     OFFICIAL_CUSTOMERS_UPSERT_BATCH_URL: ${env:OFFICIAL_CUSTOMERS_UPSERT_BATCH_URL, 'https://official-bank.internal/customers/upsert-batch'}
+    OFFICIAL_CUSTOMERS_AUTH_SECRET_ARN: ${env:OFFICIAL_CUSTOMERS_AUTH_SECRET_ARN, ''}
     OFFICIAL_CUSTOMERS_UPSERT_TIMEOUT_MS: ${env:OFFICIAL_CUSTOMERS_UPSERT_TIMEOUT_MS, '5000'}
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_MAX_ATTEMPTS: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_MAX_ATTEMPTS, '3'}
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS, '200'}
@@ -68,6 +69,8 @@ provider:
       Fn::GetAtt:
         - HubspotIntegrationDlq
         - Arn
+    SALESFORCE_INTEGRATION_AUTH_SECRET_ARN: ${env:SALESFORCE_INTEGRATION_AUTH_SECRET_ARN, ''}
+    HUBSPOT_INTEGRATION_AUTH_SECRET_ARN: ${env:HUBSPOT_INTEGRATION_AUTH_SECRET_ARN, ''}
   stackTags:
     Service: ${self:service}
     Stage: ${self:provider.stage}
@@ -685,6 +688,12 @@ resources:
                     - Fn::GetAtt:
                         - IdempotencyTable
                         - Arn
+                - Sid: ReadSalesforceOutboundAuthSecret
+                  Effect: Allow
+                  Action:
+                    - secretsmanager:GetSecretValue
+                  Resource:
+                    - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*
                 - Sid: PublishSalesforceRuntimeMetrics
                   Effect: Allow
                   Action:
@@ -738,6 +747,12 @@ resources:
                     - Fn::GetAtt:
                         - IdempotencyTable
                         - Arn
+                - Sid: ReadHubspotOutboundAuthSecret
+                  Effect: Allow
+                  Action:
+                    - secretsmanager:GetSecretValue
+                  Resource:
+                    - Fn::Sub: arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*
                 - Sid: PublishHubspotRuntimeMetrics
                   Effect: Allow
                   Action:

--- a/src/domain/collector/upsert-customers-batch.ts
+++ b/src/domain/collector/upsert-customers-batch.ts
@@ -154,6 +154,7 @@ export const createUpsertCustomersBatchClient = ({
   timeoutMs,
   retryPolicy,
   httpClient,
+  resolveAuthHeaders = () => Promise.resolve({}),
   nowMs = Date.now,
   sleep = (delayMs: number) =>
     new Promise<void>((resolve) => {
@@ -164,6 +165,7 @@ export const createUpsertCustomersBatchClient = ({
   timeoutMs: number;
   retryPolicy: UpsertCustomersBatchRetryPolicy;
   httpClient: UpsertCustomersBatchHttpClient;
+  resolveAuthHeaders?: () => Promise<Record<string, string>>;
   nowMs?: () => number;
   sleep?: (delayMs: number) => Promise<void>;
 }): UpsertCustomersBatchClient => {
@@ -186,6 +188,13 @@ export const createUpsertCustomersBatchClient = ({
     }
 
     const startedAt = nowMs();
+    let authHeaders: Record<string, string>;
+    try {
+      authHeaders = await resolveAuthHeaders();
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'UnknownError';
+      throw new Error(`Official API outbound auth resolution failed: ${reason}`);
+    }
     let attempts = 0;
 
     while (attempts < retryPolicy.maxAttempts) {
@@ -201,6 +210,7 @@ export const createUpsertCustomersBatchClient = ({
           }),
           headers: {
             'content-type': 'application/json',
+            ...authHeaders,
           },
         });
 

--- a/src/domain/security/outbound-auth-headers.ts
+++ b/src/domain/security/outbound-auth-headers.ts
@@ -1,0 +1,90 @@
+const HEADER_NAME_REGEX = /^[A-Za-z0-9-]+$/;
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const resolveApiKeyHeaderName = (payload: Record<string, unknown>): string | null => {
+  const topLevelHeaderName = payload.apiKeyHeaderName;
+  if (isNonEmptyString(topLevelHeaderName)) {
+    return topLevelHeaderName.trim();
+  }
+
+  const apiKeyPayload = payload.apiKey;
+  if (typeof apiKeyPayload !== 'object' || apiKeyPayload === null) {
+    return null;
+  }
+
+  const nestedHeaderName = (apiKeyPayload as Record<string, unknown>).headerName;
+  return isNonEmptyString(nestedHeaderName) ? nestedHeaderName.trim() : null;
+};
+
+const resolveApiKeyValue = (payload: Record<string, unknown>): string | null => {
+  const topLevelValue = payload.apiKeyValue;
+  if (isNonEmptyString(topLevelValue)) {
+    return topLevelValue.trim();
+  }
+
+  const apiKeyPayload = payload.apiKey;
+  if (typeof apiKeyPayload !== 'object' || apiKeyPayload === null) {
+    return null;
+  }
+
+  const nestedValue = (apiKeyPayload as Record<string, unknown>).value;
+  return isNonEmptyString(nestedValue) ? nestedValue.trim() : null;
+};
+
+export const parseOutboundAuthHeaders = ({
+  secretPayload,
+  secretArn,
+}: {
+  secretPayload: string;
+  secretArn: string;
+}): Record<string, string> => {
+  const normalizedSecretPayload = secretPayload.trim();
+  if (normalizedSecretPayload.length === 0) {
+    throw new Error(`Outbound auth secret "${secretArn}" is empty.`);
+  }
+
+  let parsedPayload: unknown;
+  try {
+    parsedPayload = JSON.parse(normalizedSecretPayload);
+  } catch {
+    throw new Error(`Outbound auth secret "${secretArn}" must be valid JSON.`);
+  }
+
+  if (typeof parsedPayload !== 'object' || parsedPayload === null || Array.isArray(parsedPayload)) {
+    throw new Error(`Outbound auth secret "${secretArn}" must be a JSON object.`);
+  }
+
+  const payload = parsedPayload as Record<string, unknown>;
+  const headers: Record<string, string> = {};
+
+  const bearerToken = payload.bearerToken;
+  if (isNonEmptyString(bearerToken)) {
+    headers.Authorization = `Bearer ${bearerToken.trim()}`;
+  }
+
+  const apiKeyHeaderName = resolveApiKeyHeaderName(payload);
+  const apiKeyValue = resolveApiKeyValue(payload);
+  if (apiKeyHeaderName && apiKeyValue) {
+    if (!HEADER_NAME_REGEX.test(apiKeyHeaderName)) {
+      throw new Error(
+        `Outbound auth secret "${secretArn}" contains invalid apiKey headerName "${apiKeyHeaderName}".`,
+      );
+    }
+
+    headers[apiKeyHeaderName] = apiKeyValue;
+  } else if (apiKeyHeaderName || apiKeyValue) {
+    throw new Error(
+      `Outbound auth secret "${secretArn}" must define both apiKey headerName and value.`,
+    );
+  }
+
+  if (Object.keys(headers).length === 0) {
+    throw new Error(
+      `Outbound auth secret "${secretArn}" must define bearerToken and/or apiKey credentials.`,
+    );
+  }
+
+  return headers;
+};

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -48,6 +48,7 @@ import {
   type RuntimeMetricsPublisher,
 } from '../infra/observability/cloudwatch-metrics-publisher';
 import { createSecretsManagerSecretRepository } from '../infra/secrets/secrets-manager-secret-repository';
+import { createSecretsManagerOutboundAuthHeadersResolver } from '../infra/security/secrets-manager-outbound-auth-headers-resolver';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
 import { createSnsCustomerEventsPublisher, type CustomerEventsPublisher } from '../infra/events/sns-customer-events-publisher';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
@@ -107,6 +108,7 @@ const METRICS_NAMESPACE_ENV = 'METRICS_NAMESPACE';
 const METRICS_NAMESPACE_DEFAULT = 'AlertOrchestrationService/Runtime';
 const STAGE_ENV = 'STAGE';
 const SERVICE_NAME_ENV = 'SERVICE_NAME';
+const OFFICIAL_CUSTOMERS_AUTH_SECRET_ARN_ENV = 'OFFICIAL_CUSTOMERS_AUTH_SECRET_ARN';
 
 type PostgresQueryExecutorFactory = (credentials: CollectorSourceCredentials) => PostgresQueryExecutor;
 type MySqlQueryExecutorFactory = (credentials: CollectorSourceCredentials) => MySqlQueryExecutor;
@@ -610,6 +612,10 @@ const getDefaultDependencies = (): CollectorDependencies => {
   if (!officialCustomersUpsertUrl || officialCustomersUpsertUrl.trim().length === 0) {
     throw new Error('OFFICIAL_CUSTOMERS_UPSERT_BATCH_URL is required.');
   }
+  const officialCustomersAuthSecretArn = process.env[OFFICIAL_CUSTOMERS_AUTH_SECRET_ARN_ENV];
+  if (!officialCustomersAuthSecretArn || officialCustomersAuthSecretArn.trim().length === 0) {
+    throw new Error(`${OFFICIAL_CUSTOMERS_AUTH_SECRET_ARN_ENV} is required.`);
+  }
 
   const customerEventsTopicArn = process.env.CLIENT_EVENTS_TOPIC_ARN;
   if (!customerEventsTopicArn || customerEventsTopicArn.trim().length === 0) {
@@ -621,10 +627,12 @@ const getDefaultDependencies = (): CollectorDependencies => {
     throw new Error('IDEMPOTENCY_TABLE_NAME is required.');
   }
 
+  const secretRepository = createSecretsManagerSecretRepository();
+
   cachedDefaultDependencies = {
     sourceRegistryRepository: createDynamoDbSourceRegistryRepository({ tableName }),
     cursorRepository: createDynamoDbCollectorCursorRepository({ tableName: cursorsTableName }),
-    secretRepository: createSecretsManagerSecretRepository(),
+    secretRepository,
     postgresQueryExecutorFactory: createPostgresQueryExecutorFactory({
       poolSettings: {
         maxConnections: resolvePostgresPoolMaxConnections(
@@ -672,6 +680,10 @@ const getDefaultDependencies = (): CollectorDependencies => {
         ),
       },
       httpClient: createFetchUpsertCustomersBatchHttpClient(),
+      resolveAuthHeaders: createSecretsManagerOutboundAuthHeadersResolver({
+        secretArn: officialCustomersAuthSecretArn,
+        secretRepository,
+      }),
       nowMs: Date.now,
       sleep,
     }),

--- a/src/handlers/hubspot-consumer.ts
+++ b/src/handlers/hubspot-consumer.ts
@@ -4,6 +4,7 @@ import {
   type IntegrationConsumerSqsResult,
 } from './shared/create-integration-consumer-handler';
 import {
+  IntegrationExternalApiAuthError,
   IntegrationExternalApiPermanentError,
   IntegrationExternalApiTransientError,
   createIntegrationExternalApiClient,
@@ -12,12 +13,15 @@ import { createDynamoDbCollectorIdempotencyRepository } from '../infra/idempoten
 import { createFetchIntegrationHttpClient } from '../infra/integrations/fetch-integration-http-client';
 import { createCloudWatchMetricsPublisher } from '../infra/observability/cloudwatch-metrics-publisher';
 import { createIntegrationDeliveryMetricsPublisher } from '../infra/observability/integration-delivery-metrics-publisher';
+import { createSecretsManagerSecretRepository } from '../infra/secrets/secrets-manager-secret-repository';
+import { createSecretsManagerOutboundAuthHeadersResolver } from '../infra/security/secrets-manager-outbound-auth-headers-resolver';
 
 const HUBSPOT_INTEGRATION_NAME = 'hubspot';
 const HUBSPOT_TARGET_BASE_URL_ENV = 'HUBSPOT_INTEGRATION_TARGET_BASE_URL';
 const INTEGRATION_API_TIMEOUT_MS_ENV = 'INTEGRATION_API_TIMEOUT_MS';
 const IDEMPOTENCY_TABLE_NAME_ENV = 'IDEMPOTENCY_TABLE_NAME';
 const CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV = 'CONSUMER_IDEMPOTENCY_TTL_SECONDS';
+const HUBSPOT_AUTH_SECRET_ARN_ENV = 'HUBSPOT_INTEGRATION_AUTH_SECRET_ARN';
 const METRICS_NAMESPACE_ENV = 'METRICS_NAMESPACE';
 const METRICS_NAMESPACE_DEFAULT = 'AlertOrchestrationService/Runtime';
 const STAGE_ENV = 'STAGE';
@@ -78,11 +82,22 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     }
   }
 
+  const authSecretArn = process.env[HUBSPOT_AUTH_SECRET_ARN_ENV];
+  if (!authSecretArn || authSecretArn.trim().length === 0) {
+    throw new Error(`${HUBSPOT_AUTH_SECRET_ARN_ENV} is required.`);
+  }
+
+  const secretRepository = createSecretsManagerSecretRepository();
+
   const sendCustomerEvent = createIntegrationExternalApiClient({
     integrationName: HUBSPOT_INTEGRATION_NAME,
     targetBaseUrl,
     timeoutMs,
     httpClient: createFetchIntegrationHttpClient(),
+    resolveAuthHeaders: createSecretsManagerOutboundAuthHeadersResolver({
+      secretArn: authSecretArn,
+      secretRepository,
+    }),
     metricsPublisher: createIntegrationDeliveryMetricsPublisher({
       runtimeMetricsPublisher: createCloudWatchMetricsPublisher({
         namespace: process.env[METRICS_NAMESPACE_ENV] ?? METRICS_NAMESPACE_DEFAULT,
@@ -101,6 +116,9 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     idempotencyTtlSeconds,
     processRecord: ({ messageId, payload }) => sendCustomerEvent({ messageId, payload }),
     classifyError: (error) => {
+      if (error instanceof IntegrationExternalApiAuthError) {
+        return 'permanent';
+      }
       if (error instanceof IntegrationExternalApiPermanentError) {
         return 'permanent';
       }

--- a/src/handlers/salesforce-consumer.ts
+++ b/src/handlers/salesforce-consumer.ts
@@ -4,6 +4,7 @@ import {
   type IntegrationConsumerSqsResult,
 } from './shared/create-integration-consumer-handler';
 import {
+  IntegrationExternalApiAuthError,
   IntegrationExternalApiPermanentError,
   IntegrationExternalApiTransientError,
   createIntegrationExternalApiClient,
@@ -12,12 +13,15 @@ import { createDynamoDbCollectorIdempotencyRepository } from '../infra/idempoten
 import { createFetchIntegrationHttpClient } from '../infra/integrations/fetch-integration-http-client';
 import { createCloudWatchMetricsPublisher } from '../infra/observability/cloudwatch-metrics-publisher';
 import { createIntegrationDeliveryMetricsPublisher } from '../infra/observability/integration-delivery-metrics-publisher';
+import { createSecretsManagerSecretRepository } from '../infra/secrets/secrets-manager-secret-repository';
+import { createSecretsManagerOutboundAuthHeadersResolver } from '../infra/security/secrets-manager-outbound-auth-headers-resolver';
 
 const SALESFORCE_INTEGRATION_NAME = 'salesforce';
 const SALESFORCE_TARGET_BASE_URL_ENV = 'SALESFORCE_INTEGRATION_TARGET_BASE_URL';
 const INTEGRATION_API_TIMEOUT_MS_ENV = 'INTEGRATION_API_TIMEOUT_MS';
 const IDEMPOTENCY_TABLE_NAME_ENV = 'IDEMPOTENCY_TABLE_NAME';
 const CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV = 'CONSUMER_IDEMPOTENCY_TTL_SECONDS';
+const SALESFORCE_AUTH_SECRET_ARN_ENV = 'SALESFORCE_INTEGRATION_AUTH_SECRET_ARN';
 const METRICS_NAMESPACE_ENV = 'METRICS_NAMESPACE';
 const METRICS_NAMESPACE_DEFAULT = 'AlertOrchestrationService/Runtime';
 const STAGE_ENV = 'STAGE';
@@ -78,11 +82,22 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     }
   }
 
+  const authSecretArn = process.env[SALESFORCE_AUTH_SECRET_ARN_ENV];
+  if (!authSecretArn || authSecretArn.trim().length === 0) {
+    throw new Error(`${SALESFORCE_AUTH_SECRET_ARN_ENV} is required.`);
+  }
+
+  const secretRepository = createSecretsManagerSecretRepository();
+
   const sendCustomerEvent = createIntegrationExternalApiClient({
     integrationName: SALESFORCE_INTEGRATION_NAME,
     targetBaseUrl,
     timeoutMs,
     httpClient: createFetchIntegrationHttpClient(),
+    resolveAuthHeaders: createSecretsManagerOutboundAuthHeadersResolver({
+      secretArn: authSecretArn,
+      secretRepository,
+    }),
     metricsPublisher: createIntegrationDeliveryMetricsPublisher({
       runtimeMetricsPublisher: createCloudWatchMetricsPublisher({
         namespace: process.env[METRICS_NAMESPACE_ENV] ?? METRICS_NAMESPACE_DEFAULT,
@@ -101,6 +116,9 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     idempotencyTtlSeconds,
     processRecord: ({ messageId, payload }) => sendCustomerEvent({ messageId, payload }),
     classifyError: (error) => {
+      if (error instanceof IntegrationExternalApiAuthError) {
+        return 'permanent';
+      }
       if (error instanceof IntegrationExternalApiPermanentError) {
         return 'permanent';
       }

--- a/src/infra/integrations/external-api-client.ts
+++ b/src/infra/integrations/external-api-client.ts
@@ -24,6 +24,16 @@ export class IntegrationExternalApiTransientError extends Error {
   }
 }
 
+export class IntegrationExternalApiAuthError extends Error {
+  constructor(
+    public readonly integrationName: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'IntegrationExternalApiAuthError';
+  }
+}
+
 export interface SendIntegrationCustomerEventParams {
   payload: IntegrationConsumerPayload;
   messageId: string;
@@ -51,6 +61,7 @@ export const createIntegrationExternalApiClient = ({
   targetBaseUrl,
   timeoutMs,
   httpClient,
+  resolveAuthHeaders = () => Promise.resolve({}),
   metricsPublisher = noopMetricsPublisher,
   nowMs = Date.now,
   logger = console,
@@ -59,6 +70,7 @@ export const createIntegrationExternalApiClient = ({
   targetBaseUrl: string;
   timeoutMs: number;
   httpClient: IntegrationHttpClient;
+  resolveAuthHeaders?: () => Promise<Record<string, string>>;
   metricsPublisher?: PublishIntegrationDeliveryMetrics;
   nowMs?: () => number;
   logger?: Pick<typeof console, 'info'>;
@@ -81,12 +93,23 @@ export const createIntegrationExternalApiClient = ({
   return async ({ payload, messageId }: SendIntegrationCustomerEventParams): Promise<void> => {
     const startedAt = nowMs();
     const url = `${normalizedTargetBaseUrl}/customers/events`;
+    let authHeaders: Record<string, string>;
+    try {
+      authHeaders = await resolveAuthHeaders();
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'UnknownError';
+      throw new IntegrationExternalApiAuthError(
+        normalizedIntegrationName,
+        `Outbound auth resolution failed: ${reason}`,
+      );
+    }
 
     const response = await httpClient({
       url,
       method: 'POST',
       headers: {
         'content-type': 'application/json',
+        ...authHeaders,
       },
       body: JSON.stringify({
         eventType: payload.eventType,

--- a/src/infra/security/secrets-manager-outbound-auth-headers-resolver.ts
+++ b/src/infra/security/secrets-manager-outbound-auth-headers-resolver.ts
@@ -1,0 +1,50 @@
+import type { CollectorSecretRepository } from '../../domain/collector/load-source-credentials';
+import { parseOutboundAuthHeaders } from '../../domain/security/outbound-auth-headers';
+
+const OUTBOUND_AUTH_CACHE_TTL_MS_DEFAULT = 300_000;
+
+export const createSecretsManagerOutboundAuthHeadersResolver = ({
+  secretArn,
+  secretRepository,
+  cacheTtlMs = OUTBOUND_AUTH_CACHE_TTL_MS_DEFAULT,
+  nowMs = Date.now,
+}: {
+  secretArn: string;
+  secretRepository: CollectorSecretRepository;
+  cacheTtlMs?: number;
+  nowMs?: () => number;
+}): (() => Promise<Record<string, string>>) => {
+  const normalizedSecretArn = secretArn.trim();
+  if (normalizedSecretArn.length === 0) {
+    throw new Error('secretArn is required for outbound auth headers resolver.');
+  }
+
+  if (!Number.isInteger(cacheTtlMs) || cacheTtlMs <= 0) {
+    throw new Error('cacheTtlMs must be a positive integer for outbound auth headers resolver.');
+  }
+
+  let cachedHeaders: Record<string, string> | null = null;
+  let cacheExpiresAtMs = 0;
+
+  return async (): Promise<Record<string, string>> => {
+    const nowValue = nowMs();
+    if (cachedHeaders && nowValue < cacheExpiresAtMs) {
+      return cachedHeaders;
+    }
+
+    const secretValue = await secretRepository.getSecretValue(normalizedSecretArn);
+    if (secretValue === null) {
+      throw new Error(`Outbound auth secret "${normalizedSecretArn}" was not found.`);
+    }
+
+    const parsedHeaders = parseOutboundAuthHeaders({
+      secretPayload: secretValue,
+      secretArn: normalizedSecretArn,
+    });
+
+    cachedHeaders = parsedHeaders;
+    cacheExpiresAtMs = nowValue + cacheTtlMs;
+
+    return parsedHeaders;
+  };
+};

--- a/tests/unit/domain/collector/upsert-customers-batch.test.ts
+++ b/tests/unit/domain/collector/upsert-customers-batch.test.ts
@@ -6,9 +6,13 @@ import {
 } from '../../../../src/domain/collector/upsert-customers-batch';
 
 describe('createUpsertCustomersBatchClient', () => {
-  it('maps partial success response into persisted and rejected records', async () => {
-    const httpClient = () =>
-      Promise.resolve({
+  it('maps partial success response into persisted and rejected records with auth headers', async () => {
+    const requests: Array<{ headers: Record<string, string> }> = [];
+    const httpClient = (request: {
+      headers: Record<string, string>;
+    }) => {
+      requests.push(request);
+      return Promise.resolve({
       status: 200,
       json: () =>
         Promise.resolve({
@@ -18,7 +22,8 @@ describe('createUpsertCustomersBatchClient', () => {
         ],
       }),
       text: () => Promise.resolve(''),
-    });
+      });
+    };
 
     const client = createUpsertCustomersBatchClient({
       endpointUrl: 'https://official-api.internal/upsert-batch',
@@ -29,6 +34,11 @@ describe('createUpsertCustomersBatchClient', () => {
         backoffRate: 2,
       },
       httpClient,
+      resolveAuthHeaders: () =>
+        Promise.resolve({
+          Authorization: 'Bearer token-123',
+          'x-api-key': 'key-123',
+        }),
     });
 
     const result = await client({
@@ -48,6 +58,14 @@ describe('createUpsertCustomersBatchClient', () => {
       },
     ]);
     expect(result.attempts).toBe(1);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      headers: {
+        'content-type': 'application/json',
+        Authorization: 'Bearer token-123',
+        'x-api-key': 'key-123',
+      },
+    });
   });
 
   it('retries transient status codes and succeeds in a later attempt', async () => {
@@ -130,5 +148,32 @@ describe('createUpsertCustomersBatchClient', () => {
         records: [{ id: 1 }],
       }),
     ).rejects.toBeInstanceOf(UpsertCustomersBatchApiError);
+  });
+
+  it('fails with controlled error when auth headers cannot be resolved', async () => {
+    const client = createUpsertCustomersBatchClient({
+      endpointUrl: 'https://official-api.internal/upsert-batch',
+      timeoutMs: 3000,
+      retryPolicy: {
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        backoffRate: 2,
+      },
+      resolveAuthHeaders: () => Promise.reject(new Error('missing outbound secret')),
+      httpClient: () =>
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve({ results: [] }),
+          text: () => Promise.resolve(''),
+        }),
+    });
+
+    await expect(
+      client({
+        sourceId: 'source-1',
+        correlationId: 'exec-1',
+        records: [{ id: 1 }],
+      }),
+    ).rejects.toThrow('Official API outbound auth resolution failed: missing outbound secret');
   });
 });

--- a/tests/unit/domain/security/outbound-auth-headers.test.ts
+++ b/tests/unit/domain/security/outbound-auth-headers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { parseOutboundAuthHeaders } from '../../../../src/domain/security/outbound-auth-headers';
+
+describe('parseOutboundAuthHeaders', () => {
+  it('maps bearer token and api key headers from secret JSON', () => {
+    const headers = parseOutboundAuthHeaders({
+      secretArn: 'arn:aws:secretsmanager:us-east-1:123:secret:outbound',
+      secretPayload: JSON.stringify({
+        bearerToken: 'token-123',
+        apiKey: {
+          headerName: 'x-api-key',
+          value: 'key-123',
+        },
+      }),
+    });
+
+    expect(headers).toEqual({
+      Authorization: 'Bearer token-123',
+      'x-api-key': 'key-123',
+    });
+  });
+
+  it('fails when secret payload is missing credentials', () => {
+    expect(() =>
+      parseOutboundAuthHeaders({
+        secretArn: 'arn:aws:secretsmanager:us-east-1:123:secret:outbound',
+        secretPayload: JSON.stringify({
+          ignored: true,
+        }),
+      }),
+    ).toThrow('must define bearerToken and/or apiKey credentials');
+  });
+
+  it('fails when api key shape is incomplete', () => {
+    expect(() =>
+      parseOutboundAuthHeaders({
+        secretArn: 'arn:aws:secretsmanager:us-east-1:123:secret:outbound',
+        secretPayload: JSON.stringify({
+          apiKeyHeaderName: 'x-api-key',
+        }),
+      }),
+    ).toThrow('must define both apiKey headerName and value');
+  });
+});

--- a/tests/unit/handlers/hubspot-consumer.test.ts
+++ b/tests/unit/handlers/hubspot-consumer.test.ts
@@ -35,10 +35,17 @@ describe('hubspot-consumer handler', () => {
     jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
       createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
     }));
+    jest.doMock('../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver', () => ({
+      createSecretsManagerOutboundAuthHeadersResolver: () => () =>
+        Promise.resolve({
+          Authorization: 'Bearer token-123',
+        }),
+    }));
     process.env = {
       ...originalEnv,
       HUBSPOT_INTEGRATION_TARGET_BASE_URL: 'https://hubspot.internal',
       IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
+      HUBSPOT_INTEGRATION_AUTH_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123:secret:hubspot',
     };
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -68,10 +75,17 @@ describe('hubspot-consumer handler', () => {
     jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
       createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
     }));
+    jest.doMock('../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver', () => ({
+      createSecretsManagerOutboundAuthHeadersResolver: () => () =>
+        Promise.resolve({
+          Authorization: 'Bearer token-123',
+        }),
+    }));
     process.env = {
       ...originalEnv,
       HUBSPOT_INTEGRATION_TARGET_BASE_URL: 'https://hubspot.internal',
       IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
+      HUBSPOT_INTEGRATION_AUTH_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123:secret:hubspot',
     };
     global.fetch = jest.fn(() =>
       Promise.resolve({

--- a/tests/unit/handlers/salesforce-consumer.test.ts
+++ b/tests/unit/handlers/salesforce-consumer.test.ts
@@ -35,10 +35,17 @@ describe('salesforce-consumer handler', () => {
     jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
       createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
     }));
+    jest.doMock('../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver', () => ({
+      createSecretsManagerOutboundAuthHeadersResolver: () => () =>
+        Promise.resolve({
+          Authorization: 'Bearer token-123',
+        }),
+    }));
     process.env = {
       ...originalEnv,
       SALESFORCE_INTEGRATION_TARGET_BASE_URL: 'https://salesforce.internal',
       IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
+      SALESFORCE_INTEGRATION_AUTH_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123:secret:salesforce',
     };
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -68,10 +75,17 @@ describe('salesforce-consumer handler', () => {
     jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
       createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
     }));
+    jest.doMock('../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver', () => ({
+      createSecretsManagerOutboundAuthHeadersResolver: () => () =>
+        Promise.resolve({
+          Authorization: 'Bearer token-123',
+        }),
+    }));
     process.env = {
       ...originalEnv,
       SALESFORCE_INTEGRATION_TARGET_BASE_URL: 'https://salesforce.internal',
       IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
+      SALESFORCE_INTEGRATION_AUTH_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123:secret:salesforce',
     };
     global.fetch = jest.fn(() =>
       Promise.resolve({

--- a/tests/unit/infra/integrations/external-api-client.test.ts
+++ b/tests/unit/infra/integrations/external-api-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import {
+  IntegrationExternalApiAuthError,
   IntegrationExternalApiPermanentError,
   IntegrationExternalApiTransientError,
   createIntegrationExternalApiClient,
@@ -35,6 +36,11 @@ describe('createIntegrationExternalApiClient', () => {
         metricCalls.push(metric);
         return Promise.resolve();
       },
+      resolveAuthHeaders: () =>
+        Promise.resolve({
+          Authorization: 'Bearer token-123',
+          'x-api-key': 'key-123',
+        }),
       httpClient: (request) => {
         requests.push(request);
         return Promise.resolve({
@@ -61,7 +67,11 @@ describe('createIntegrationExternalApiClient', () => {
       {
         url: 'https://salesforce.internal/customers/events',
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: {
+          'content-type': 'application/json',
+          Authorization: 'Bearer token-123',
+          'x-api-key': 'key-123',
+        },
         body: JSON.stringify({
           eventType: 'customer.persisted',
           integrationId: 'salesforce',
@@ -145,5 +155,32 @@ describe('createIntegrationExternalApiClient', () => {
         },
       }),
     ).rejects.toBeInstanceOf(IntegrationExternalApiTransientError);
+  });
+
+  it('throws auth error when outbound auth resolution fails', async () => {
+    const client = createIntegrationExternalApiClient({
+      integrationName: 'hubspot',
+      targetBaseUrl: 'https://hubspot.internal',
+      timeoutMs: 3000,
+      resolveAuthHeaders: () => Promise.reject(new Error('secret missing')),
+      httpClient: () =>
+        Promise.resolve({
+          status: 200,
+          text: () => Promise.resolve('ok'),
+        }),
+    });
+
+    await expect(
+      client({
+        messageId: 'msg-1',
+        payload: {
+          eventType: 'customer.persisted',
+          sourceId: 'source-1',
+          correlationId: 'exec-1',
+          publishedAt: '2026-03-04T10:00:00.000Z',
+          customer: { id: 1 },
+        },
+      }),
+    ).rejects.toBeInstanceOf(IntegrationExternalApiAuthError);
   });
 });

--- a/tests/unit/infra/security/secrets-manager-outbound-auth-headers-resolver.test.ts
+++ b/tests/unit/infra/security/secrets-manager-outbound-auth-headers-resolver.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { CollectorSecretRepository } from '../../../../src/domain/collector/load-source-credentials';
+import { createSecretsManagerOutboundAuthHeadersResolver } from '../../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver';
+
+class SpySecretRepository implements CollectorSecretRepository {
+  public readonly getSecretValueCalls: string[] = [];
+
+  constructor(private readonly valueByArn: Map<string, string | null>) {}
+
+  getSecretValue(secretArn: string): Promise<string | null> {
+    this.getSecretValueCalls.push(secretArn);
+    return Promise.resolve(this.valueByArn.get(secretArn) ?? null);
+  }
+}
+
+describe('createSecretsManagerOutboundAuthHeadersResolver', () => {
+  it('loads and caches auth headers from secrets manager payload', async () => {
+    const secretArn = 'arn:aws:secretsmanager:us-east-1:123:secret:outbound';
+    const secretRepository = new SpySecretRepository(
+      new Map<string, string | null>([
+        [
+          secretArn,
+          JSON.stringify({
+            bearerToken: 'token-123',
+          }),
+        ],
+      ]),
+    );
+
+    const resolver = createSecretsManagerOutboundAuthHeadersResolver({
+      secretArn,
+      secretRepository,
+      cacheTtlMs: 1000,
+      nowMs: (() => {
+        let current = 100;
+        return () => {
+          current += 100;
+          return current;
+        };
+      })(),
+    });
+
+    await expect(resolver()).resolves.toEqual({
+      Authorization: 'Bearer token-123',
+    });
+    await expect(resolver()).resolves.toEqual({
+      Authorization: 'Bearer token-123',
+    });
+
+    expect(secretRepository.getSecretValueCalls).toEqual([secretArn]);
+  });
+
+  it('fails with controlled error when secret is missing', async () => {
+    const secretArn = 'arn:aws:secretsmanager:us-east-1:123:secret:missing';
+    const secretRepository = new SpySecretRepository(new Map([[secretArn, null]]));
+
+    const resolver = createSecretsManagerOutboundAuthHeadersResolver({
+      secretArn,
+      secretRepository,
+    });
+
+    await expect(resolver()).rejects.toThrow(`Outbound auth secret "${secretArn}" was not found.`);
+  });
+});


### PR DESCRIPTION
Closes #173

---

## 🎯 Objetivo

Implementar autenticação de saída para API oficial (coletora) e APIs externas de integração (consumidoras), usando segredos com validação e falha controlada.

---

## 🧠 Decisão Técnica

- Definido contrato de segredo outbound com suporte a:
  - `bearerToken`
  - `apiKey` (`headerName` + `value`)
- Implementado parser/validação de segredo:
  - `src/domain/security/outbound-auth-headers.ts`
- Implementado resolver com cache via Secrets Manager:
  - `src/infra/security/secrets-manager-outbound-auth-headers-resolver.ts`
- API oficial (collector/upsert):
  - `createUpsertCustomersBatchClient` agora resolve headers de auth antes da chamada.
  - `collector` exige `OFFICIAL_CUSTOMERS_AUTH_SECRET_ARN`.
- Integrações externas:
  - `createIntegrationExternalApiClient` agora resolve headers de auth por envio.
  - erro específico de auth (`IntegrationExternalApiAuthError`) classificado como permanente nas consumidoras.
  - `salesforce-consumer`/`hubspot-consumer` exigem secret ARN de auth.
- IaC:
  - novas env vars de auth no `serverless.yml`.
  - permissões de `secretsmanager:GetSecretValue` nas roles das consumidoras.

---

## 🧪 BDD Validado

Dado que os segredos de auth estão configurados no Secrets Manager
Quando coletora e consumidoras realizam chamadas de saída
Então os headers de autenticação são aplicados corretamente.

Dado que o segredo está ausente ou inválido
Quando ocorre tentativa de chamada externa
Então a execução falha com erro controlado e observável.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [ ] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [x] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [x] PATCH
- [ ] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
