### PR TITLE
feat: multi-tenant com tenant_id end-to-end

### DIFF
--- a/src/domain/collector/upsert-customers-batch.ts
+++ b/src/domain/collector/upsert-customers-batch.ts
@@ -45,6 +45,7 @@ export type UpsertCustomersBatchHttpClient = (request: {
 
 export interface UpsertCustomersBatchParams {
   sourceId: string;
+  tenantId: string;
   correlationId: string;
   records: readonly CollectorStandardizedRecord[];
 }
@@ -175,6 +176,7 @@ export const createUpsertCustomersBatchClient = ({
 
   return async ({
     sourceId,
+    tenantId,
     correlationId,
     records,
   }: UpsertCustomersBatchParams): Promise<UpsertCustomersBatchResult> => {
@@ -205,6 +207,7 @@ export const createUpsertCustomersBatchClient = ({
           timeoutMs,
           body: JSON.stringify({
             sourceId,
+            tenantId,
             correlationId,
             records,
           }),

--- a/src/domain/scheduler/list-eligible-sources.ts
+++ b/src/domain/scheduler/list-eligible-sources.ts
@@ -5,6 +5,7 @@ import { calculateNextRunAt, type NextRunSchedule } from '../sources/next-run-at
  * Infrastructure details are hidden behind the repository contract.
  */
 interface SchedulerSourceBase {
+  tenantId: string;
   sourceId: string;
   nextRunAt: string;
 }
@@ -77,6 +78,10 @@ const resolveReferenceNow = (rawNow?: string): { iso: string; timestamp: number 
 };
 
 const normalizeSchedulerSource = (source: SchedulerSource): SchedulerSource => {
+  if (!isNonEmptyString(source.tenantId)) {
+    throw new Error('Invalid scheduler source record: tenantId is required.');
+  }
+
   if (!isNonEmptyString(source.sourceId)) {
     throw new Error('Invalid scheduler source record: sourceId is required.');
   }
@@ -87,6 +92,7 @@ const normalizeSchedulerSource = (source: SchedulerSource): SchedulerSource => {
     );
   }
 
+  const tenantId = source.tenantId.trim();
   const sourceId = source.sourceId.trim();
   const nextRunAt = source.nextRunAt.trim();
 
@@ -98,6 +104,7 @@ const normalizeSchedulerSource = (source: SchedulerSource): SchedulerSource => {
     }
 
     return {
+      tenantId,
       sourceId,
       nextRunAt,
       scheduleType: 'interval',
@@ -113,6 +120,7 @@ const normalizeSchedulerSource = (source: SchedulerSource): SchedulerSource => {
     }
 
     return {
+      tenantId,
       sourceId,
       nextRunAt,
       scheduleType: 'cron',

--- a/src/domain/sources/source-payload-validation.ts
+++ b/src/domain/sources/source-payload-validation.ts
@@ -5,7 +5,14 @@ import {
   validateSourceSchemaV1,
 } from './source-schema';
 
-const IMMUTABLE_FIELDS = ['sourceId', 'engine', 'schemaVersion', 'createdAt', 'updatedAt'] as const;
+const IMMUTABLE_FIELDS = [
+  'tenantId',
+  'sourceId',
+  'engine',
+  'schemaVersion',
+  'createdAt',
+  'updatedAt',
+] as const;
 const MUTABLE_FIELDS = [
   'active',
   'secretArn',
@@ -141,6 +148,7 @@ export const mergeAndValidateSourcePatch = (
   const nextSchedule = resolveSourceSchedule(current, patch);
 
   const validation = validateSourceSchemaV1({
+    tenantId: current.tenantId,
     sourceId: current.sourceId,
     active: patch.active ?? current.active,
     engine: current.engine,

--- a/src/domain/sources/source-registry-repository.ts
+++ b/src/domain/sources/source-registry-repository.ts
@@ -7,6 +7,7 @@ export type SourceRegistryRecord = SourceSchemaV1 & {
 };
 
 export interface ListSourceRegistryParams {
+  tenantId: string;
   limit: number;
   nextToken?: string;
   active?: boolean;

--- a/src/domain/sources/source-schema.ts
+++ b/src/domain/sources/source-schema.ts
@@ -11,6 +11,7 @@ export type SourceScheduleType = (typeof SOURCE_SCHEDULE_TYPES)[number];
 export type SourceFieldMap = Record<string, string>;
 
 export interface SourceBaseSchemaV1 {
+  tenantId: string;
   sourceId: string;
   active: boolean;
   engine: SourceEngine;
@@ -67,6 +68,7 @@ export type SourceSchemaValidationResult =
 export const sourceSchemaV1Definition = Object.freeze({
   version: SOURCE_SCHEMA_VERSION,
   requiredFields: [
+    'tenantId',
     'sourceId',
     'active',
     'engine',
@@ -176,6 +178,7 @@ export function validateSourceSchemaV1(input: unknown): SourceSchemaValidationRe
     };
   }
 
+  const tenantIdValue = input.tenantId;
   const sourceIdValue = input.sourceId;
   const activeValue = input.active;
   const engineValue = input.engine;
@@ -187,6 +190,19 @@ export function validateSourceSchemaV1(input: unknown): SourceSchemaValidationRe
   const intervalMinutesValue = input.intervalMinutes;
   const cronExprValue = input.cronExpr;
   const nextRunAtValue = input.nextRunAt;
+
+  let tenantId: string | undefined;
+  if (!hasOwn(input, 'tenantId')) {
+    errors.push({ field: 'tenantId', code: 'REQUIRED', message: 'tenantId is required.' });
+  } else if (!isNonEmptyString(tenantIdValue)) {
+    errors.push({
+      field: 'tenantId',
+      code: 'INVALID_TYPE',
+      message: 'tenantId must be a non-empty string.',
+    });
+  } else {
+    tenantId = tenantIdValue.trim();
+  }
 
   let sourceId: string | undefined;
   if (!hasOwn(input, 'sourceId')) {
@@ -423,6 +439,7 @@ export function validateSourceSchemaV1(input: unknown): SourceSchemaValidationRe
   }
 
   const base: SourceBaseSchemaV1 = {
+    tenantId: tenantId as string,
     sourceId: sourceId as string,
     active: active as boolean,
     engine: engine as SourceEngine,

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -115,6 +115,7 @@ type MySqlQueryExecutorFactory = (credentials: CollectorSourceCredentials) => My
 
 export interface CollectorEvent {
   sourceId: string;
+  tenantId?: string;
   cursor?: string | number | null;
   meta?: {
     executionId?: string;
@@ -124,6 +125,7 @@ export interface CollectorEvent {
 
 export interface CollectorResult {
   sourceId: string;
+  tenantId: string;
   processedAt: string;
   recordsSent: number;
   records: CollectorStandardizedRecord[];
@@ -735,6 +737,7 @@ export const createHandler =
     if (sourceId.length === 0) {
       throw new Error('sourceId is required for collector execution.');
     }
+    let resolvedTenantId = event.tenantId?.trim() || 'unknown';
     let executionStatus: 'SUCCEEDED' | 'FAILED' = 'FAILED';
 
     try {
@@ -742,10 +745,19 @@ export const createHandler =
         sourceId,
         sourceRegistryRepository,
       });
+      const eventTenantId = event.tenantId?.trim();
+      if (eventTenantId && eventTenantId !== sourceConfiguration.tenantId) {
+        throw new Error(
+          `Collector tenant mismatch for source "${sourceId}": expected "${sourceConfiguration.tenantId}" but received "${eventTenantId}".`,
+        );
+      }
+      const tenantId = eventTenantId || sourceConfiguration.tenantId;
+      resolvedTenantId = tenantId;
 
       const cursorSnapshot = await cursorRepository.getBySource(sourceId);
       logger.info('collector.cursor.loaded', {
         sourceId,
+        tenantId,
         hasPersistedCursor: cursorSnapshot !== null,
         persistedCursor: cursorSnapshot?.last ?? null,
       });
@@ -762,6 +774,7 @@ export const createHandler =
 
       logger.info('collector.source_credentials.loaded', {
         sourceId,
+        tenantId,
         engine: sourceConfiguration.engine,
         attempts: loadedCredentials.metrics.attempts,
         durationMs: loadedCredentials.metrics.durationMs,
@@ -795,6 +808,7 @@ export const createHandler =
 
       logger.info('collector.source_records.collected', {
         sourceId,
+        tenantId,
         engine: sourceConfiguration.engine,
         cursor,
         recordsCollected: records.length,
@@ -904,6 +918,7 @@ export const createHandler =
 
       const upsertResult = await upsertCustomersBatchClient({
         sourceId,
+        tenantId,
         correlationId,
         records: nonDuplicatedUpsertRecords,
       });
@@ -1031,6 +1046,7 @@ export const createHandler =
       for (const record of nonDuplicatedEventRecords) {
         await customerEventsPublisher({
           sourceId,
+          tenantId,
           correlationId,
           records: [record],
           publishedAt: processedAt,
@@ -1094,6 +1110,7 @@ export const createHandler =
 
       const result: CollectorResult = {
         sourceId,
+        tenantId,
         processedAt,
         recordsSent: upsertResult.persistedRecords.length,
         records: upsertResult.persistedRecords,
@@ -1113,6 +1130,7 @@ export const createHandler =
           unit: 'Count',
           dimensions: {
             SourceId: sourceId,
+            TenantId: tenantId,
           },
         },
         {
@@ -1121,6 +1139,7 @@ export const createHandler =
           unit: 'Count',
           dimensions: {
             SourceId: sourceId,
+            TenantId: tenantId,
           },
         },
         {
@@ -1129,6 +1148,7 @@ export const createHandler =
           unit: 'Count',
           dimensions: {
             SourceId: sourceId,
+            TenantId: tenantId,
           },
         },
       ]);
@@ -1143,6 +1163,7 @@ export const createHandler =
           unit: 'Count',
           dimensions: {
             SourceId: sourceId,
+            TenantId: resolvedTenantId,
           },
         },
         {
@@ -1151,6 +1172,7 @@ export const createHandler =
           unit: 'Milliseconds',
           dimensions: {
             SourceId: sourceId,
+            TenantId: resolvedTenantId,
           },
         },
       ]);

--- a/src/handlers/create-source.ts
+++ b/src/handlers/create-source.ts
@@ -10,6 +10,7 @@ import {
 } from '../domain/sources/source-registry-repository';
 import { calculateNextRunAt } from '../domain/sources/next-run-at';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
+import { resolveTenantIdFromJwtClaims } from '../shared/auth/tenant-context';
 import { resolveCorrelationId } from '../shared/logging/correlation-id';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
 import { nowIso } from '../shared/time/now-iso';
@@ -23,6 +24,11 @@ export interface CreateSourceEvent {
   headers?: Record<string, string | undefined>;
   requestContext?: {
     requestId?: string;
+    authorizer?: {
+      jwt?: {
+        claims?: Record<string, unknown>;
+      };
+    };
   };
 }
 
@@ -75,6 +81,9 @@ const parseBody = (
   }
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
 const getDefaultDependencies = (): CreateSourceDependencies => {
   if (cachedDefaultDependencies) {
     return cachedDefaultDependencies;
@@ -114,7 +123,43 @@ export const createHandler =
       return parsedBody.response;
     }
 
-    const validation = validateSourceCreatePayload(parsedBody.value);
+    const tenantId = resolveTenantIdFromJwtClaims(event);
+    if (!tenantId) {
+      logger.info('api.sources.create.rejected', {
+        correlationId,
+        statusCode: 401,
+        reason: 'tenant_context_missing',
+      });
+      return response(401, {
+        message: 'Missing tenant context in JWT claims.',
+        code: 'TENANT_CONTEXT_MISSING',
+      });
+    }
+
+    if (
+      isRecord(parsedBody.value) &&
+      typeof parsedBody.value.tenantId === 'string' &&
+      parsedBody.value.tenantId.trim().length > 0 &&
+      parsedBody.value.tenantId.trim() !== tenantId
+    ) {
+      logger.info('api.sources.create.rejected', {
+        correlationId,
+        statusCode: 403,
+        reason: 'tenant_mismatch',
+      });
+      return response(403, {
+        message: 'Payload tenantId does not match authenticated tenant.',
+        code: 'TENANT_CONTEXT_MISMATCH',
+      });
+    }
+
+    const payloadForValidation = isRecord(parsedBody.value)
+      ? {
+          ...parsedBody.value,
+          tenantId,
+        }
+      : parsedBody.value;
+    const validation = validateSourceCreatePayload(payloadForValidation);
     if (!validation.success) {
       logger.info('api.sources.create.rejected', {
         correlationId,

--- a/src/handlers/delete-source.ts
+++ b/src/handlers/delete-source.ts
@@ -4,6 +4,7 @@ import {
   type SourceRegistryRepository,
 } from '../domain/sources/source-registry-repository';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
+import { resolveTenantIdFromJwtClaims } from '../shared/auth/tenant-context';
 import { resolveCorrelationId } from '../shared/logging/correlation-id';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
 import { nowIso } from '../shared/time/now-iso';
@@ -19,6 +20,11 @@ export interface DeleteSourceEvent {
   };
   requestContext?: {
     requestId?: string;
+    authorizer?: {
+      jwt?: {
+        claims?: Record<string, unknown>;
+      };
+    };
   };
 }
 
@@ -116,12 +122,27 @@ export const createHandler =
       return sourceId.response;
     }
 
+    const tenantId = resolveTenantIdFromJwtClaims(event);
+    if (!tenantId) {
+      logger.info('api.sources.delete.rejected', {
+        correlationId,
+        statusCode: 401,
+        sourceId: sourceId.value,
+        reason: 'tenant_context_missing',
+      });
+      return response(401, {
+        message: 'Missing tenant context in JWT claims.',
+        code: 'TENANT_CONTEXT_MISSING',
+      });
+    }
+
     const current = await sourceRegistryRepository.getById(sourceId.value);
-    if (!current) {
+    if (!current || current.tenantId !== tenantId) {
       logger.info('api.sources.delete.not_found', {
         correlationId,
         statusCode: 404,
         sourceId: sourceId.value,
+        tenantId,
       });
       return response(404, {
         message: `Source "${sourceId.value}" was not found.`,
@@ -154,11 +175,12 @@ export const createHandler =
     } catch (error) {
       if (error instanceof SourceVersionConflictError) {
         const latest = await sourceRegistryRepository.getById(sourceId.value);
-        if (!latest) {
+        if (!latest || latest.tenantId !== tenantId) {
           logger.info('api.sources.delete.not_found', {
             correlationId,
             statusCode: 404,
             sourceId: sourceId.value,
+            tenantId,
           });
           return response(404, {
             message: `Source "${sourceId.value}" was not found.`,

--- a/src/handlers/list-sources.ts
+++ b/src/handlers/list-sources.ts
@@ -5,6 +5,7 @@ import {
 } from '../domain/sources/source-registry-repository';
 import { SOURCE_ENGINES, type SourceEngine } from '../domain/sources/source-schema';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
+import { resolveTenantIdFromJwtClaims } from '../shared/auth/tenant-context';
 import { resolveCorrelationId } from '../shared/logging/correlation-id';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
 
@@ -26,6 +27,11 @@ export interface ListSourcesEvent {
   };
   requestContext?: {
     requestId?: string;
+    authorizer?: {
+      jwt?: {
+        claims?: Record<string, unknown>;
+      };
+    };
   };
 }
 
@@ -210,6 +216,19 @@ export const createHandler =
       correlationId,
     });
 
+    const tenantId = resolveTenantIdFromJwtClaims(event);
+    if (!tenantId) {
+      logger.info('api.sources.list.rejected', {
+        correlationId,
+        statusCode: 401,
+        reason: 'tenant_context_missing',
+      });
+      return response(401, {
+        message: 'Missing tenant context in JWT claims.',
+        code: 'TENANT_CONTEXT_MISSING',
+      });
+    }
+
     const query = event.queryStringParameters ?? {};
 
     const limit = parseLimit(query.limit);
@@ -253,6 +272,7 @@ export const createHandler =
     }
 
     const params: ListSourceRegistryParams = {
+      tenantId,
       limit: limit.value,
       nextToken: nextToken.value,
       active: active.value,
@@ -269,6 +289,7 @@ export const createHandler =
       return response(200, {
         items: result.items,
         filters: {
+          tenantId,
           active: active.value ?? null,
           engine: engine.value ?? null,
         },

--- a/src/handlers/scheduler.ts
+++ b/src/handlers/scheduler.ts
@@ -20,6 +20,10 @@ export interface SchedulerEvent {
 
 export interface SchedulerResult {
   contractVersion: string;
+  sources: Array<{
+    sourceId: string;
+    tenantId: string;
+  }>;
   sourceIds: string[];
   eligibleSources: number;
   hasEligibleSources: boolean;
@@ -112,17 +116,23 @@ export const createHandler =
       pageSize: activeSourcesPageSize,
     });
 
-    const sourceIds = sources.map((source) => source.sourceId);
-    const eligibleSources = sourceIds.length;
+    const sourceItems = sources.map((source) => ({
+      sourceId: source.sourceId,
+      tenantId: source.tenantId,
+    }));
+    const sourceIds = sourceItems.map((source) => source.sourceId);
+    const eligibleSources = sourceItems.length;
     const maxConcurrency = resolveMapMaxConcurrency(process.env.MAP_MAX_CONCURRENCY);
     logger.info('scheduler.eligible_sources.filtered', {
       referenceNow,
       eligibleSources,
+      tenants: [...new Set(sourceItems.map((source) => source.tenantId))].length,
       correlationId: event.meta?.executionId?.trim() || null,
     });
 
     return {
       contractVersion: SCHEDULER_RESULT_CONTRACT_VERSION,
+      sources: sourceItems,
       sourceIds,
       eligibleSources,
       hasEligibleSources: eligibleSources > 0,

--- a/src/handlers/update-source.ts
+++ b/src/handlers/update-source.ts
@@ -11,6 +11,7 @@ import {
 } from '../domain/sources/source-payload-validation';
 import { calculateNextRunAt } from '../domain/sources/next-run-at';
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
+import { resolveTenantIdFromJwtClaims } from '../shared/auth/tenant-context';
 import { resolveCorrelationId } from '../shared/logging/correlation-id';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
 import { nowIso } from '../shared/time/now-iso';
@@ -27,6 +28,11 @@ export interface UpdateSourceEvent {
   };
   requestContext?: {
     requestId?: string;
+    authorizer?: {
+      jwt?: {
+        claims?: Record<string, unknown>;
+      };
+    };
   };
 }
 
@@ -147,6 +153,20 @@ export const createHandler =
       return parsedBody.response;
     }
 
+    const tenantId = resolveTenantIdFromJwtClaims(event);
+    if (!tenantId) {
+      logger.info('api.sources.update.rejected', {
+        correlationId,
+        statusCode: 401,
+        sourceId: sourceId.value,
+        reason: 'tenant_context_missing',
+      });
+      return response(401, {
+        message: 'Missing tenant context in JWT claims.',
+        code: 'TENANT_CONTEXT_MISSING',
+      });
+    }
+
     const patchValidation = validateSourcePatchPayload(parsedBody.value);
     if (!patchValidation.success) {
       logger.info('api.sources.update.rejected', {
@@ -162,11 +182,12 @@ export const createHandler =
     }
 
     const current = await sourceRegistryRepository.getById(sourceId.value);
-    if (!current) {
+    if (!current || current.tenantId !== tenantId) {
       logger.info('api.sources.update.not_found', {
         correlationId,
         statusCode: 404,
         sourceId: sourceId.value,
+        tenantId,
       });
       return response(404, {
         message: `Source "${sourceId.value}" was not found.`,

--- a/src/infra/events/sns-customer-events-publisher.ts
+++ b/src/infra/events/sns-customer-events-publisher.ts
@@ -4,6 +4,7 @@ import type { CollectorStandardizedRecord } from '../../domain/collector/collect
 
 export interface PublishCustomerEventsParams {
   sourceId: string;
+  tenantId: string;
   correlationId: string;
   records: readonly CollectorStandardizedRecord[];
   publishedAt: string;
@@ -48,6 +49,7 @@ export const createSnsCustomerEventsPublisher = ({
 
   return async ({
     sourceId,
+    tenantId,
     correlationId,
     records,
     publishedAt,
@@ -62,6 +64,7 @@ export const createSnsCustomerEventsPublisher = ({
       const message = {
         eventType: 'customer.persisted',
         sourceId,
+        tenantId,
         correlationId,
         publishedAt,
         integrationTargets: normalizedIntegrationTargets,
@@ -76,6 +79,10 @@ export const createSnsCustomerEventsPublisher = ({
             sourceId: {
               DataType: 'String',
               StringValue: sourceId,
+            },
+            tenantId: {
+              DataType: 'String',
+              StringValue: tenantId,
             },
             correlationId: {
               DataType: 'String',

--- a/src/infra/sources/dynamodb-scheduler-source-repository.ts
+++ b/src/infra/sources/dynamodb-scheduler-source-repository.ts
@@ -63,6 +63,11 @@ const decodeToken = (token: string): Record<string, AttributeValue> => {
 const toSchedulerSource = (item: Record<string, AttributeValue>): SchedulerSource => {
   const raw = unmarshall(item) as Record<string, unknown>;
 
+  const tenantId = raw.tenantId;
+  if (typeof tenantId !== 'string' || tenantId.trim().length === 0) {
+    throw new Error('Invalid scheduler source item: tenantId is required.');
+  }
+
   const sourceId = raw.sourceId;
   if (typeof sourceId !== 'string' || sourceId.trim().length === 0) {
     throw new Error('Invalid scheduler source item: sourceId is required.');
@@ -87,6 +92,7 @@ const toSchedulerSource = (item: Record<string, AttributeValue>): SchedulerSourc
     }
 
     return {
+      tenantId: tenantId.trim(),
       sourceId: sourceId.trim(),
       nextRunAt: nextRunAt.trim(),
       scheduleType: 'interval',
@@ -101,6 +107,7 @@ const toSchedulerSource = (item: Record<string, AttributeValue>): SchedulerSourc
     }
 
     return {
+      tenantId: tenantId.trim(),
       sourceId: sourceId.trim(),
       nextRunAt: nextRunAt.trim(),
       scheduleType: 'cron',
@@ -168,7 +175,7 @@ export function createDynamoDbSchedulerSourceRepository({
                 S: 'true',
               },
             },
-        ProjectionExpression: 'sourceId, nextRunAt, scheduleType, intervalMinutes, cronExpr',
+        ProjectionExpression: 'tenantId, sourceId, nextRunAt, scheduleType, intervalMinutes, cronExpr',
         ExclusiveStartKey: nextToken ? decodeToken(nextToken) : undefined,
         Limit: limit,
         ScanIndexForward: true,

--- a/src/infra/sources/dynamodb-source-registry-repository.ts
+++ b/src/infra/sources/dynamodb-source-registry-repository.ts
@@ -25,6 +25,7 @@ export interface DynamoDbSourceRegistryRepositoryParams {
 }
 
 interface ListTokenPayload {
+  tenantId: string;
   offset: number;
   active?: boolean;
   engine?: SourceEngine;
@@ -53,6 +54,10 @@ const decodeListToken = (token: string): ListTokenPayload => {
     }
 
     const record = parsed as Record<string, unknown>;
+    if (typeof record.tenantId !== 'string' || record.tenantId.trim().length === 0) {
+      throw new SourcePaginationTokenError();
+    }
+
     if (!Number.isInteger(record.offset) || (record.offset as number) < 0) {
       throw new SourcePaginationTokenError();
     }
@@ -78,6 +83,7 @@ const decodeListToken = (token: string): ListTokenPayload => {
     }
 
     return {
+      tenantId: record.tenantId.trim(),
       offset: record.offset as number,
       active,
       engine,
@@ -92,7 +98,9 @@ const decodeListToken = (token: string): ListTokenPayload => {
 };
 
 const areFiltersEqual = (token: ListTokenPayload, params: ListSourceRegistryParams): boolean =>
-  token.active === params.active && token.engine === params.engine;
+  token.tenantId === params.tenantId &&
+  token.active === params.active &&
+  token.engine === params.engine;
 
 const buildScanFilter = (
   params: ListSourceRegistryParams,
@@ -100,8 +108,10 @@ const buildScanFilter = (
   FilterExpression?: string;
   ExpressionAttributeValues?: Record<string, AttributeValue>;
 } => {
-  const expressions: string[] = [];
-  const values: Record<string, AttributeValue> = {};
+  const expressions: string[] = ['tenantId = :tenantId'];
+  const values: Record<string, AttributeValue> = {
+    ':tenantId': { S: params.tenantId },
+  };
 
   if (params.active !== undefined) {
     expressions.push('active = :active');
@@ -113,10 +123,6 @@ const buildScanFilter = (
     values[':engine'] = { S: params.engine };
   }
 
-  if (expressions.length === 0) {
-    return {};
-  }
-
   return {
     FilterExpression: expressions.join(' AND '),
     ExpressionAttributeValues: values,
@@ -124,6 +130,7 @@ const buildScanFilter = (
 };
 
 const toDynamoItem = (source: SourceRegistryRecord): Record<string, unknown> => ({
+  tenantId: source.tenantId,
   sourceId: source.sourceId,
   active: source.active ? 'true' : 'false',
   engine: source.engine,
@@ -160,6 +167,7 @@ const toSourceRegistryRecord = (item: Record<string, AttributeValue>): SourceReg
   }
 
   const validation = validateSourceSchemaV1({
+    tenantId: raw.tenantId,
     sourceId: raw.sourceId,
     active,
     engine: raw.engine,
@@ -238,13 +246,27 @@ export function createDynamoDbSourceRegistryRepository({
       return toSourceRegistryRecord(result.Item);
     },
     async list(params: ListSourceRegistryParams): Promise<ListSourceRegistryResult> {
+      const normalizedTenantId = params.tenantId.trim();
+      if (normalizedTenantId.length === 0) {
+        throw new Error('tenantId is required for source listing.');
+      }
+
       const tokenPayload = params.nextToken ? decodeListToken(params.nextToken) : undefined;
       const offset = tokenPayload?.offset ?? 0;
-      if (tokenPayload && !areFiltersEqual(tokenPayload, params)) {
+      if (
+        tokenPayload &&
+        !areFiltersEqual(tokenPayload, {
+          ...params,
+          tenantId: normalizedTenantId,
+        })
+      ) {
         throw new SourcePaginationTokenError('Pagination token does not match provided filters.');
       }
 
-      const filter = buildScanFilter(params);
+      const filter = buildScanFilter({
+        ...params,
+        tenantId: normalizedTenantId,
+      });
       const items: SourceRegistryRecord[] = [];
       let lastEvaluatedKey: Record<string, AttributeValue> | undefined;
 
@@ -270,6 +292,7 @@ export function createDynamoDbSourceRegistryRepository({
       const nextToken =
         nextOffset < sorted.length
           ? encodeListToken({
+              tenantId: normalizedTenantId,
               offset: nextOffset,
               active: params.active,
               engine: params.engine,

--- a/src/infra/sources/in-memory-source-registry-repository.ts
+++ b/src/infra/sources/in-memory-source-registry-repository.ts
@@ -10,6 +10,7 @@ import {
 import type { SourceEngine } from '../../domain/sources/source-schema';
 
 interface ListTokenPayload {
+  tenantId: string;
   offset: number;
   active?: boolean;
   engine?: SourceEngine;
@@ -26,6 +27,10 @@ const decodeListToken = (token: string): ListTokenPayload => {
     }
 
     const record = parsed as Record<string, unknown>;
+    if (typeof record.tenantId !== 'string' || record.tenantId.trim().length === 0) {
+      throw new SourcePaginationTokenError();
+    }
+
     if (!Number.isInteger(record.offset) || (record.offset as number) < 0) {
       throw new SourcePaginationTokenError();
     }
@@ -51,6 +56,7 @@ const decodeListToken = (token: string): ListTokenPayload => {
     }
 
     return {
+      tenantId: record.tenantId.trim(),
       offset: record.offset as number,
       active,
       engine,
@@ -65,7 +71,9 @@ const decodeListToken = (token: string): ListTokenPayload => {
 };
 
 const areFiltersEqual = (token: ListTokenPayload, params: ListSourceRegistryParams): boolean =>
-  token.active === params.active && token.engine === params.engine;
+  token.tenantId === params.tenantId &&
+  token.active === params.active &&
+  token.engine === params.engine;
 
 export interface InMemorySourceRegistryStore {
   get(sourceId: string): SourceRegistryRecord | undefined;
@@ -94,15 +102,26 @@ export function createInMemorySourceRegistryRepository(
       return Promise.resolve(storage.get(sourceId) ?? null);
     },
     list(params: ListSourceRegistryParams): Promise<ListSourceRegistryResult> {
+      const normalizedTenantId = params.tenantId.trim();
+      if (normalizedTenantId.length === 0) {
+        throw new Error('tenantId is required for source listing.');
+      }
+
       const tokenPayload = params.nextToken ? decodeListToken(params.nextToken) : undefined;
       const offset = tokenPayload?.offset ?? 0;
       if (tokenPayload) {
-        if (!areFiltersEqual(tokenPayload, params)) {
+        if (
+          !areFiltersEqual(tokenPayload, {
+            ...params,
+            tenantId: normalizedTenantId,
+          })
+        ) {
           throw new SourcePaginationTokenError('Pagination token does not match provided filters.');
         }
       }
 
       const filtered = [...storage.values()]
+        .filter((source) => source.tenantId === normalizedTenantId)
         .filter((source) => (params.active === undefined ? true : source.active === params.active))
         .filter((source) => (params.engine === undefined ? true : source.engine === params.engine))
         .sort((left, right) => left.sourceId.localeCompare(right.sourceId));
@@ -112,6 +131,7 @@ export function createInMemorySourceRegistryRepository(
       const nextToken =
         nextOffset < filtered.length
           ? encodeListToken({
+              tenantId: normalizedTenantId,
               offset: nextOffset,
               active: params.active,
               engine: params.engine,

--- a/src/infra/sources/in-memory-source-repository.ts
+++ b/src/infra/sources/in-memory-source-repository.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../domain/scheduler/list-eligible-sources';
 
 interface InMemorySourceBase {
+  tenantId: string;
   sourceId: string;
   nextRunAt: string;
   active?: boolean;
@@ -65,6 +66,7 @@ const resolvePage = (
   const toSchedulerSource = (item: InMemorySource): SchedulerSource => {
     if (item.scheduleType === 'interval') {
       return {
+        tenantId: item.tenantId,
         sourceId: item.sourceId,
         nextRunAt: item.nextRunAt,
         scheduleType: 'interval',
@@ -73,6 +75,7 @@ const resolvePage = (
     }
 
     return {
+      tenantId: item.tenantId,
       sourceId: item.sourceId,
       nextRunAt: item.nextRunAt,
       scheduleType: 'cron',
@@ -92,6 +95,7 @@ export function createInMemorySourceRepository(seed: InMemorySource[] = []): Sou
     .map((item) =>
       item.scheduleType === 'interval'
         ? {
+            tenantId: item.tenantId,
             sourceId: item.sourceId,
             nextRunAt: item.nextRunAt,
             active: true,
@@ -99,6 +103,7 @@ export function createInMemorySourceRepository(seed: InMemorySource[] = []): Sou
             intervalMinutes: item.intervalMinutes,
           }
         : {
+            tenantId: item.tenantId,
             sourceId: item.sourceId,
             nextRunAt: item.nextRunAt,
             active: true,

--- a/src/shared/auth/tenant-context.ts
+++ b/src/shared/auth/tenant-context.ts
@@ -1,0 +1,36 @@
+export interface JwtAuthorizerContext {
+  requestContext?: {
+    authorizer?: {
+      jwt?: {
+        claims?: Record<string, unknown>;
+      };
+    };
+  };
+}
+
+const CLAIM_CANDIDATES = ['tenant_id', 'tenantId'] as const;
+
+const asTenantId = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+export const resolveTenantIdFromJwtClaims = (event: JwtAuthorizerContext): string | null => {
+  const claims = event.requestContext?.authorizer?.jwt?.claims;
+  if (!claims) {
+    return null;
+  }
+
+  for (const claimName of CLAIM_CANDIDATES) {
+    const tenantId = asTenantId(claims[claimName]);
+    if (tenantId) {
+      return tenantId;
+    }
+  }
+
+  return null;
+};

--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -60,10 +60,11 @@
     },
     "ProcessEligibleSources": {
       "Type": "Map",
-      "ItemsPath": "$.schedulerResult.sourceIds",
+      "ItemsPath": "$.schedulerResult.sources",
       "MaxConcurrencyPath": "$.schedulerResult.maxConcurrency",
       "Parameters": {
-        "sourceId.$": "$$.Map.Item.Value",
+        "sourceId.$": "$$.Map.Item.Value.sourceId",
+        "tenantId.$": "$$.Map.Item.Value.tenantId",
         "meta.$": "$.meta"
       },
       "Iterator": {
@@ -76,6 +77,7 @@
             },
             "Parameters": {
               "sourceId.$": "$.sourceId",
+              "tenantId.$": "$.tenantId",
               "meta.$": "$.meta"
             },
             "Retry": [
@@ -112,6 +114,7 @@
             "Parameters": {
               "result": {
                 "sourceId.$": "$.sourceId",
+                "tenantId.$": "$.tenantId",
                 "status": "SUCCEEDED",
                 "processedAt.$": "$.collectorResult.processedAt",
                 "recordsSent.$": "$.collectorResult.recordsSent"
@@ -175,6 +178,7 @@
             "Type": "Pass",
             "Parameters": {
               "sourceId.$": "$.result.sourceId",
+              "tenantId.$": "$.result.tenantId",
               "status.$": "$.result.status",
               "processedAt.$": "$.result.processedAt",
               "recordsSent.$": "$.result.recordsSent"
@@ -186,6 +190,7 @@
             "Parameters": {
               "result": {
                 "sourceId.$": "$.sourceId",
+                "tenantId.$": "$.tenantId",
                 "status": "FAILED",
                 "error.$": "$.collectorError.Error",
                 "cause.$": "$.collectorError.Cause"
@@ -249,6 +254,7 @@
             "Type": "Pass",
             "Parameters": {
               "sourceId.$": "$.result.sourceId",
+              "tenantId.$": "$.result.tenantId",
               "status.$": "$.result.status",
               "error.$": "$.result.error",
               "cause.$": "$.result.cause"
@@ -264,7 +270,7 @@
       "Type": "Pass",
       "Parameters": {
         "meta.$": "$.meta",
-        "sources.$": "$.schedulerResult.sourceIds",
+        "sources.$": "$.schedulerResult.sources",
         "results.$": "$.collectorResults",
         "scheduler": {
           "contractVersion.$": "$.schedulerResult.contractVersion",

--- a/tests/unit/domain/collector/load-source-configuration.test.ts
+++ b/tests/unit/domain/collector/load-source-configuration.test.ts
@@ -9,6 +9,7 @@ import {
 import type { SourceRegistryRecord } from '../../../../src/domain/sources/source-registry-repository';
 
 const VALID_SOURCE: SourceRegistryRecord = {
+  tenantId: 'tenant-acme',
   sourceId: 'source-acme',
   active: true,
   engine: 'postgres',

--- a/tests/unit/domain/collector/upsert-customers-batch.test.ts
+++ b/tests/unit/domain/collector/upsert-customers-batch.test.ts
@@ -43,6 +43,7 @@ describe('createUpsertCustomersBatchClient', () => {
 
     const result = await client({
       sourceId: 'source-1',
+      tenantId: 'tenant-acme',
       correlationId: 'exec-1',
       records: [
         { id: 1, email: 'a@example.com' },
@@ -113,6 +114,7 @@ describe('createUpsertCustomersBatchClient', () => {
 
     const result = await client({
       sourceId: 'source-1',
+      tenantId: 'tenant-acme',
       correlationId: 'exec-1',
       records: [{ id: 1, email: 'a@example.com' }],
     });
@@ -144,6 +146,7 @@ describe('createUpsertCustomersBatchClient', () => {
     await expect(
       client({
         sourceId: 'source-1',
+        tenantId: 'tenant-acme',
         correlationId: 'exec-1',
         records: [{ id: 1 }],
       }),
@@ -171,6 +174,7 @@ describe('createUpsertCustomersBatchClient', () => {
     await expect(
       client({
         sourceId: 'source-1',
+        tenantId: 'tenant-acme',
         correlationId: 'exec-1',
         records: [{ id: 1 }],
       }),

--- a/tests/unit/domain/scheduler/list-eligible-sources.test.ts
+++ b/tests/unit/domain/scheduler/list-eligible-sources.test.ts
@@ -37,6 +37,7 @@ describe('listEligibleSources', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-a',
             nextRunAt: '2026-03-04T09:00:00.000Z',
             scheduleType: 'interval',
@@ -48,6 +49,7 @@ describe('listEligibleSources', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-b',
             nextRunAt: '2026-03-04T09:05:00.000Z',
             scheduleType: 'interval',
@@ -78,6 +80,7 @@ describe('listEligibleSources', () => {
     ]);
     expect(result).toEqual([
       {
+        tenantId: 'tenant-acme',
         sourceId: 'source-a',
         nextRunAt: '2026-03-04T09:00:00.000Z',
         scheduleType: 'interval',
@@ -91,6 +94,7 @@ describe('listEligibleSources', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-cron',
             nextRunAt: '2026-03-04T09:00:00.000Z',
             scheduleType: 'cron',
@@ -117,6 +121,7 @@ describe('listEligibleSources', () => {
     ]);
     expect(result).toEqual([
       {
+        tenantId: 'tenant-acme',
         sourceId: 'source-cron',
         nextRunAt: '2026-03-04T09:00:00.000Z',
         scheduleType: 'cron',
@@ -130,6 +135,7 @@ describe('listEligibleSources', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-a',
             nextRunAt: '2026-03-04T08:55:00.000Z',
             scheduleType: 'interval',
@@ -141,12 +147,14 @@ describe('listEligibleSources', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-a',
             nextRunAt: '2026-03-04T08:55:00.000Z',
             scheduleType: 'interval',
             intervalMinutes: 5,
           },
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-b',
             nextRunAt: '2026-03-04T09:10:00.000Z',
             scheduleType: 'cron',
@@ -166,6 +174,7 @@ describe('listEligibleSources', () => {
     expect(repository.reserveCalls).toHaveLength(1);
     expect(result).toEqual([
       {
+        tenantId: 'tenant-acme',
         sourceId: 'source-a',
         nextRunAt: '2026-03-04T08:55:00.000Z',
         scheduleType: 'interval',
@@ -180,6 +189,7 @@ describe('listEligibleSources', () => {
         {
           items: [
             {
+              tenantId: 'tenant-acme',
               sourceId: 'source-a',
               nextRunAt: '2026-03-04T08:55:00.000Z',
               scheduleType: 'interval',
@@ -207,6 +217,7 @@ describe('listEligibleSources', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: '',
             nextRunAt: '2026-03-04T09:00:00.000Z',
             scheduleType: 'interval',

--- a/tests/unit/domain/sources/source-schema.test.ts
+++ b/tests/unit/domain/sources/source-schema.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../src/domain/sources/source-schema';
 
 const validIntervalPayload = {
+  tenantId: 'tenant-acme',
   sourceId: 'source-acme',
   active: true,
   engine: 'postgres',
@@ -63,6 +64,7 @@ describe('source schema v1', () => {
     }
 
     const fields = result.errors.map((entry) => entry.field);
+    expect(fields).toContain('tenantId');
     expect(fields).toContain('sourceId');
     expect(fields).toContain('engine');
     expect(fields).toContain('scheduleType');

--- a/tests/unit/handlers/collector.test.ts
+++ b/tests/unit/handlers/collector.test.ts
@@ -25,6 +25,7 @@ import type { SourceRegistryRecord } from '../../../src/domain/sources/source-re
 import { createHandler, type CollectorDependencies } from '../../../src/handlers/collector';
 
 const VALID_SOURCE: SourceRegistryRecord = {
+  tenantId: 'tenant-acme',
   sourceId: 'source-acme',
   active: true,
   engine: 'postgres',
@@ -374,6 +375,7 @@ describe('collector handler', () => {
     const result = await handler({ sourceId: ' source-acme ' });
 
     expect(result.sourceId).toBe('source-acme');
+    expect(result.tenantId).toBe('tenant-acme');
     expect(result.processedAt).toBe('2026-03-04T11:00:00.000Z');
     expect(result.recordsSent).toBe(2);
     expect(result.schemaVersion).toBe('1.0.0');
@@ -417,6 +419,7 @@ describe('collector handler', () => {
         'collector.cursor.loaded',
         {
           sourceId: 'source-acme',
+          tenantId: 'tenant-acme',
           hasPersistedCursor: true,
           persistedCursor: '2026-03-04T09:59:00.000Z',
         },
@@ -425,6 +428,7 @@ describe('collector handler', () => {
         'collector.source_credentials.loaded',
         {
           sourceId: 'source-acme',
+          tenantId: 'tenant-acme',
           engine: 'postgres',
           attempts: 1,
           durationMs: expect.any(Number),
@@ -434,6 +438,7 @@ describe('collector handler', () => {
         'collector.source_records.collected',
         {
           sourceId: 'source-acme',
+          tenantId: 'tenant-acme',
           engine: 'postgres',
           cursor: '2026-03-04T09:59:00.000Z',
           recordsCollected: 2,

--- a/tests/unit/handlers/create-source.test.ts
+++ b/tests/unit/handlers/create-source.test.ts
@@ -22,6 +22,17 @@ const VALID_INTERVAL_SOURCE = {
   intervalMinutes: 30,
 } as const;
 
+const tenantRequestContext = (requestId?: string) => ({
+  requestId,
+  authorizer: {
+    jwt: {
+      claims: {
+        tenant_id: 'tenant-acme',
+      },
+    },
+  },
+});
+
 class SpySourceRegistryRepository implements SourceRegistryRepository {
   public readonly created: SourceRegistryRecord[] = [];
 
@@ -63,7 +74,7 @@ describe('create-source handler', () => {
 
     const result = await handler({
       body: JSON.stringify(VALID_INTERVAL_SOURCE),
-      requestContext: { requestId: 'req-40' },
+      requestContext: tenantRequestContext('req-40'),
     });
 
     expect(result.statusCode).toBe(201);
@@ -79,6 +90,7 @@ describe('create-source handler', () => {
     });
     expect(repository.created).toHaveLength(1);
     expect(repository.created[0]).toMatchObject({
+      tenantId: 'tenant-acme',
       sourceId: 'source-acme',
       nextRunAt: '2026-03-03T12:30:00.000Z',
       schemaVersion: '1.0.0',
@@ -101,6 +113,7 @@ describe('create-source handler', () => {
         intervalMinutes: undefined,
         cronExpr: '0 */15 * * * *',
       }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(201);
@@ -119,6 +132,7 @@ describe('create-source handler', () => {
         ...VALID_INTERVAL_SOURCE,
         sourceId: '',
       }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -157,6 +171,7 @@ describe('create-source handler', () => {
 
     const result = await handler({
       body: JSON.stringify(VALID_INTERVAL_SOURCE),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(409);
@@ -174,6 +189,7 @@ describe('create-source handler', () => {
 
     const result = await handler({
       body: JSON.stringify(VALID_INTERVAL_SOURCE),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(500);
@@ -195,6 +211,7 @@ describe('create-source handler', () => {
         intervalMinutes: undefined,
         cronExpr: 'invalid cron',
       }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);

--- a/tests/unit/handlers/delete-source.test.ts
+++ b/tests/unit/handlers/delete-source.test.ts
@@ -11,6 +11,7 @@ import {
 import { createHandler } from '../../../src/handlers/delete-source';
 
 const ACTIVE_SOURCE: SourceRegistryRecord = {
+  tenantId: 'tenant-acme',
   sourceId: 'source-acme',
   active: true,
   engine: 'postgres',
@@ -99,6 +100,17 @@ class SpySourceRegistryRepository implements SourceRegistryRepository {
   }
 }
 
+const tenantRequestContext = (requestId?: string) => ({
+  requestId,
+  authorizer: {
+    jwt: {
+      claims: {
+        tenant_id: 'tenant-acme',
+      },
+    },
+  },
+});
+
 describe('delete-source handler', () => {
   it('deactivates active source and returns 204', async () => {
     const repository = new SpySourceRegistryRepository([ACTIVE_SOURCE]);
@@ -109,6 +121,7 @@ describe('delete-source handler', () => {
 
     const result = await handler({
       pathParameters: { id: ACTIVE_SOURCE.sourceId },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result).toEqual({
@@ -140,6 +153,7 @@ describe('delete-source handler', () => {
 
     const result = await handler({
       pathParameters: { id: ACTIVE_SOURCE.sourceId },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(204);
@@ -154,6 +168,7 @@ describe('delete-source handler', () => {
 
     const result = await handler({
       pathParameters: { id: 'missing-source' },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(404);
@@ -190,6 +205,7 @@ describe('delete-source handler', () => {
 
     const result = await handler({
       pathParameters: { id: ACTIVE_SOURCE.sourceId },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(409);
@@ -217,6 +233,7 @@ describe('delete-source handler', () => {
 
     const result = await handler({
       pathParameters: { id: ACTIVE_SOURCE.sourceId },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(204);
@@ -234,6 +251,7 @@ describe('delete-source handler', () => {
 
     const result = await handler({
       pathParameters: { id: ACTIVE_SOURCE.sourceId },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(500);

--- a/tests/unit/handlers/list-sources.test.ts
+++ b/tests/unit/handlers/list-sources.test.ts
@@ -10,6 +10,7 @@ import {
 import { createHandler } from '../../../src/handlers/list-sources';
 
 const SOURCE_A: SourceRegistryRecord = {
+  tenantId: 'tenant-acme',
   sourceId: 'source-acme',
   active: true,
   engine: 'postgres',
@@ -58,6 +59,17 @@ class SpySourceRegistryRepository implements SourceRegistryRepository {
   }
 }
 
+const tenantRequestContext = (requestId?: string) => ({
+  requestId,
+  authorizer: {
+    jwt: {
+      claims: {
+        tenant_id: 'tenant-acme',
+      },
+    },
+  },
+});
+
 describe('list-sources handler', () => {
   it('returns paginated source list with default limit', async () => {
     const repository = new SpySourceRegistryRepository({
@@ -69,13 +81,14 @@ describe('list-sources handler', () => {
     });
 
     const result = await handler({
-      requestContext: { requestId: 'req-42' },
+      requestContext: tenantRequestContext('req-42'),
     });
 
     expect(result.statusCode).toBe(200);
     expect(result.headers['content-type']).toBe('application/json');
     expect(repository.listCalls).toEqual([
       {
+        tenantId: 'tenant-acme',
         limit: 25,
         nextToken: undefined,
         active: undefined,
@@ -85,6 +98,7 @@ describe('list-sources handler', () => {
     expect(JSON.parse(result.body)).toEqual({
       items: [SOURCE_A],
       filters: {
+        tenantId: 'tenant-acme',
         active: null,
         engine: null,
       },
@@ -112,11 +126,13 @@ describe('list-sources handler', () => {
         active: 'false',
         engine: 'mysql',
       },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(200);
     expect(repository.listCalls).toEqual([
       {
+        tenantId: 'tenant-acme',
         limit: 10,
         nextToken: 'opaque-token',
         active: false,
@@ -126,6 +142,7 @@ describe('list-sources handler', () => {
     expect(JSON.parse(result.body)).toEqual({
       items: [],
       filters: {
+        tenantId: 'tenant-acme',
         active: false,
         engine: 'mysql',
       },
@@ -146,6 +163,7 @@ describe('list-sources handler', () => {
       queryStringParameters: {
         limit: '0',
       },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -163,6 +181,7 @@ describe('list-sources handler', () => {
       queryStringParameters: {
         active: 'yes',
       },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -180,6 +199,7 @@ describe('list-sources handler', () => {
       queryStringParameters: {
         engine: 'oracle',
       },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -197,6 +217,7 @@ describe('list-sources handler', () => {
       queryStringParameters: {
         nextToken: '   ',
       },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -217,6 +238,7 @@ describe('list-sources handler', () => {
       queryStringParameters: {
         nextToken: 'invalid-token',
       },
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -234,7 +256,9 @@ describe('list-sources handler', () => {
       ),
     });
 
-    const result = await handler({});
+    const result = await handler({
+      requestContext: tenantRequestContext(),
+    });
 
     expect(result.statusCode).toBe(500);
     expect(JSON.parse(result.body)).toEqual({

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -52,12 +52,14 @@ describe('scheduler handler', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-b',
             nextRunAt: '2026-03-04T09:00:00.000Z',
             scheduleType: 'interval',
             intervalMinutes: 5,
           },
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-a',
             nextRunAt: '2026-03-04T09:05:00.000Z',
             scheduleType: 'interval',
@@ -69,6 +71,7 @@ describe('scheduler handler', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-c',
             nextRunAt: '2026-03-04T08:59:00.000Z',
             scheduleType: 'interval',
@@ -117,6 +120,16 @@ describe('scheduler handler', () => {
       },
     ]);
     expect(result.sourceIds).toEqual(['source-b', 'source-c']);
+    expect(result.sources).toEqual([
+      {
+        sourceId: 'source-b',
+        tenantId: 'tenant-acme',
+      },
+      {
+        sourceId: 'source-c',
+        tenantId: 'tenant-acme',
+      },
+    ]);
     expect(result.contractVersion).toBe('scheduler-output.v1');
     expect(result.eligibleSources).toBe(2);
     expect(result.hasEligibleSources).toBe(true);
@@ -126,6 +139,7 @@ describe('scheduler handler', () => {
     expect(logger.info).toHaveBeenCalledWith('scheduler.eligible_sources.filtered', {
       referenceNow: '2026-03-04T09:01:00.000Z',
       eligibleSources: 2,
+      tenants: 1,
       correlationId: null,
     });
   });
@@ -136,12 +150,14 @@ describe('scheduler handler', () => {
         {
           items: [
             {
+              tenantId: 'tenant-acme',
               sourceId: 'source-a',
               nextRunAt: '2026-03-04T09:00:00.000Z',
               scheduleType: 'interval',
               intervalMinutes: 5,
             },
             {
+              tenantId: 'tenant-acme',
               sourceId: 'source-b',
               nextRunAt: '2026-03-04T09:00:00.000Z',
               scheduleType: 'interval',
@@ -174,12 +190,14 @@ describe('scheduler handler', () => {
         {
           items: [
             {
+              tenantId: 'tenant-acme',
               sourceId: 'source-a',
               nextRunAt: '2026-03-04T09:00:00.000Z',
               scheduleType: 'interval',
               intervalMinutes: 5,
             },
             {
+              tenantId: 'tenant-acme',
               sourceId: 'source-b',
               nextRunAt: '2026-03-04T09:00:00.000Z',
               scheduleType: 'interval',
@@ -236,12 +254,14 @@ describe('scheduler handler', () => {
       {
         items: [
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-a',
             nextRunAt: '2026-03-04T10:00:00.000Z',
             scheduleType: 'interval',
             intervalMinutes: 5,
           },
           {
+            tenantId: 'tenant-acme',
             sourceId: 'source-b',
             nextRunAt: '2026-03-04T10:01:00.000Z',
             scheduleType: 'interval',
@@ -317,6 +337,7 @@ describe('scheduler handler', () => {
 
     expect(result).toEqual({
       contractVersion: 'scheduler-output.v1',
+      sources: [],
       sourceIds: [],
       eligibleSources: 0,
       hasEligibleSources: false,
@@ -327,6 +348,7 @@ describe('scheduler handler', () => {
     expect(logger.info).toHaveBeenCalledWith('scheduler.eligible_sources.filtered', {
       referenceNow: '2026-03-04T10:01:00.000Z',
       eligibleSources: 0,
+      tenants: 0,
       correlationId: 'exec-123',
     });
   });

--- a/tests/unit/handlers/update-source.test.ts
+++ b/tests/unit/handlers/update-source.test.ts
@@ -9,6 +9,7 @@ import {
 import { createHandler } from '../../../src/handlers/update-source';
 
 const EXISTING_SOURCE: SourceRegistryRecord = {
+  tenantId: 'tenant-acme',
   sourceId: 'source-acme',
   active: true,
   engine: 'postgres',
@@ -86,6 +87,17 @@ class SpySourceRegistryRepository implements SourceRegistryRepository {
   }
 }
 
+const tenantRequestContext = (requestId?: string) => ({
+  requestId,
+  authorizer: {
+    jwt: {
+      claims: {
+        tenant_id: 'tenant-acme',
+      },
+    },
+  },
+});
+
 describe('update-source handler', () => {
   it('updates only mutable fields and returns 200', async () => {
     const repository = new SpySourceRegistryRepository([EXISTING_SOURCE]);
@@ -99,7 +111,7 @@ describe('update-source handler', () => {
       body: JSON.stringify({
         active: false,
       }),
-      requestContext: { requestId: 'req-41' },
+      requestContext: tenantRequestContext('req-41'),
     });
 
     expect(result.statusCode).toBe(200);
@@ -136,6 +148,7 @@ describe('update-source handler', () => {
       body: JSON.stringify({
         intervalMinutes: 45,
       }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(200);
@@ -156,6 +169,7 @@ describe('update-source handler', () => {
     const result = await handler({
       pathParameters: { id: 'missing-source' },
       body: JSON.stringify({ active: false }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(404);
@@ -177,6 +191,7 @@ describe('update-source handler', () => {
         sourceId: 'other-source',
         active: false,
       }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -199,6 +214,7 @@ describe('update-source handler', () => {
       body: JSON.stringify({
         nextRunAt: '2026-03-03T12:30:00.000Z',
       }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -219,6 +235,7 @@ describe('update-source handler', () => {
     const result = await handler({
       pathParameters: { id: EXISTING_SOURCE.sourceId },
       body: JSON.stringify({ active: false }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(409);
@@ -239,6 +256,7 @@ describe('update-source handler', () => {
       body: JSON.stringify({
         scheduleType: 'cron',
       }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(400);
@@ -263,6 +281,7 @@ describe('update-source handler', () => {
         scheduleType: 'cron',
         cronExpr: '0 */15 * * *',
       }),
+      requestContext: tenantRequestContext(),
     });
 
     expect(result.statusCode).toBe(200);

--- a/tests/unit/infra/events/sns-customer-events-publisher.test.ts
+++ b/tests/unit/infra/events/sns-customer-events-publisher.test.ts
@@ -23,6 +23,7 @@ describe('createSnsCustomerEventsPublisher', () => {
 
     const result = await publisher({
       sourceId: 'source-acme',
+      tenantId: 'tenant-acme',
       correlationId: 'exec-123',
       publishedAt: '2026-03-04T10:00:00.000Z',
       records: [
@@ -40,6 +41,10 @@ describe('createSnsCustomerEventsPublisher', () => {
         DataType: 'String',
         StringValue: 'source-acme',
       },
+      tenantId: {
+        DataType: 'String',
+        StringValue: 'tenant-acme',
+      },
       correlationId: {
         DataType: 'String',
         StringValue: 'exec-123',
@@ -51,6 +56,7 @@ describe('createSnsCustomerEventsPublisher', () => {
     });
 
     const firstMessage = JSON.parse(firstCommand.input.Message ?? '{}') as Record<string, unknown>;
+    expect(firstMessage.tenantId).toBe('tenant-acme');
     expect(firstMessage.integrationTargets).toEqual(['salesforce', 'hubspot']);
   });
 
@@ -64,6 +70,7 @@ describe('createSnsCustomerEventsPublisher', () => {
 
     const result = await publisher({
       sourceId: 'source-acme',
+      tenantId: 'tenant-acme',
       correlationId: 'exec-123',
       publishedAt: '2026-03-04T10:00:00.000Z',
       records: [],

--- a/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts
+++ b/tests/unit/infra/sources/dynamodb-scheduler-source-repository.test.ts
@@ -56,12 +56,14 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
         value: {
           Items: [
             marshall({
+              tenantId: 'tenant-acme',
               sourceId: 'source-a',
               nextRunAt: '2026-03-04T10:00:00.000Z',
               scheduleType: 'interval',
               intervalMinutes: 5,
             }),
             marshall({
+              tenantId: 'tenant-acme',
               sourceId: 'source-b',
               nextRunAt: '2026-03-04T11:00:00.000Z',
               scheduleType: 'cron',
@@ -100,18 +102,20 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
       ':nextRunAt': { S: '2026-03-04T10:30:00.000Z' },
     });
     expect(queryCommand.input.ProjectionExpression).toBe(
-      'sourceId, nextRunAt, scheduleType, intervalMinutes, cronExpr',
+      'tenantId, sourceId, nextRunAt, scheduleType, intervalMinutes, cronExpr',
     );
     expect(queryCommand.input.Limit).toBe(2);
     expect(queryCommand.input.ScanIndexForward).toBe(true);
     expect(result.items).toEqual([
       {
+        tenantId: 'tenant-acme',
         sourceId: 'source-a',
         nextRunAt: '2026-03-04T10:00:00.000Z',
         scheduleType: 'interval',
         intervalMinutes: 5,
       },
       {
+        tenantId: 'tenant-acme',
         sourceId: 'source-b',
         nextRunAt: '2026-03-04T11:00:00.000Z',
         scheduleType: 'cron',
@@ -132,6 +136,7 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
         value: {
           Items: [
             marshall({
+              tenantId: 'tenant-acme',
               sourceId: 'source-a',
               nextRunAt: '2026-03-04T10:00:00.000Z',
               scheduleType: 'interval',
@@ -145,6 +150,7 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
         value: {
           Items: [
             marshall({
+              tenantId: 'tenant-acme',
               sourceId: 'source-c',
               nextRunAt: '2026-03-04T12:00:00.000Z',
               scheduleType: 'interval',
@@ -213,6 +219,7 @@ describe('createDynamoDbSchedulerSourceRepository', () => {
         value: {
           Items: [
             marshall({
+              tenantId: 'tenant-acme',
               sourceId: '',
               nextRunAt: '2026-03-04T10:00:00.000Z',
               scheduleType: 'interval',

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -137,12 +137,13 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(schedulerCatchEntry.Next).toBe('BuildSchedulerFailureOutput');
 
     expect(processEligibleSources.Type).toBe('Map');
-    expect(processEligibleSources.ItemsPath).toBe('$.schedulerResult.sourceIds');
+    expect(processEligibleSources.ItemsPath).toBe('$.schedulerResult.sources');
     expect(processEligibleSources.MaxConcurrencyPath).toBe('$.schedulerResult.maxConcurrency');
     expect(processEligibleSources.ResultPath).toBe('$.collectorResults');
     expect(processEligibleSources.Next).toBe('BuildExecutionOutput');
     const processEligibleSourcesParameters = asObject(processEligibleSources.Parameters);
-    expect(processEligibleSourcesParameters['sourceId.$']).toBe('$$.Map.Item.Value');
+    expect(processEligibleSourcesParameters['sourceId.$']).toBe('$$.Map.Item.Value.sourceId');
+    expect(processEligibleSourcesParameters['tenantId.$']).toBe('$$.Map.Item.Value.tenantId');
     expect(processEligibleSourcesParameters['meta.$']).toBe('$.meta');
     const iterator = asObject(processEligibleSources.Iterator);
     expect(iterator.StartAt).toBe('InvokeCollector');
@@ -162,6 +163,7 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(invokeCollectorResource['Fn::GetAtt']).toEqual(['CollectorLambdaFunction', 'Arn']);
     const invokeCollectorParameters = asObject(invokeCollector.Parameters);
     expect(invokeCollectorParameters['sourceId.$']).toBe('$.sourceId');
+    expect(invokeCollectorParameters['tenantId.$']).toBe('$.tenantId');
     expect(invokeCollectorParameters['meta.$']).toBe('$.meta');
     const invokeCollectorRetry = invokeCollector.Retry as unknown[];
     expect(Array.isArray(invokeCollectorRetry)).toBe(true);
@@ -194,6 +196,7 @@ describe('main-orchestration-v1.asl.json', () => {
     const buildItemSuccessParameters = asObject(buildItemSuccessResult.Parameters);
     const buildItemSuccessPayload = asObject(buildItemSuccessParameters.result);
     expect(buildItemSuccessPayload['sourceId.$']).toBe('$.sourceId');
+    expect(buildItemSuccessPayload['tenantId.$']).toBe('$.tenantId');
     expect(buildItemSuccessPayload.status).toBe('SUCCEEDED');
     expect(buildItemSuccessPayload['processedAt.$']).toBe('$.collectorResult.processedAt');
     expect(buildItemSuccessPayload['recordsSent.$']).toBe('$.collectorResult.recordsSent');
@@ -222,6 +225,7 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(returnItemSuccessResult.End).toBe(true);
     const returnItemSuccessParameters = asObject(returnItemSuccessResult.Parameters);
     expect(returnItemSuccessParameters['sourceId.$']).toBe('$.result.sourceId');
+    expect(returnItemSuccessParameters['tenantId.$']).toBe('$.result.tenantId');
     expect(returnItemSuccessParameters['status.$']).toBe('$.result.status');
     expect(returnItemSuccessParameters['processedAt.$']).toBe('$.result.processedAt');
     expect(returnItemSuccessParameters['recordsSent.$']).toBe('$.result.recordsSent');
@@ -231,6 +235,7 @@ describe('main-orchestration-v1.asl.json', () => {
     const buildItemFailureParameters = asObject(buildItemFailureResult.Parameters);
     const buildItemFailurePayload = asObject(buildItemFailureParameters.result);
     expect(buildItemFailurePayload['sourceId.$']).toBe('$.sourceId');
+    expect(buildItemFailurePayload['tenantId.$']).toBe('$.tenantId');
     expect(buildItemFailurePayload.status).toBe('FAILED');
     expect(buildItemFailurePayload['error.$']).toBe('$.collectorError.Error');
     expect(buildItemFailurePayload['cause.$']).toBe('$.collectorError.Cause');
@@ -259,6 +264,7 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(returnItemFailureResult.End).toBe(true);
     const returnItemFailureParameters = asObject(returnItemFailureResult.Parameters);
     expect(returnItemFailureParameters['sourceId.$']).toBe('$.result.sourceId');
+    expect(returnItemFailureParameters['tenantId.$']).toBe('$.result.tenantId');
     expect(returnItemFailureParameters['status.$']).toBe('$.result.status');
     expect(returnItemFailureParameters['error.$']).toBe('$.result.error');
     expect(returnItemFailureParameters['cause.$']).toBe('$.result.cause');
@@ -268,7 +274,7 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(buildExecutionOutput.Next).toBe('PublishExecutionSuccessMetric');
     const outputParameters = asObject(buildExecutionOutput.Parameters);
     expect(outputParameters['meta.$']).toBe('$.meta');
-    expect(outputParameters['sources.$']).toBe('$.schedulerResult.sourceIds');
+    expect(outputParameters['sources.$']).toBe('$.schedulerResult.sources');
     expect(outputParameters['results.$']).toBe('$.collectorResults');
     const schedulerOutput = asObject(outputParameters.scheduler);
     expect(schedulerOutput['contractVersion.$']).toBe('$.schedulerResult.contractVersion');
@@ -354,6 +360,7 @@ describe('main-orchestration-v1.asl.json', () => {
     const sourceARawResult = asObject(
       materializeParameters(buildItemSuccessParameters, {
         sourceId: 'source-a',
+        tenantId: 'tenant-a',
         meta: {
           stage: 'dev',
           executionId: 'exec-123',
@@ -370,6 +377,7 @@ describe('main-orchestration-v1.asl.json', () => {
     const sourceBRawResult = asObject(
       materializeParameters(buildItemFailureParameters, {
         sourceId: 'source-b',
+        tenantId: 'tenant-b',
         meta: {
           stage: 'dev',
           executionId: 'exec-123',
@@ -386,6 +394,7 @@ describe('main-orchestration-v1.asl.json', () => {
     const sourceCRawResult = asObject(
       materializeParameters(buildItemSuccessParameters, {
         sourceId: 'source-c',
+        tenantId: 'tenant-c',
         meta: {
           stage: 'dev',
           executionId: 'exec-123',
@@ -407,7 +416,11 @@ describe('main-orchestration-v1.asl.json', () => {
           stage: 'dev',
         },
         schedulerResult: {
-          sourceIds: ['source-a', 'source-b', 'source-c'],
+          sources: [
+            { sourceId: 'source-a', tenantId: 'tenant-a' },
+            { sourceId: 'source-b', tenantId: 'tenant-b' },
+            { sourceId: 'source-c', tenantId: 'tenant-c' },
+          ],
           contractVersion: 'scheduler-output.v1',
           referenceNow: '2026-03-03T00:00:00.000Z',
           hasEligibleSources: true,
@@ -420,7 +433,11 @@ describe('main-orchestration-v1.asl.json', () => {
     );
 
     const sources = asArray(executionOutput.sources);
-    expect(sources).toEqual(['source-a', 'source-b', 'source-c']);
+    expect(sources).toEqual([
+      { sourceId: 'source-a', tenantId: 'tenant-a' },
+      { sourceId: 'source-b', tenantId: 'tenant-b' },
+      { sourceId: 'source-c', tenantId: 'tenant-c' },
+    ]);
 
     const results = asArray(executionOutput.results).map((entry) => asObject(entry));
     expect(results).toHaveLength(3);
@@ -457,7 +474,7 @@ describe('main-orchestration-v1.asl.json', () => {
           stage: 'dev',
         },
         schedulerResult: {
-          sourceIds: [],
+          sources: [],
           contractVersion: 'scheduler-output.v1',
           referenceNow: '2026-03-04T09:00:00.000Z',
           hasEligibleSources: false,


### PR DESCRIPTION
Closes #181

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Propagar `tenant_id` fim-a-fim na plataforma para garantir isolamento multi-tenant em API, scheduler, orquestração e coletora.

---

## 🧠 Decisão Técnica

Introduzido `tenant-context` para resolver tenant via claims JWT e aplicado enforcement nos handlers de `/sources`. Repositórios e modelos passaram a persistir/filtrar por `tenantId`. Scheduler e Step Functions passaram a transportar `tenantId` por item do Map; coletora valida mismatch e propaga tenant para upsert e eventos SNS.

---

## 🧪 BDD Validado

Dado um usuário autenticado com `tenant_id`
Quando cria/lista/atualiza/remove uma fonte
Então somente dados do próprio tenant são aceitos e retornados.

Dado o scheduler retornando fontes elegíveis
Quando a orquestração executa o Map
Então cada execução da coletora recebe `sourceId` e `tenantId` correspondentes.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

---

## 🔥 Tipo de Release

- [ ] PATCH
- [x] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
