### PR TITLE
feat: baseline OpenTelemetry nas lambdas críticas

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Guia operacional completo: `docs/integrations/dlq-reprocessing.md`.
 
 Playbook de resposta para alarmes operacionais (ingestão + integrações + Step Functions): `docs/observability/operational-alarms-playbook.md`.
 
+Baseline de instrumentação OpenTelemetry para Lambdas críticas (spans, propagação e logs de trace): `docs/observability/open-telemetry-baseline.md`.
+
 ## Ambiente de testes (isolado)
 
 - Runner: `Jest` com `ts-jest` e `testEnvironment: node`.

--- a/docs/observability/open-telemetry-baseline.md
+++ b/docs/observability/open-telemetry-baseline.md
@@ -1,0 +1,50 @@
+# OpenTelemetry baseline (Lambda)
+
+## Escopo
+
+Baseline de instrumentacao aplicada nos handlers criticos:
+
+- `scheduler`
+- `collector`
+- `POST /sources`
+- `PATCH /sources/{id}`
+- `GET /sources`
+- `DELETE /sources/{id}`
+
+## O que foi instrumentado
+
+- Span raiz por execucao de handler.
+- Child spans para etapas criticas de IO (repositorio, leitura de credenciais, coleta, upsert, publicacao de eventos, persistencia de cursor e publicacao de metricas).
+- Atributos padrao em spans:
+  - `service`
+  - `stage`
+  - `sourceId`
+  - `tenantId`
+  - `executionId`
+- Logs estruturados com evento de contexto de trace:
+  - `*.trace_context` para APIs
+  - `scheduler.telemetry.trace_context`
+  - `collector.telemetry.trace_context`
+
+## Propagacao de contexto (Scheduler -> Step Functions -> Collector)
+
+1. `scheduler` gera `traceContext` no output (`traceparent`, `traceId`, `spanId`, `traceFlags`).
+2. A state machine injeta `schedulerResult.traceContext` em `meta.traceContext` de cada item do `Map`.
+3. `collector` inicia span raiz usando `meta.traceContext` como parent remoto.
+
+## Variaveis de ambiente
+
+- `SERVICE_NAME`: nome do servico usado em atributos (fallback default: `alert-orchestration-service`).
+- `STAGE`: stage ativo (`dev`, `stg`, `prod`).
+- `OTEL_SERVICE_NAME` (opcional): override de nome de servico para tracer.
+
+Obs.: o baseline usa provider local (`BasicTracerProvider`) e nao inclui exporter remoto neste escopo.
+
+## Operacao
+
+- Verificar continuidade de trace por `trace_id` e `traceparent` nos logs de `scheduler` e `collector`.
+- Em incidentes, correlacionar:
+  - `meta.executionId` da orquestracao
+  - `trace_id` dos eventos `*.trace_context`
+  - `sourceId` e `tenantId` dos eventos de negocio
+

--- a/docs/step-functions/main-orchestration-v1.md
+++ b/docs/step-functions/main-orchestration-v1.md
@@ -29,7 +29,7 @@ Payload esperado na execução:
 
 ### Scheduler (Task)
 
-- Entrada: `schedulerInput.now`.
+- Entrada: `schedulerInput.now` + `meta` (execution/stage/service).
 - Ação: invoca `SchedulerLambdaFunction`.
 - Implementação do scheduler:
   - Consulta fontes ativas no DynamoDB usando o índice `active-nextRunAt-index`.
@@ -46,18 +46,20 @@ Payload esperado na execução:
   - Política limitada: número de tentativas é finito (`MaxAttempts`) para evitar loop infinito.
 - Saída esperada em `schedulerResult`:
   - `contractVersion` (`scheduler-output.v1`)
+  - `sources` (`Array<{sourceId, tenantId}>`)
   - `sourceIds` (array de string)
   - `eligibleSources` (number)
   - `hasEligibleSources` (boolean)
   - `referenceNow` (string ISO)
   - `generatedAt` (string ISO)
   - `maxConcurrency` (number, inteiro entre 1 e 40)
+  - `traceContext` (traceparent/traceId/spanId/traceFlags)
   - Contrato detalhado em `docs/step-functions/scheduler-output-v1.md`.
 
 ### ProcessEligibleSources (Map)
 
-- Entrada: `schedulerResult.sourceIds` e `schedulerResult.maxConcurrency`.
-- Ação: itera cada `sourceId` e invoca `CollectorLambdaFunction`.
+- Entrada: `schedulerResult.sources` e `schedulerResult.maxConcurrency`.
+- Ação: itera cada item `{sourceId, tenantId}` e invoca `CollectorLambdaFunction`.
 - Retry com backoff exponencial na task `InvokeCollector` com os mesmos limites do `Scheduler`.
 - Política limitada também no coletor (`MaxAttempts` finito), com `Catch` por item para manter tolerância a falha parcial.
 - Catch por item no `InvokeCollector` (`States.ALL`) para registrar falha da fonte sem interromper o `Map`.
@@ -65,8 +67,11 @@ Payload esperado na execução:
   - `SourceProcessed` / `SourceFailed` (dimensão `Stage`);
   - `SourceProcessedBySource` / `SourceFailedBySource` (dimensões `Stage`, `ExecutionId`, `SourceId`).
 - Contrato por item em `collectorResults`:
-  - sucesso: `sourceId`, `status=SUCCEEDED`, `processedAt`, `recordsSent`;
-  - falha: `sourceId`, `status=FAILED`, `error`, `cause`.
+  - sucesso: `sourceId`, `tenantId`, `status=SUCCEEDED`, `processedAt`, `recordsSent`;
+  - falha: `sourceId`, `tenantId`, `status=FAILED`, `error`, `cause`.
+- Propagacao de trace:
+  - `schedulerResult.traceContext` e injetado em `meta.traceContext` de cada item do `Map`.
+  - `Collector` usa esse contexto como parent span para continuidade de rastreio distribuido.
 - Controle de paralelismo:
   - `MaxConcurrencyPath = $.schedulerResult.maxConcurrency`.
   - Valor configurado por stage via `custom.stages.<stage>.mapMaxConcurrency`:
@@ -80,7 +85,7 @@ Payload esperado na execução:
 - Entrada: `meta` + `schedulerResult`.
 - Saída final:
   - `meta`
-  - `sources` (`schedulerResult.sourceIds`)
+  - `sources` (`schedulerResult.sources`)
   - `results` (lista de itens com sucesso/falha por `sourceId`)
   - `scheduler.contractVersion`
   - `scheduler.referenceNow`

--- a/docs/step-functions/scheduler-output-v1.md
+++ b/docs/step-functions/scheduler-output-v1.md
@@ -4,29 +4,45 @@ Contrato versionado da Lambda `scheduler` consumido diretamente pela state machi
 
 ## Objetivo
 
-Padronizar a resposta da Scheduler para que o `Map State` consuma `sourceIds` e `maxConcurrency` sem etapa intermediaria de transformacao.
+Padronizar a resposta da Scheduler para que o `Map State` consuma itens `{sourceId, tenantId}` com `maxConcurrency` e contexto de trace sem etapa intermediaria de transformacao.
 
 ## Estrutura
 
 - `contractVersion` (`string`, obrigatorio): versao do contrato. Valor fixo `scheduler-output.v1`.
-- `sourceIds` (`string[]`, obrigatorio): lista de fontes reservadas para processamento.
-- `eligibleSources` (`number`, obrigatorio): quantidade de itens em `sourceIds`.
+- `sources` (`Array<{sourceId, tenantId}>`, obrigatorio): lista de fontes reservadas para processamento.
+- `sourceIds` (`string[]`, obrigatorio): espelho de compatibilidade para consumidores legados.
+- `eligibleSources` (`number`, obrigatorio): quantidade de itens em `sources`.
 - `hasEligibleSources` (`boolean`, obrigatorio): indica se ha pelo menos uma fonte elegivel.
 - `referenceNow` (`string`, obrigatorio, ISO-8601 UTC): relogio usado para elegibilidade/reserva.
 - `generatedAt` (`string`, obrigatorio, ISO-8601 UTC): timestamp de geracao da resposta.
 - `maxConcurrency` (`number`, obrigatorio): limite de paralelismo para o `Map` (1 a 40).
+- `traceContext` (`object`, obrigatorio): contexto W3C para propagacao Scheduler -> Collector.
+  - `traceparent` (`string`)
+  - `traceId` (`string`, 32 hex)
+  - `spanId` (`string`, 16 hex)
+  - `traceFlags` (`string`, 2 hex)
 
 ## Exemplo com fontes elegiveis
 
 ```json
 {
   "contractVersion": "scheduler-output.v1",
+  "sources": [
+    { "sourceId": "crm-a", "tenantId": "tenant-a" },
+    { "sourceId": "erp-b", "tenantId": "tenant-b" }
+  ],
   "sourceIds": ["crm-a", "erp-b"],
   "eligibleSources": 2,
   "hasEligibleSources": true,
   "referenceNow": "2026-03-04T09:01:00.000Z",
   "generatedAt": "2026-03-04T09:01:00.000Z",
-  "maxConcurrency": 5
+  "maxConcurrency": 5,
+  "traceContext": {
+    "traceparent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+    "traceId": "0123456789abcdef0123456789abcdef",
+    "spanId": "0123456789abcdef",
+    "traceFlags": "01"
+  }
 }
 ```
 
@@ -35,12 +51,19 @@ Padronizar a resposta da Scheduler para que o `Map State` consuma `sourceIds` e 
 ```json
 {
   "contractVersion": "scheduler-output.v1",
+  "sources": [],
   "sourceIds": [],
   "eligibleSources": 0,
   "hasEligibleSources": false,
   "referenceNow": "2026-03-04T09:01:00.000Z",
   "generatedAt": "2026-03-04T09:01:00.000Z",
-  "maxConcurrency": 5
+  "maxConcurrency": 5,
+  "traceContext": {
+    "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    "traceId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "spanId": "bbbbbbbbbbbbbbbb",
+    "traceFlags": "01"
+  }
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@aws-sdk/client-sns": "^3.1001.0",
         "@aws-sdk/client-sqs": "^3.1001.0",
         "@aws-sdk/util-dynamodb": "^3.996.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.0",
         "@types/pg": "^8.18.0",
         "cron-parser": "^5.5.0",
         "mysql2": "^3.18.2",
@@ -2846,6 +2848,72 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
+      "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
+      "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@aws-sdk/client-sns": "^3.1001.0",
     "@aws-sdk/client-sqs": "^3.1001.0",
     "@aws-sdk/util-dynamodb": "^3.996.1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^2.6.0",
     "@types/pg": "^8.18.0",
     "cron-parser": "^5.5.0",
     "mysql2": "^3.18.2",

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,7 @@ provider:
   environment:
     STAGE: ${self:provider.stage}
     SERVICE_NAME: ${self:service}
+    OTEL_SERVICE_NAME: ${env:OTEL_SERVICE_NAME, 'alert-orchestration-service'}
     SOURCES_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.sourcesTableName}
     CURSORS_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.cursorsTableName}
     IDEMPOTENCY_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.idempotencyTableName}

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -52,6 +52,12 @@ import { createSecretsManagerOutboundAuthHeadersResolver } from '../infra/securi
 import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamodb-source-registry-repository';
 import { createSnsCustomerEventsPublisher, type CustomerEventsPublisher } from '../infra/events/sns-customer-events-publisher';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
+import {
+  buildTelemetryAttributes,
+  toTelemetryLogContext,
+  withTelemetrySpan,
+  type TelemetryTraceContext,
+} from '../shared/observability/open-telemetry';
 import { nowIso } from '../shared/time/now-iso';
 
 const COLLECTOR_SECRET_RETRY_MAX_ATTEMPTS_DEFAULT = 3;
@@ -120,6 +126,8 @@ export interface CollectorEvent {
   meta?: {
     executionId?: string;
     stage?: string;
+    service?: string;
+    traceContext?: Partial<TelemetryTraceContext>;
   };
 }
 
@@ -734,449 +742,607 @@ export const createHandler =
   async (event: CollectorEvent): Promise<CollectorResult> => {
     const executionStartedAtMs = nowMs();
     const sourceId = event?.sourceId?.trim() ?? '';
-    if (sourceId.length === 0) {
-      throw new Error('sourceId is required for collector execution.');
-    }
-    let resolvedTenantId = event.tenantId?.trim() || 'unknown';
-    let executionStatus: 'SUCCEEDED' | 'FAILED' = 'FAILED';
+    const executionId = event?.meta?.executionId?.trim();
+    const stage = event?.meta?.stage ?? process.env.STAGE;
+    const service = event?.meta?.service ?? process.env.SERVICE_NAME;
 
-    try {
-      const sourceConfiguration = await loadCollectorSourceConfiguration({
-        sourceId,
-        sourceRegistryRepository,
-      });
-      const eventTenantId = event.tenantId?.trim();
-      if (eventTenantId && eventTenantId !== sourceConfiguration.tenantId) {
-        throw new Error(
-          `Collector tenant mismatch for source "${sourceId}": expected "${sourceConfiguration.tenantId}" but received "${eventTenantId}".`,
-        );
-      }
-      const tenantId = eventTenantId || sourceConfiguration.tenantId;
-      resolvedTenantId = tenantId;
+    return withTelemetrySpan({
+      component: 'collector',
+      spanName: 'collector.execute',
+      parentTraceContext: event?.meta?.traceContext,
+      attributes: buildTelemetryAttributes({
+        service,
+        stage,
+        sourceId: sourceId || undefined,
+        tenantId: event.tenantId,
+        executionId,
+      }),
+      run: async ({ span, traceContext, runInChildSpan }): Promise<CollectorResult> => {
+        logger.info('collector.telemetry.trace_context', {
+          sourceId: sourceId || null,
+          executionId: executionId ?? null,
+          ...toTelemetryLogContext(traceContext),
+        });
 
-      const cursorSnapshot = await cursorRepository.getBySource(sourceId);
-      logger.info('collector.cursor.loaded', {
-        sourceId,
-        tenantId,
-        hasPersistedCursor: cursorSnapshot !== null,
-        persistedCursor: cursorSnapshot?.last ?? null,
-      });
+        if (sourceId.length === 0) {
+          throw new Error('sourceId is required for collector execution.');
+        }
+        span.setAttribute('sourceId', sourceId);
 
-      const loadedCredentials = await loadCollectorSourceCredentials({
-        sourceId,
-        engine: sourceConfiguration.engine,
-        secretArn: sourceConfiguration.secretArn,
-        secretRepository,
-        retryPolicy: secretRetryPolicy,
-        nowMs,
-        sleep,
-      });
+        let resolvedTenantId = event.tenantId?.trim() || 'unknown';
+        let executionStatus: 'SUCCEEDED' | 'FAILED' = 'FAILED';
 
-      logger.info('collector.source_credentials.loaded', {
-        sourceId,
-        tenantId,
-        engine: sourceConfiguration.engine,
-        attempts: loadedCredentials.metrics.attempts,
-        durationMs: loadedCredentials.metrics.durationMs,
-      });
-
-      const cursor = resolveCursorValue(event?.cursor, cursorSnapshot?.last, defaultCursorValue);
-
-      let records: CollectorStandardizedRecord[];
-      switch (sourceConfiguration.engine) {
-        case 'postgres':
-          records = await collectPostgresRecords({
-            sourceId,
-            queryTemplate: sourceConfiguration.query,
-            cursor,
-            postgresQueryExecutor: postgresQueryExecutorFactory(loadedCredentials.credentials),
-          });
-          break;
-        case 'mysql':
-          records = await collectMySqlRecords({
-            sourceId,
-            queryTemplate: sourceConfiguration.query,
-            cursor,
-            mySqlQueryExecutor: mySqlQueryExecutorFactory(loadedCredentials.credentials),
-          });
-          break;
-        default:
-          throw new Error(
-            `Collector engine "${String(sourceConfiguration.engine)}" is not supported yet.`,
+        try {
+          const sourceConfiguration = await runInChildSpan(
+            {
+              spanName: 'collector.load_source_configuration',
+              attributes: buildTelemetryAttributes({
+                service,
+                stage,
+                sourceId,
+                tenantId: event.tenantId,
+                executionId,
+              }),
+            },
+            async () =>
+              loadCollectorSourceConfiguration({
+                sourceId,
+                sourceRegistryRepository,
+              }),
           );
-      }
+          const eventTenantId = event.tenantId?.trim();
+          if (eventTenantId && eventTenantId !== sourceConfiguration.tenantId) {
+            throw new Error(
+              `Collector tenant mismatch for source "${sourceId}": expected "${sourceConfiguration.tenantId}" but received "${eventTenantId}".`,
+            );
+          }
+          const tenantId = eventTenantId || sourceConfiguration.tenantId;
+          resolvedTenantId = tenantId;
+          span.setAttribute('tenantId', tenantId);
 
-      logger.info('collector.source_records.collected', {
-        sourceId,
-        tenantId,
-        engine: sourceConfiguration.engine,
-        cursor,
-        recordsCollected: records.length,
-      });
-
-      const requiredCanonicalFields = sourceConfiguration.fieldMap.id ? ['id'] : [];
-      const mappingResult = mapRecordsWithFieldMap({
-        sourceId,
-        records,
-        fieldMap: sourceConfiguration.fieldMap,
-        requiredCanonicalFields,
-      });
-
-      const ignoredSourceColumns = mappingResult.ignoredSourceColumns.filter(
-        (sourceColumn) => sourceColumn !== sourceConfiguration.cursorField,
-      );
-      if (ignoredSourceColumns.length > 0) {
-        logger.info('collector.field_map.ignored_source_columns', {
-          sourceId,
-          ignoredColumns: ignoredSourceColumns,
-          ignoredColumnsCount: ignoredSourceColumns.length,
-        });
-      }
-
-      const canonicalValidationResult = validateCanonicalCustomerBatch(mappingResult.records);
-      if (canonicalValidationResult.rejectedRecords.length > 0) {
-        logger.info('collector.canonical_validation.rejected_records', {
-          sourceId,
-          schemaVersion: canonicalValidationResult.schemaVersion,
-          rejectedRecordsCount: canonicalValidationResult.rejectedRecords.length,
-          rejectedIssues: canonicalValidationResult.rejectedRecords.map((rejectedRecord) => ({
-            index: rejectedRecord.index,
-            issues: rejectedRecord.issues,
-          })),
-        });
-      }
-
-      const correlationId =
-        event?.meta?.executionId?.trim() ??
-        `${sourceId}-${event?.meta?.stage ?? 'unknown'}-${sourceConfiguration.cursorField}`;
-
-      const cursorToken = normalizeCursorToken(cursor);
-      const claimCreatedAt = now();
-      const claimExpiration = Math.floor(nowMs() / 1000) + idempotencyTtlSeconds;
-
-      const nonDuplicatedUpsertRecords: CollectorStandardizedRecord[] = [];
-      const duplicatedUpsertRecords: CollectorStandardizedRecord[] = [];
-      for (const record of canonicalValidationResult.validRecords) {
-        const recordId = normalizeRecordId(record);
-        if (recordId.length === 0) {
-          duplicatedUpsertRecords.push(record);
-          continue;
-        }
-
-        const claimed = await idempotencyRepository.tryClaim({
-          deduplicationKey: buildDeduplicationKey({
-            scope: 'upsert',
+          const cursorSnapshot = await runInChildSpan(
+            {
+              spanName: 'collector.load_cursor_snapshot',
+              attributes: buildTelemetryAttributes({
+                service,
+                stage,
+                sourceId,
+                tenantId,
+                executionId,
+              }),
+            },
+            async () => cursorRepository.getBySource(sourceId),
+          );
+          logger.info('collector.cursor.loaded', {
             sourceId,
-            recordId,
-            cursorToken,
-          }),
-          scope: 'upsert',
-          status: 'PENDING',
-          sourceId,
-          recordId,
-          cursor: cursorToken,
-          correlationId,
-          createdAt: claimCreatedAt,
-          expiresAtEpochSeconds: claimExpiration,
-        });
+            tenantId,
+            hasPersistedCursor: cursorSnapshot !== null,
+            persistedCursor: cursorSnapshot?.last ?? null,
+          });
 
-        if (claimed) {
-          nonDuplicatedUpsertRecords.push(record);
-        } else {
-          duplicatedUpsertRecords.push(record);
-        }
-      }
-      if (duplicatedUpsertRecords.length > 0) {
-        logger.info('collector.idempotency.upsert_deduplicated', {
-          sourceId,
-          correlationId,
-          deduplicatedCount: duplicatedUpsertRecords.length,
-        });
-        logger.info('collector.idempotency.metric', {
-          _aws: {
-            Timestamp: nowMs(),
-            CloudWatchMetrics: [
-              {
-                Namespace: 'AlertOrchestrationService/Collector',
-                Dimensions: [['Stage', 'Scope']],
-                Metrics: [{ Name: 'DeduplicatedRecords', Unit: 'Count' }],
+          const loadedCredentials = await runInChildSpan(
+            {
+              spanName: 'collector.load_source_credentials',
+              attributes: buildTelemetryAttributes({
+                service,
+                stage,
+                sourceId,
+                tenantId,
+                executionId,
+              }),
+            },
+            async () =>
+              loadCollectorSourceCredentials({
+                sourceId,
+                engine: sourceConfiguration.engine,
+                secretArn: sourceConfiguration.secretArn,
+                secretRepository,
+                retryPolicy: secretRetryPolicy,
+                nowMs,
+                sleep,
+              }),
+          );
+
+          logger.info('collector.source_credentials.loaded', {
+            sourceId,
+            tenantId,
+            engine: sourceConfiguration.engine,
+            attempts: loadedCredentials.metrics.attempts,
+            durationMs: loadedCredentials.metrics.durationMs,
+          });
+
+          const cursor = resolveCursorValue(event?.cursor, cursorSnapshot?.last, defaultCursorValue);
+
+          let records: CollectorStandardizedRecord[];
+          switch (sourceConfiguration.engine) {
+            case 'postgres':
+              records = await runInChildSpan(
+                {
+                  spanName: 'collector.collect_postgres_records',
+                  attributes: buildTelemetryAttributes({
+                    service,
+                    stage,
+                    sourceId,
+                    tenantId,
+                    executionId,
+                  }),
+                },
+                async () =>
+                  collectPostgresRecords({
+                    sourceId,
+                    queryTemplate: sourceConfiguration.query,
+                    cursor,
+                    postgresQueryExecutor: postgresQueryExecutorFactory(loadedCredentials.credentials),
+                  }),
+              );
+              break;
+            case 'mysql':
+              records = await runInChildSpan(
+                {
+                  spanName: 'collector.collect_mysql_records',
+                  attributes: buildTelemetryAttributes({
+                    service,
+                    stage,
+                    sourceId,
+                    tenantId,
+                    executionId,
+                  }),
+                },
+                async () =>
+                  collectMySqlRecords({
+                    sourceId,
+                    queryTemplate: sourceConfiguration.query,
+                    cursor,
+                    mySqlQueryExecutor: mySqlQueryExecutorFactory(loadedCredentials.credentials),
+                  }),
+              );
+              break;
+            default:
+              throw new Error(
+                `Collector engine "${String(sourceConfiguration.engine)}" is not supported yet.`,
+              );
+          }
+
+          logger.info('collector.source_records.collected', {
+            sourceId,
+            tenantId,
+            engine: sourceConfiguration.engine,
+            cursor,
+            recordsCollected: records.length,
+          });
+
+          const requiredCanonicalFields = sourceConfiguration.fieldMap.id ? ['id'] : [];
+          const mappingResult = mapRecordsWithFieldMap({
+            sourceId,
+            records,
+            fieldMap: sourceConfiguration.fieldMap,
+            requiredCanonicalFields,
+          });
+
+          const ignoredSourceColumns = mappingResult.ignoredSourceColumns.filter(
+            (sourceColumn) => sourceColumn !== sourceConfiguration.cursorField,
+          );
+          if (ignoredSourceColumns.length > 0) {
+            logger.info('collector.field_map.ignored_source_columns', {
+              sourceId,
+              ignoredColumns: ignoredSourceColumns,
+              ignoredColumnsCount: ignoredSourceColumns.length,
+            });
+          }
+
+          const canonicalValidationResult = validateCanonicalCustomerBatch(mappingResult.records);
+          if (canonicalValidationResult.rejectedRecords.length > 0) {
+            logger.info('collector.canonical_validation.rejected_records', {
+              sourceId,
+              schemaVersion: canonicalValidationResult.schemaVersion,
+              rejectedRecordsCount: canonicalValidationResult.rejectedRecords.length,
+              rejectedIssues: canonicalValidationResult.rejectedRecords.map((rejectedRecord) => ({
+                index: rejectedRecord.index,
+                issues: rejectedRecord.issues,
+              })),
+            });
+          }
+
+          const correlationId =
+            executionId ?? `${sourceId}-${event?.meta?.stage ?? 'unknown'}-${sourceConfiguration.cursorField}`;
+
+          const cursorToken = normalizeCursorToken(cursor);
+          const claimCreatedAt = now();
+          const claimExpiration = Math.floor(nowMs() / 1000) + idempotencyTtlSeconds;
+
+          const nonDuplicatedUpsertRecords: CollectorStandardizedRecord[] = [];
+          const duplicatedUpsertRecords: CollectorStandardizedRecord[] = [];
+          for (const record of canonicalValidationResult.validRecords) {
+            const recordId = normalizeRecordId(record);
+            if (recordId.length === 0) {
+              duplicatedUpsertRecords.push(record);
+              continue;
+            }
+
+            const claimed = await idempotencyRepository.tryClaim({
+              deduplicationKey: buildDeduplicationKey({
+                scope: 'upsert',
+                sourceId,
+                recordId,
+                cursorToken,
+              }),
+              scope: 'upsert',
+              status: 'PENDING',
+              sourceId,
+              recordId,
+              cursor: cursorToken,
+              correlationId,
+              createdAt: claimCreatedAt,
+              expiresAtEpochSeconds: claimExpiration,
+            });
+
+            if (claimed) {
+              nonDuplicatedUpsertRecords.push(record);
+            } else {
+              duplicatedUpsertRecords.push(record);
+            }
+          }
+          if (duplicatedUpsertRecords.length > 0) {
+            logger.info('collector.idempotency.upsert_deduplicated', {
+              sourceId,
+              correlationId,
+              deduplicatedCount: duplicatedUpsertRecords.length,
+            });
+            logger.info('collector.idempotency.metric', {
+              _aws: {
+                Timestamp: nowMs(),
+                CloudWatchMetrics: [
+                  {
+                    Namespace: 'AlertOrchestrationService/Collector',
+                    Dimensions: [['Stage', 'Scope']],
+                    Metrics: [{ Name: 'DeduplicatedRecords', Unit: 'Count' }],
+                  },
+                ],
               },
-            ],
-          },
-          Stage: event?.meta?.stage ?? process.env.STAGE ?? 'unknown',
-          Scope: 'upsert',
-          DeduplicatedRecords: duplicatedUpsertRecords.length,
-        });
-      }
-      if (nonDuplicatedUpsertRecords.length > 0) {
-        logger.info('collector.idempotency.upsert_pending_claimed', {
-          sourceId,
-          correlationId,
-          pendingCount: nonDuplicatedUpsertRecords.length,
-        });
-      }
+              Stage: event?.meta?.stage ?? process.env.STAGE ?? 'unknown',
+              Scope: 'upsert',
+              DeduplicatedRecords: duplicatedUpsertRecords.length,
+            });
+          }
+          if (nonDuplicatedUpsertRecords.length > 0) {
+            logger.info('collector.idempotency.upsert_pending_claimed', {
+              sourceId,
+              correlationId,
+              pendingCount: nonDuplicatedUpsertRecords.length,
+            });
+          }
 
-      const upsertResult = await upsertCustomersBatchClient({
-        sourceId,
-        tenantId,
-        correlationId,
-        records: nonDuplicatedUpsertRecords,
-      });
-      if (upsertResult.rejectedRecords.length > 0) {
-        logger.info('collector.official_api.partial_rejection', {
-          sourceId,
-          correlationId,
-          rejectedRecordsCount: upsertResult.rejectedRecords.length,
-          attempts: upsertResult.attempts,
-        });
-      }
+          const upsertResult = await runInChildSpan(
+            {
+              spanName: 'collector.upsert_customers_batch',
+              attributes: buildTelemetryAttributes({
+                service,
+                stage,
+                sourceId,
+                tenantId,
+                executionId,
+              }),
+            },
+            async () =>
+              upsertCustomersBatchClient({
+                sourceId,
+                tenantId,
+                correlationId,
+                records: nonDuplicatedUpsertRecords,
+              }),
+          );
+          if (upsertResult.rejectedRecords.length > 0) {
+            logger.info('collector.official_api.partial_rejection', {
+              sourceId,
+              correlationId,
+              rejectedRecordsCount: upsertResult.rejectedRecords.length,
+              attempts: upsertResult.attempts,
+            });
+          }
 
-      const processedAt = now();
-      let completedUpsertClaims = 0;
-      for (const record of upsertResult.persistedRecords) {
-        const recordId = normalizeRecordId(record);
-        if (recordId.length === 0) {
-          continue;
-        }
+          const processedAt = now();
+          let completedUpsertClaims = 0;
+          for (const record of upsertResult.persistedRecords) {
+            const recordId = normalizeRecordId(record);
+            if (recordId.length === 0) {
+              continue;
+            }
 
-        await idempotencyRepository.markCompleted({
-          deduplicationKey: buildDeduplicationKey({
-            scope: 'upsert',
-            sourceId,
-            recordId,
-            cursorToken,
-          }),
-          completedAt: processedAt,
-          expiresAtEpochSeconds: claimExpiration,
-        });
-        completedUpsertClaims += 1;
-      }
-      if (completedUpsertClaims > 0) {
-        logger.info('collector.idempotency.upsert_completed', {
-          sourceId,
-          correlationId,
-          completedCount: completedUpsertClaims,
-        });
-      }
+            await idempotencyRepository.markCompleted({
+              deduplicationKey: buildDeduplicationKey({
+                scope: 'upsert',
+                sourceId,
+                recordId,
+                cursorToken,
+              }),
+              completedAt: processedAt,
+              expiresAtEpochSeconds: claimExpiration,
+            });
+            completedUpsertClaims += 1;
+          }
+          if (completedUpsertClaims > 0) {
+            logger.info('collector.idempotency.upsert_completed', {
+              sourceId,
+              correlationId,
+              completedCount: completedUpsertClaims,
+            });
+          }
 
-      const eventCandidatesByRecordId = new Map<string, CollectorStandardizedRecord>();
-      for (const record of upsertResult.persistedRecords) {
-        const recordId = normalizeRecordId(record);
-        if (recordId.length === 0) {
-          continue;
-        }
+          const eventCandidatesByRecordId = new Map<string, CollectorStandardizedRecord>();
+          for (const record of upsertResult.persistedRecords) {
+            const recordId = normalizeRecordId(record);
+            if (recordId.length === 0) {
+              continue;
+            }
 
-        eventCandidatesByRecordId.set(recordId, record);
-      }
-      for (const record of duplicatedUpsertRecords) {
-        const recordId = normalizeRecordId(record);
-        if (recordId.length === 0) {
-          continue;
-        }
+            eventCandidatesByRecordId.set(recordId, record);
+          }
+          for (const record of duplicatedUpsertRecords) {
+            const recordId = normalizeRecordId(record);
+            if (recordId.length === 0) {
+              continue;
+            }
 
-        eventCandidatesByRecordId.set(recordId, record);
-      }
-      const eventCandidateRecords = Array.from(eventCandidatesByRecordId.values());
+            eventCandidatesByRecordId.set(recordId, record);
+          }
+          const eventCandidateRecords = Array.from(eventCandidatesByRecordId.values());
 
-      const nonDuplicatedEventRecords: CollectorStandardizedRecord[] = [];
-      const duplicatedEventRecords: CollectorStandardizedRecord[] = [];
-      for (const record of eventCandidateRecords) {
-        const recordId = normalizeRecordId(record);
-        if (recordId.length === 0) {
-          duplicatedEventRecords.push(record);
-          continue;
-        }
+          const nonDuplicatedEventRecords: CollectorStandardizedRecord[] = [];
+          const duplicatedEventRecords: CollectorStandardizedRecord[] = [];
+          for (const record of eventCandidateRecords) {
+            const recordId = normalizeRecordId(record);
+            if (recordId.length === 0) {
+              duplicatedEventRecords.push(record);
+              continue;
+            }
 
-        const claimed = await idempotencyRepository.tryClaim({
-          deduplicationKey: buildDeduplicationKey({
-            scope: 'event',
-            sourceId,
-            recordId,
-            cursorToken,
-          }),
-          scope: 'event',
-          status: 'PENDING',
-          sourceId,
-          recordId,
-          cursor: cursorToken,
-          correlationId,
-          createdAt: claimCreatedAt,
-          expiresAtEpochSeconds: claimExpiration,
-        });
+            const claimed = await idempotencyRepository.tryClaim({
+              deduplicationKey: buildDeduplicationKey({
+                scope: 'event',
+                sourceId,
+                recordId,
+                cursorToken,
+              }),
+              scope: 'event',
+              status: 'PENDING',
+              sourceId,
+              recordId,
+              cursor: cursorToken,
+              correlationId,
+              createdAt: claimCreatedAt,
+              expiresAtEpochSeconds: claimExpiration,
+            });
 
-        if (claimed) {
-          nonDuplicatedEventRecords.push(record);
-        } else {
-          duplicatedEventRecords.push(record);
-        }
-      }
-      if (duplicatedEventRecords.length > 0) {
-        logger.info('collector.idempotency.event_deduplicated', {
-          sourceId,
-          correlationId,
-          deduplicatedCount: duplicatedEventRecords.length,
-        });
-        logger.info('collector.idempotency.metric', {
-          _aws: {
-            Timestamp: nowMs(),
-            CloudWatchMetrics: [
-              {
-                Namespace: 'AlertOrchestrationService/Collector',
-                Dimensions: [['Stage', 'Scope']],
-                Metrics: [{ Name: 'DeduplicatedRecords', Unit: 'Count' }],
+            if (claimed) {
+              nonDuplicatedEventRecords.push(record);
+            } else {
+              duplicatedEventRecords.push(record);
+            }
+          }
+          if (duplicatedEventRecords.length > 0) {
+            logger.info('collector.idempotency.event_deduplicated', {
+              sourceId,
+              correlationId,
+              deduplicatedCount: duplicatedEventRecords.length,
+            });
+            logger.info('collector.idempotency.metric', {
+              _aws: {
+                Timestamp: nowMs(),
+                CloudWatchMetrics: [
+                  {
+                    Namespace: 'AlertOrchestrationService/Collector',
+                    Dimensions: [['Stage', 'Scope']],
+                    Metrics: [{ Name: 'DeduplicatedRecords', Unit: 'Count' }],
+                  },
+                ],
               },
-            ],
-          },
-          Stage: event?.meta?.stage ?? process.env.STAGE ?? 'unknown',
-          Scope: 'event',
-          DeduplicatedRecords: duplicatedEventRecords.length,
-        });
-      }
+              Stage: event?.meta?.stage ?? process.env.STAGE ?? 'unknown',
+              Scope: 'event',
+              DeduplicatedRecords: duplicatedEventRecords.length,
+            });
+          }
 
-      if (nonDuplicatedEventRecords.length > 0) {
-        logger.info('collector.idempotency.event_pending_claimed', {
-          sourceId,
-          correlationId,
-          pendingCount: nonDuplicatedEventRecords.length,
-        });
-      }
+          if (nonDuplicatedEventRecords.length > 0) {
+            logger.info('collector.idempotency.event_pending_claimed', {
+              sourceId,
+              correlationId,
+              pendingCount: nonDuplicatedEventRecords.length,
+            });
+          }
 
-      let publishedEventsCount = 0;
-      let completedEventClaims = 0;
-      for (const record of nonDuplicatedEventRecords) {
-        await customerEventsPublisher({
-          sourceId,
-          tenantId,
-          correlationId,
-          records: [record],
-          publishedAt: processedAt,
-        });
+          let publishedEventsCount = 0;
+          let completedEventClaims = 0;
+          await runInChildSpan(
+            {
+              spanName: 'collector.publish_customer_events',
+              attributes: buildTelemetryAttributes({
+                service,
+                stage,
+                sourceId,
+                tenantId,
+                executionId,
+              }),
+            },
+            async () => {
+              for (const record of nonDuplicatedEventRecords) {
+                await customerEventsPublisher({
+                  sourceId,
+                  tenantId,
+                  correlationId,
+                  records: [record],
+                  publishedAt: processedAt,
+                });
 
-        publishedEventsCount += 1;
-        const recordId = normalizeRecordId(record);
-        if (recordId.length === 0) {
-          continue;
-        }
+                publishedEventsCount += 1;
+                const recordId = normalizeRecordId(record);
+                if (recordId.length === 0) {
+                  continue;
+                }
 
-        await idempotencyRepository.markCompleted({
-          deduplicationKey: buildDeduplicationKey({
-            scope: 'event',
+                await idempotencyRepository.markCompleted({
+                  deduplicationKey: buildDeduplicationKey({
+                    scope: 'event',
+                    sourceId,
+                    recordId,
+                    cursorToken,
+                  }),
+                  completedAt: processedAt,
+                  expiresAtEpochSeconds: claimExpiration,
+                });
+                completedEventClaims += 1;
+              }
+            },
+          );
+          if (publishedEventsCount > 0) {
+            logger.info('collector.sns.events_published', {
+              sourceId,
+              correlationId,
+              publishedCount: publishedEventsCount,
+            });
+          }
+          if (completedEventClaims > 0) {
+            logger.info('collector.idempotency.event_completed', {
+              sourceId,
+              correlationId,
+              completedCount: completedEventClaims,
+            });
+          }
+
+          const candidateCursor = resolveLatestCursorFromRecords({
+            records,
+            cursorField: sourceConfiguration.cursorField,
+          });
+
+          if (candidateCursor === null) {
+            logger.info('collector.cursor.update_skipped', {
+              sourceId,
+              reason: 'no-cursor-value-found',
+              cursorField: sourceConfiguration.cursorField,
+              recordsCollected: records.length,
+            });
+          } else {
+            await runInChildSpan(
+              {
+                spanName: 'collector.persist_cursor',
+                attributes: buildTelemetryAttributes({
+                  service,
+                  stage,
+                  sourceId,
+                  tenantId,
+                  executionId,
+                }),
+              },
+              async () =>
+                persistCollectorCursor({
+                  sourceId,
+                  candidateCursor,
+                  initialSnapshot: cursorSnapshot,
+                  cursorRepository,
+                  updatedAt: processedAt,
+                  logger,
+                }),
+            );
+          }
+
+          const result: CollectorResult = {
             sourceId,
-            recordId,
-            cursorToken,
-          }),
-          completedAt: processedAt,
-          expiresAtEpochSeconds: claimExpiration,
-        });
-        completedEventClaims += 1;
-      }
-      if (publishedEventsCount > 0) {
-        logger.info('collector.sns.events_published', {
-          sourceId,
-          correlationId,
-          publishedCount: publishedEventsCount,
-        });
-      }
-      if (completedEventClaims > 0) {
-        logger.info('collector.idempotency.event_completed', {
-          sourceId,
-          correlationId,
-          completedCount: completedEventClaims,
-        });
-      }
+            tenantId,
+            processedAt,
+            recordsSent: upsertResult.persistedRecords.length,
+            records: upsertResult.persistedRecords,
+            schemaVersion: canonicalValidationResult.schemaVersion,
+            rejectedRecords: canonicalValidationResult.rejectedRecords,
+            persistenceRejectedRecords: upsertResult.rejectedRecords,
+            upsertAttempts: upsertResult.attempts,
+            eventsPublished: publishedEventsCount,
+            deduplicatedUpsertRecords: duplicatedUpsertRecords.length,
+            deduplicatedEventRecords: duplicatedEventRecords.length,
+          };
 
-      const candidateCursor = resolveLatestCursorFromRecords({
-        records,
-        cursorField: sourceConfiguration.cursorField,
-      });
+          await runInChildSpan(
+            {
+              spanName: 'collector.publish_metrics',
+              attributes: buildTelemetryAttributes({
+                service,
+                stage,
+                sourceId,
+                tenantId,
+                executionId,
+              }),
+            },
+            async () =>
+              metricsPublisher.publish([
+                {
+                  name: 'CollectorRecordsCollected',
+                  value: records.length,
+                  unit: 'Count',
+                  dimensions: {
+                    SourceId: sourceId,
+                    TenantId: tenantId,
+                  },
+                },
+                {
+                  name: 'CollectorRecordsPersisted',
+                  value: result.recordsSent,
+                  unit: 'Count',
+                  dimensions: {
+                    SourceId: sourceId,
+                    TenantId: tenantId,
+                  },
+                },
+                {
+                  name: 'CollectorRecordsRejected',
+                  value: result.rejectedRecords.length + result.persistenceRejectedRecords.length,
+                  unit: 'Count',
+                  dimensions: {
+                    SourceId: sourceId,
+                    TenantId: tenantId,
+                  },
+                },
+              ]),
+          );
 
-      if (candidateCursor === null) {
-        logger.info('collector.cursor.update_skipped', {
-          sourceId,
-          reason: 'no-cursor-value-found',
-          cursorField: sourceConfiguration.cursorField,
-          recordsCollected: records.length,
-        });
-      } else {
-        await persistCollectorCursor({
-          sourceId,
-          candidateCursor,
-          initialSnapshot: cursorSnapshot,
-          cursorRepository,
-          updatedAt: processedAt,
-          logger,
-        });
-      }
-
-      const result: CollectorResult = {
-        sourceId,
-        tenantId,
-        processedAt,
-        recordsSent: upsertResult.persistedRecords.length,
-        records: upsertResult.persistedRecords,
-        schemaVersion: canonicalValidationResult.schemaVersion,
-        rejectedRecords: canonicalValidationResult.rejectedRecords,
-        persistenceRejectedRecords: upsertResult.rejectedRecords,
-        upsertAttempts: upsertResult.attempts,
-        eventsPublished: publishedEventsCount,
-        deduplicatedUpsertRecords: duplicatedUpsertRecords.length,
-        deduplicatedEventRecords: duplicatedEventRecords.length,
-      };
-
-      await metricsPublisher.publish([
-        {
-          name: 'CollectorRecordsCollected',
-          value: records.length,
-          unit: 'Count',
-          dimensions: {
-            SourceId: sourceId,
-            TenantId: tenantId,
-          },
-        },
-        {
-          name: 'CollectorRecordsPersisted',
-          value: result.recordsSent,
-          unit: 'Count',
-          dimensions: {
-            SourceId: sourceId,
-            TenantId: tenantId,
-          },
-        },
-        {
-          name: 'CollectorRecordsRejected',
-          value: result.rejectedRecords.length + result.persistenceRejectedRecords.length,
-          unit: 'Count',
-          dimensions: {
-            SourceId: sourceId,
-            TenantId: tenantId,
-          },
-        },
-      ]);
-
-      executionStatus = 'SUCCEEDED';
-      return result;
-    } finally {
-      await metricsPublisher.publish([
-        {
-          name: executionStatus === 'SUCCEEDED' ? 'CollectorExecutionSuccess' : 'CollectorExecutionFailure',
-          value: 1,
-          unit: 'Count',
-          dimensions: {
-            SourceId: sourceId,
-            TenantId: resolvedTenantId,
-          },
-        },
-        {
-          name: 'CollectorExecutionLatencyMs',
-          value: nowMs() - executionStartedAtMs,
-          unit: 'Milliseconds',
-          dimensions: {
-            SourceId: sourceId,
-            TenantId: resolvedTenantId,
-          },
-        },
-      ]);
-    }
+          executionStatus = 'SUCCEEDED';
+          return result;
+        } finally {
+          await runInChildSpan(
+            {
+              spanName: 'collector.publish_execution_metrics',
+              attributes: buildTelemetryAttributes({
+                service,
+                stage,
+                sourceId,
+                tenantId: resolvedTenantId,
+                executionId,
+              }),
+            },
+            async () =>
+              metricsPublisher.publish([
+                {
+                  name: executionStatus === 'SUCCEEDED'
+                    ? 'CollectorExecutionSuccess'
+                    : 'CollectorExecutionFailure',
+                  value: 1,
+                  unit: 'Count',
+                  dimensions: {
+                    SourceId: sourceId,
+                    TenantId: resolvedTenantId,
+                  },
+                },
+                {
+                  name: 'CollectorExecutionLatencyMs',
+                  value: nowMs() - executionStartedAtMs,
+                  unit: 'Milliseconds',
+                  dimensions: {
+                    SourceId: sourceId,
+                    TenantId: resolvedTenantId,
+                  },
+                },
+              ]),
+          );
+        }
+      },
+    });
   };
 
 export async function handler(event: CollectorEvent): Promise<CollectorResult> {

--- a/src/handlers/create-source.ts
+++ b/src/handlers/create-source.ts
@@ -13,6 +13,11 @@ import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamod
 import { resolveTenantIdFromJwtClaims } from '../shared/auth/tenant-context';
 import { resolveCorrelationId } from '../shared/logging/correlation-id';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
+import {
+  buildTelemetryAttributes,
+  toTelemetryLogContext,
+  withTelemetrySpan,
+} from '../shared/observability/open-telemetry';
 import { nowIso } from '../shared/time/now-iso';
 
 const JSON_HEADERS = {
@@ -109,144 +114,170 @@ export const createHandler =
       headers: event.headers,
       requestId: event.requestContext?.requestId,
     });
-    logger.info('api.sources.create.received', {
-      correlationId,
-    });
-
-    const parsedBody = parseBody(event.body);
-    if (!parsedBody.success) {
-      logger.info('api.sources.create.rejected', {
-        correlationId,
-        statusCode: parsedBody.response.statusCode,
-        reason: 'invalid_body',
-      });
-      return parsedBody.response;
-    }
-
-    const tenantId = resolveTenantIdFromJwtClaims(event);
-    if (!tenantId) {
-      logger.info('api.sources.create.rejected', {
-        correlationId,
-        statusCode: 401,
-        reason: 'tenant_context_missing',
-      });
-      return response(401, {
-        message: 'Missing tenant context in JWT claims.',
-        code: 'TENANT_CONTEXT_MISSING',
-      });
-    }
-
-    if (
-      isRecord(parsedBody.value) &&
-      typeof parsedBody.value.tenantId === 'string' &&
-      parsedBody.value.tenantId.trim().length > 0 &&
-      parsedBody.value.tenantId.trim() !== tenantId
-    ) {
-      logger.info('api.sources.create.rejected', {
-        correlationId,
-        statusCode: 403,
-        reason: 'tenant_mismatch',
-      });
-      return response(403, {
-        message: 'Payload tenantId does not match authenticated tenant.',
-        code: 'TENANT_CONTEXT_MISMATCH',
-      });
-    }
-
-    const payloadForValidation = isRecord(parsedBody.value)
-      ? {
-          ...parsedBody.value,
-          tenantId,
-        }
-      : parsedBody.value;
-    const validation = validateSourceCreatePayload(payloadForValidation);
-    if (!validation.success) {
-      logger.info('api.sources.create.rejected', {
-        correlationId,
-        statusCode: 400,
-        reason: 'validation_error',
-      });
-      return response(400, {
-        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
-        errors: validation.errors,
-      });
-    }
-
-    const createdAt = now();
-    const nextRunAt =
-      validation.value.scheduleType === 'interval'
-        ? calculateNextRunAt(
-            {
-              scheduleType: 'interval',
-              intervalMinutes: validation.value.intervalMinutes,
-            },
-            createdAt,
-          )
-        : calculateNextRunAt(
-            {
-              scheduleType: 'cron',
-              cronExpr: validation.value.cronExpr,
-            },
-            createdAt,
-          );
-    if (!nextRunAt.success) {
-      logger.info('api.sources.create.rejected', {
-        correlationId,
-        statusCode: 400,
-        reason: 'invalid_schedule',
-      });
-      return response(400, {
-        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
-        errors: nextRunAt.errors,
-      });
-    }
-
-    const record: SourceRegistryRecord = {
-      ...validation.value,
-      nextRunAt: nextRunAt.value,
-      schemaVersion: SOURCE_SCHEMA_VERSION,
-      createdAt,
-      updatedAt: createdAt,
-    };
-
-    try {
-      await sourceRegistryRepository.create(record);
-      logger.info('api.sources.create.succeeded', {
-        correlationId,
-        statusCode: 201,
-        sourceId: record.sourceId,
-      });
-      return response(201, {
-        sourceId: record.sourceId,
-        metadata: {
-          schemaVersion: record.schemaVersion,
-          createdAt: record.createdAt,
-          updatedAt: record.updatedAt,
-          requestId: event.requestContext?.requestId ?? null,
-        },
-      });
-    } catch (error) {
-      if (error instanceof SourceAlreadyExistsError) {
-        logger.info('api.sources.create.conflict', {
+    return withTelemetrySpan({
+      component: 'api.sources.create',
+      spanName: 'api.sources.create',
+      attributes: buildTelemetryAttributes({
+        executionId: correlationId ?? undefined,
+      }),
+      run: async ({ span, traceContext, runInChildSpan }) => {
+        logger.info('api.sources.create.received', {
           correlationId,
-          statusCode: 409,
-          sourceId: record.sourceId,
         });
-        return response(409, {
-          message: error.message,
-          code: 'SOURCE_ALREADY_EXISTS',
+        logger.info('api.sources.create.trace_context', {
+          correlationId,
+          ...toTelemetryLogContext(traceContext),
         });
-      }
 
-      logger.info('api.sources.create.failed', {
-        correlationId,
-        statusCode: 500,
-        sourceId: record.sourceId,
-      });
-      return response(500, {
-        message: 'Failed to create source.',
-      });
-    }
+        const parsedBody = parseBody(event.body);
+        if (!parsedBody.success) {
+          logger.info('api.sources.create.rejected', {
+            correlationId,
+            statusCode: parsedBody.response.statusCode,
+            reason: 'invalid_body',
+          });
+          return parsedBody.response;
+        }
+
+        const tenantId = resolveTenantIdFromJwtClaims(event);
+        if (!tenantId) {
+          logger.info('api.sources.create.rejected', {
+            correlationId,
+            statusCode: 401,
+            reason: 'tenant_context_missing',
+          });
+          return response(401, {
+            message: 'Missing tenant context in JWT claims.',
+            code: 'TENANT_CONTEXT_MISSING',
+          });
+        }
+
+        span.setAttribute('tenantId', tenantId);
+
+        if (
+          isRecord(parsedBody.value) &&
+          typeof parsedBody.value.tenantId === 'string' &&
+          parsedBody.value.tenantId.trim().length > 0 &&
+          parsedBody.value.tenantId.trim() !== tenantId
+        ) {
+          logger.info('api.sources.create.rejected', {
+            correlationId,
+            statusCode: 403,
+            reason: 'tenant_mismatch',
+          });
+          return response(403, {
+            message: 'Payload tenantId does not match authenticated tenant.',
+            code: 'TENANT_CONTEXT_MISMATCH',
+          });
+        }
+
+        const payloadForValidation = isRecord(parsedBody.value)
+          ? {
+              ...parsedBody.value,
+              tenantId,
+            }
+          : parsedBody.value;
+        const validation = validateSourceCreatePayload(payloadForValidation);
+        if (!validation.success) {
+          logger.info('api.sources.create.rejected', {
+            correlationId,
+            statusCode: 400,
+            reason: 'validation_error',
+          });
+          return response(400, {
+            message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+            errors: validation.errors,
+          });
+        }
+
+        const createdAt = now();
+        const nextRunAt =
+          validation.value.scheduleType === 'interval'
+            ? calculateNextRunAt(
+                {
+                  scheduleType: 'interval',
+                  intervalMinutes: validation.value.intervalMinutes,
+                },
+                createdAt,
+              )
+            : calculateNextRunAt(
+                {
+                  scheduleType: 'cron',
+                  cronExpr: validation.value.cronExpr,
+                },
+                createdAt,
+              );
+        if (!nextRunAt.success) {
+          logger.info('api.sources.create.rejected', {
+            correlationId,
+            statusCode: 400,
+            reason: 'invalid_schedule',
+          });
+          return response(400, {
+            message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+            errors: nextRunAt.errors,
+          });
+        }
+
+        const record: SourceRegistryRecord = {
+          ...validation.value,
+          nextRunAt: nextRunAt.value,
+          schemaVersion: SOURCE_SCHEMA_VERSION,
+          createdAt,
+          updatedAt: createdAt,
+        };
+        span.setAttribute('sourceId', record.sourceId);
+
+        try {
+          await runInChildSpan(
+            {
+              spanName: 'api.sources.create.repository.create',
+              attributes: buildTelemetryAttributes({
+                sourceId: record.sourceId,
+                tenantId,
+                executionId: correlationId ?? undefined,
+              }),
+            },
+            async () => sourceRegistryRepository.create(record),
+          );
+          logger.info('api.sources.create.succeeded', {
+            correlationId,
+            statusCode: 201,
+            sourceId: record.sourceId,
+          });
+          return response(201, {
+            sourceId: record.sourceId,
+            metadata: {
+              schemaVersion: record.schemaVersion,
+              createdAt: record.createdAt,
+              updatedAt: record.updatedAt,
+              requestId: event.requestContext?.requestId ?? null,
+            },
+          });
+        } catch (error) {
+          if (error instanceof SourceAlreadyExistsError) {
+            logger.info('api.sources.create.conflict', {
+              correlationId,
+              statusCode: 409,
+              sourceId: record.sourceId,
+            });
+            return response(409, {
+              message: error.message,
+              code: 'SOURCE_ALREADY_EXISTS',
+            });
+          }
+
+          logger.info('api.sources.create.failed', {
+            correlationId,
+            statusCode: 500,
+            sourceId: record.sourceId,
+          });
+          return response(500, {
+            message: 'Failed to create source.',
+          });
+        }
+      },
+    });
   };
 
 export async function handler(event: CreateSourceEvent): Promise<CreateSourceResponse> {

--- a/src/handlers/delete-source.ts
+++ b/src/handlers/delete-source.ts
@@ -7,6 +7,11 @@ import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamod
 import { resolveTenantIdFromJwtClaims } from '../shared/auth/tenant-context';
 import { resolveCorrelationId } from '../shared/logging/correlation-id';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
+import {
+  buildTelemetryAttributes,
+  toTelemetryLogContext,
+  withTelemetrySpan,
+} from '../shared/observability/open-telemetry';
 import { nowIso } from '../shared/time/now-iso';
 
 const JSON_HEADERS = {
@@ -108,74 +113,59 @@ export const createHandler =
       headers: event.headers,
       requestId: event.requestContext?.requestId,
     });
-    logger.info('api.sources.delete.received', {
-      correlationId,
-    });
+    return withTelemetrySpan({
+      component: 'api.sources.delete',
+      spanName: 'api.sources.delete',
+      attributes: buildTelemetryAttributes({
+        executionId: correlationId ?? undefined,
+      }),
+      run: async ({ span, traceContext, runInChildSpan }) => {
+        logger.info('api.sources.delete.received', {
+          correlationId,
+        });
+        logger.info('api.sources.delete.trace_context', {
+          correlationId,
+          ...toTelemetryLogContext(traceContext),
+        });
 
-    const sourceId = parseSourceId(event.pathParameters?.id);
-    if (!sourceId.success) {
-      logger.info('api.sources.delete.rejected', {
-        correlationId,
-        statusCode: sourceId.response.statusCode,
-        reason: 'missing_source_id',
-      });
-      return sourceId.response;
-    }
+        const sourceId = parseSourceId(event.pathParameters?.id);
+        if (!sourceId.success) {
+          logger.info('api.sources.delete.rejected', {
+            correlationId,
+            statusCode: sourceId.response.statusCode,
+            reason: 'missing_source_id',
+          });
+          return sourceId.response;
+        }
+        span.setAttribute('sourceId', sourceId.value);
 
-    const tenantId = resolveTenantIdFromJwtClaims(event);
-    if (!tenantId) {
-      logger.info('api.sources.delete.rejected', {
-        correlationId,
-        statusCode: 401,
-        sourceId: sourceId.value,
-        reason: 'tenant_context_missing',
-      });
-      return response(401, {
-        message: 'Missing tenant context in JWT claims.',
-        code: 'TENANT_CONTEXT_MISSING',
-      });
-    }
+        const tenantId = resolveTenantIdFromJwtClaims(event);
+        if (!tenantId) {
+          logger.info('api.sources.delete.rejected', {
+            correlationId,
+            statusCode: 401,
+            sourceId: sourceId.value,
+            reason: 'tenant_context_missing',
+          });
+          return response(401, {
+            message: 'Missing tenant context in JWT claims.',
+            code: 'TENANT_CONTEXT_MISSING',
+          });
+        }
+        span.setAttribute('tenantId', tenantId);
 
-    const current = await sourceRegistryRepository.getById(sourceId.value);
-    if (!current || current.tenantId !== tenantId) {
-      logger.info('api.sources.delete.not_found', {
-        correlationId,
-        statusCode: 404,
-        sourceId: sourceId.value,
-        tenantId,
-      });
-      return response(404, {
-        message: `Source "${sourceId.value}" was not found.`,
-        code: 'SOURCE_NOT_FOUND',
-      });
-    }
-
-    if (!current.active) {
-      logger.info('api.sources.delete.noop', {
-        correlationId,
-        statusCode: 204,
-        sourceId: sourceId.value,
-      });
-      return noContent();
-    }
-
-    try {
-      const deactivatedSource = deactivateSourceRecord(current, now());
-      await sourceRegistryRepository.update({
-        sourceId: current.sourceId,
-        source: deactivatedSource,
-        expectedUpdatedAt: current.updatedAt,
-      });
-      logger.info('api.sources.delete.succeeded', {
-        correlationId,
-        statusCode: 204,
-        sourceId: current.sourceId,
-      });
-      return noContent();
-    } catch (error) {
-      if (error instanceof SourceVersionConflictError) {
-        const latest = await sourceRegistryRepository.getById(sourceId.value);
-        if (!latest || latest.tenantId !== tenantId) {
+        const current = await runInChildSpan(
+          {
+            spanName: 'api.sources.delete.repository.get',
+            attributes: buildTelemetryAttributes({
+              sourceId: sourceId.value,
+              tenantId,
+              executionId: correlationId ?? undefined,
+            }),
+          },
+          async () => sourceRegistryRepository.getById(sourceId.value),
+        );
+        if (!current || current.tenantId !== tenantId) {
           logger.info('api.sources.delete.not_found', {
             correlationId,
             statusCode: 404,
@@ -188,7 +178,7 @@ export const createHandler =
           });
         }
 
-        if (!latest.active) {
+        if (!current.active) {
           logger.info('api.sources.delete.noop', {
             correlationId,
             statusCode: 204,
@@ -197,26 +187,87 @@ export const createHandler =
           return noContent();
         }
 
-        logger.info('api.sources.delete.conflict', {
-          correlationId,
-          statusCode: 409,
-          sourceId: sourceId.value,
-        });
-        return response(409, {
-          message: error.message,
-          code: 'SOURCE_VERSION_CONFLICT',
-        });
-      }
+        try {
+          const deactivatedSource = deactivateSourceRecord(current, now());
+          await runInChildSpan(
+            {
+              spanName: 'api.sources.delete.repository.update',
+              attributes: buildTelemetryAttributes({
+                sourceId: current.sourceId,
+                tenantId,
+                executionId: correlationId ?? undefined,
+              }),
+            },
+            async () =>
+              sourceRegistryRepository.update({
+                sourceId: current.sourceId,
+                source: deactivatedSource,
+                expectedUpdatedAt: current.updatedAt,
+              }),
+          );
+          logger.info('api.sources.delete.succeeded', {
+            correlationId,
+            statusCode: 204,
+            sourceId: current.sourceId,
+          });
+          return noContent();
+        } catch (error) {
+          if (error instanceof SourceVersionConflictError) {
+            const latest = await runInChildSpan(
+              {
+                spanName: 'api.sources.delete.repository.get_after_conflict',
+                attributes: buildTelemetryAttributes({
+                  sourceId: sourceId.value,
+                  tenantId,
+                  executionId: correlationId ?? undefined,
+                }),
+              },
+              async () => sourceRegistryRepository.getById(sourceId.value),
+            );
+            if (!latest || latest.tenantId !== tenantId) {
+              logger.info('api.sources.delete.not_found', {
+                correlationId,
+                statusCode: 404,
+                sourceId: sourceId.value,
+                tenantId,
+              });
+              return response(404, {
+                message: `Source "${sourceId.value}" was not found.`,
+                code: 'SOURCE_NOT_FOUND',
+              });
+            }
 
-      logger.info('api.sources.delete.failed', {
-        correlationId,
-        statusCode: 500,
-        sourceId: sourceId.value,
-      });
-      return response(500, {
-        message: 'Failed to delete source.',
-      });
-    }
+            if (!latest.active) {
+              logger.info('api.sources.delete.noop', {
+                correlationId,
+                statusCode: 204,
+                sourceId: sourceId.value,
+              });
+              return noContent();
+            }
+
+            logger.info('api.sources.delete.conflict', {
+              correlationId,
+              statusCode: 409,
+              sourceId: sourceId.value,
+            });
+            return response(409, {
+              message: error.message,
+              code: 'SOURCE_VERSION_CONFLICT',
+            });
+          }
+
+          logger.info('api.sources.delete.failed', {
+            correlationId,
+            statusCode: 500,
+            sourceId: sourceId.value,
+          });
+          return response(500, {
+            message: 'Failed to delete source.',
+          });
+        }
+      },
+    });
   };
 
 export async function handler(event: DeleteSourceEvent): Promise<DeleteSourceResponse> {

--- a/src/handlers/list-sources.ts
+++ b/src/handlers/list-sources.ts
@@ -8,6 +8,11 @@ import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamod
 import { resolveTenantIdFromJwtClaims } from '../shared/auth/tenant-context';
 import { resolveCorrelationId } from '../shared/logging/correlation-id';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
+import {
+  buildTelemetryAttributes,
+  toTelemetryLogContext,
+  withTelemetrySpan,
+} from '../shared/observability/open-telemetry';
 
 const JSON_HEADERS = {
   'content-type': 'application/json',
@@ -212,114 +217,137 @@ export const createHandler =
       headers: event.headers,
       requestId: event.requestContext?.requestId,
     });
-    logger.info('api.sources.list.received', {
-      correlationId,
-    });
-
-    const tenantId = resolveTenantIdFromJwtClaims(event);
-    if (!tenantId) {
-      logger.info('api.sources.list.rejected', {
-        correlationId,
-        statusCode: 401,
-        reason: 'tenant_context_missing',
-      });
-      return response(401, {
-        message: 'Missing tenant context in JWT claims.',
-        code: 'TENANT_CONTEXT_MISSING',
-      });
-    }
-
-    const query = event.queryStringParameters ?? {};
-
-    const limit = parseLimit(query.limit);
-    if (!limit.success) {
-      logger.info('api.sources.list.rejected', {
-        correlationId,
-        statusCode: limit.response.statusCode,
-        reason: 'invalid_limit',
-      });
-      return limit.response;
-    }
-
-    const nextToken = parseNextToken(query.nextToken);
-    if (!nextToken.success) {
-      logger.info('api.sources.list.rejected', {
-        correlationId,
-        statusCode: nextToken.response.statusCode,
-        reason: 'invalid_next_token',
-      });
-      return nextToken.response;
-    }
-
-    const active = parseActive(query.active);
-    if (!active.success) {
-      logger.info('api.sources.list.rejected', {
-        correlationId,
-        statusCode: active.response.statusCode,
-        reason: 'invalid_active',
-      });
-      return active.response;
-    }
-
-    const engine = parseEngine(query.engine);
-    if (!engine.success) {
-      logger.info('api.sources.list.rejected', {
-        correlationId,
-        statusCode: engine.response.statusCode,
-        reason: 'invalid_engine',
-      });
-      return engine.response;
-    }
-
-    const params: ListSourceRegistryParams = {
-      tenantId,
-      limit: limit.value,
-      nextToken: nextToken.value,
-      active: active.value,
-      engine: engine.value,
-    };
-
-    try {
-      const result = await sourceRegistryRepository.list(params);
-      logger.info('api.sources.list.succeeded', {
-        correlationId,
-        statusCode: 200,
-        returnedItems: result.items.length,
-      });
-      return response(200, {
-        items: result.items,
-        filters: {
-          tenantId,
-          active: active.value ?? null,
-          engine: engine.value ?? null,
-        },
-        pagination: {
-          limit: limit.value,
-          nextToken: result.nextToken,
-        },
-        requestId: event.requestContext?.requestId ?? null,
-      });
-    } catch (error) {
-      if (error instanceof SourcePaginationTokenError) {
-        logger.info('api.sources.list.rejected', {
+    return withTelemetrySpan({
+      component: 'api.sources.list',
+      spanName: 'api.sources.list',
+      attributes: buildTelemetryAttributes({
+        executionId: correlationId ?? undefined,
+      }),
+      run: async ({ span, traceContext, runInChildSpan }) => {
+        logger.info('api.sources.list.received', {
           correlationId,
-          statusCode: 400,
-          reason: 'invalid_pagination_token',
         });
-        return response(400, {
-          message: error.message,
-          code: 'INVALID_PAGINATION_TOKEN',
+        logger.info('api.sources.list.trace_context', {
+          correlationId,
+          ...toTelemetryLogContext(traceContext),
         });
-      }
 
-      logger.info('api.sources.list.failed', {
-        correlationId,
-        statusCode: 500,
-      });
-      return response(500, {
-        message: 'Failed to list sources.',
-      });
-    }
+        const tenantId = resolveTenantIdFromJwtClaims(event);
+        if (!tenantId) {
+          logger.info('api.sources.list.rejected', {
+            correlationId,
+            statusCode: 401,
+            reason: 'tenant_context_missing',
+          });
+          return response(401, {
+            message: 'Missing tenant context in JWT claims.',
+            code: 'TENANT_CONTEXT_MISSING',
+          });
+        }
+        span.setAttribute('tenantId', tenantId);
+
+        const query = event.queryStringParameters ?? {};
+
+        const limit = parseLimit(query.limit);
+        if (!limit.success) {
+          logger.info('api.sources.list.rejected', {
+            correlationId,
+            statusCode: limit.response.statusCode,
+            reason: 'invalid_limit',
+          });
+          return limit.response;
+        }
+
+        const nextToken = parseNextToken(query.nextToken);
+        if (!nextToken.success) {
+          logger.info('api.sources.list.rejected', {
+            correlationId,
+            statusCode: nextToken.response.statusCode,
+            reason: 'invalid_next_token',
+          });
+          return nextToken.response;
+        }
+
+        const active = parseActive(query.active);
+        if (!active.success) {
+          logger.info('api.sources.list.rejected', {
+            correlationId,
+            statusCode: active.response.statusCode,
+            reason: 'invalid_active',
+          });
+          return active.response;
+        }
+
+        const engine = parseEngine(query.engine);
+        if (!engine.success) {
+          logger.info('api.sources.list.rejected', {
+            correlationId,
+            statusCode: engine.response.statusCode,
+            reason: 'invalid_engine',
+          });
+          return engine.response;
+        }
+
+        const params: ListSourceRegistryParams = {
+          tenantId,
+          limit: limit.value,
+          nextToken: nextToken.value,
+          active: active.value,
+          engine: engine.value,
+        };
+
+        try {
+          const result = await runInChildSpan(
+            {
+              spanName: 'api.sources.list.repository.list',
+              attributes: buildTelemetryAttributes({
+                tenantId,
+                executionId: correlationId ?? undefined,
+              }),
+            },
+            async () => sourceRegistryRepository.list(params),
+          );
+          logger.info('api.sources.list.succeeded', {
+            correlationId,
+            statusCode: 200,
+            returnedItems: result.items.length,
+          });
+          return response(200, {
+            items: result.items,
+            filters: {
+              tenantId,
+              active: active.value ?? null,
+              engine: engine.value ?? null,
+            },
+            pagination: {
+              limit: limit.value,
+              nextToken: result.nextToken,
+            },
+            requestId: event.requestContext?.requestId ?? null,
+          });
+        } catch (error) {
+          if (error instanceof SourcePaginationTokenError) {
+            logger.info('api.sources.list.rejected', {
+              correlationId,
+              statusCode: 400,
+              reason: 'invalid_pagination_token',
+            });
+            return response(400, {
+              message: error.message,
+              code: 'INVALID_PAGINATION_TOKEN',
+            });
+          }
+
+          logger.info('api.sources.list.failed', {
+            correlationId,
+            statusCode: 500,
+          });
+          return response(500, {
+            message: 'Failed to list sources.',
+          });
+        }
+      },
+    });
   };
 
 export async function handler(event: ListSourcesEvent): Promise<ListSourcesResponse> {

--- a/src/handlers/scheduler.ts
+++ b/src/handlers/scheduler.ts
@@ -1,6 +1,12 @@
 import type { SourceRepository } from '../domain/scheduler/list-eligible-sources';
 import { listEligibleSources } from '../domain/scheduler/list-eligible-sources';
 import { createDynamoDbSchedulerSourceRepository } from '../infra/sources/dynamodb-scheduler-source-repository';
+import {
+  buildTelemetryAttributes,
+  toTelemetryLogContext,
+  withTelemetrySpan,
+  type TelemetryTraceContext,
+} from '../shared/observability/open-telemetry';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
 import { nowIso } from '../shared/time/now-iso';
 
@@ -15,6 +21,9 @@ export interface SchedulerEvent {
   now?: string;
   meta?: {
     executionId?: string;
+    stage?: string;
+    service?: string;
+    traceContext?: Partial<TelemetryTraceContext>;
   };
 }
 
@@ -30,6 +39,7 @@ export interface SchedulerResult {
   referenceNow: string;
   generatedAt: string;
   maxConcurrency: number;
+  traceContext: TelemetryTraceContext;
 }
 
 export interface SchedulerDependencies {
@@ -110,36 +120,67 @@ export const createHandler =
   async (event: SchedulerEvent = {}): Promise<SchedulerResult> => {
     const generatedAt = now();
     const referenceNow = event.now ?? generatedAt;
-    const sources = await listEligibleSources({
-      sourceRepository,
-      now: referenceNow,
-      pageSize: activeSourcesPageSize,
-    });
+    const executionId = event.meta?.executionId?.trim();
 
-    const sourceItems = sources.map((source) => ({
-      sourceId: source.sourceId,
-      tenantId: source.tenantId,
-    }));
-    const sourceIds = sourceItems.map((source) => source.sourceId);
-    const eligibleSources = sourceItems.length;
-    const maxConcurrency = resolveMapMaxConcurrency(process.env.MAP_MAX_CONCURRENCY);
-    logger.info('scheduler.eligible_sources.filtered', {
-      referenceNow,
-      eligibleSources,
-      tenants: [...new Set(sourceItems.map((source) => source.tenantId))].length,
-      correlationId: event.meta?.executionId?.trim() || null,
-    });
+    return withTelemetrySpan({
+      component: 'scheduler',
+      spanName: 'scheduler.execute',
+      parentTraceContext: event.meta?.traceContext,
+      attributes: buildTelemetryAttributes({
+        service: event.meta?.service,
+        stage: event.meta?.stage,
+        executionId,
+      }),
+      run: async ({ traceContext, runInChildSpan }) => {
+        logger.info('scheduler.telemetry.trace_context', {
+          ...toTelemetryLogContext(traceContext),
+          executionId: executionId ?? null,
+        });
 
-    return {
-      contractVersion: SCHEDULER_RESULT_CONTRACT_VERSION,
-      sources: sourceItems,
-      sourceIds,
-      eligibleSources,
-      hasEligibleSources: eligibleSources > 0,
-      referenceNow,
-      generatedAt,
-      maxConcurrency,
-    };
+        const sources = await runInChildSpan(
+          {
+            spanName: 'scheduler.list_eligible_sources',
+            attributes: buildTelemetryAttributes({
+              service: event.meta?.service,
+              stage: event.meta?.stage,
+              executionId,
+            }),
+          },
+          async () =>
+            listEligibleSources({
+              sourceRepository,
+              now: referenceNow,
+              pageSize: activeSourcesPageSize,
+            }),
+        );
+
+        const sourceItems = sources.map((source) => ({
+          sourceId: source.sourceId,
+          tenantId: source.tenantId,
+        }));
+        const sourceIds = sourceItems.map((source) => source.sourceId);
+        const eligibleSources = sourceItems.length;
+        const maxConcurrency = resolveMapMaxConcurrency(process.env.MAP_MAX_CONCURRENCY);
+        logger.info('scheduler.eligible_sources.filtered', {
+          referenceNow,
+          eligibleSources,
+          tenants: [...new Set(sourceItems.map((source) => source.tenantId))].length,
+          correlationId: executionId || null,
+        });
+
+        return {
+          contractVersion: SCHEDULER_RESULT_CONTRACT_VERSION,
+          sources: sourceItems,
+          sourceIds,
+          eligibleSources,
+          hasEligibleSources: eligibleSources > 0,
+          referenceNow,
+          generatedAt,
+          maxConcurrency,
+          traceContext,
+        };
+      },
+    });
   };
 
 export async function handler(event: SchedulerEvent = {}): Promise<SchedulerResult> {

--- a/src/handlers/update-source.ts
+++ b/src/handlers/update-source.ts
@@ -14,6 +14,11 @@ import { createDynamoDbSourceRegistryRepository } from '../infra/sources/dynamod
 import { resolveTenantIdFromJwtClaims } from '../shared/auth/tenant-context';
 import { resolveCorrelationId } from '../shared/logging/correlation-id';
 import { createStructuredLogger } from '../shared/logging/structured-logger';
+import {
+  buildTelemetryAttributes,
+  toTelemetryLogContext,
+  withTelemetrySpan,
+} from '../shared/observability/open-telemetry';
 import { nowIso } from '../shared/time/now-iso';
 
 const JSON_HEADERS = {
@@ -128,157 +133,193 @@ export const createHandler =
       headers: event.headers,
       requestId: event.requestContext?.requestId,
     });
-    logger.info('api.sources.update.received', {
-      correlationId,
-    });
-
-    const sourceId = parseSourceId(event.pathParameters?.id);
-    if (!sourceId.success) {
-      logger.info('api.sources.update.rejected', {
-        correlationId,
-        statusCode: sourceId.response.statusCode,
-        reason: 'missing_source_id',
-      });
-      return sourceId.response;
-    }
-
-    const parsedBody = parseBody(event.body);
-    if (!parsedBody.success) {
-      logger.info('api.sources.update.rejected', {
-        correlationId,
-        statusCode: parsedBody.response.statusCode,
-        sourceId: sourceId.value,
-        reason: 'invalid_body',
-      });
-      return parsedBody.response;
-    }
-
-    const tenantId = resolveTenantIdFromJwtClaims(event);
-    if (!tenantId) {
-      logger.info('api.sources.update.rejected', {
-        correlationId,
-        statusCode: 401,
-        sourceId: sourceId.value,
-        reason: 'tenant_context_missing',
-      });
-      return response(401, {
-        message: 'Missing tenant context in JWT claims.',
-        code: 'TENANT_CONTEXT_MISSING',
-      });
-    }
-
-    const patchValidation = validateSourcePatchPayload(parsedBody.value);
-    if (!patchValidation.success) {
-      logger.info('api.sources.update.rejected', {
-        correlationId,
-        statusCode: 400,
-        sourceId: sourceId.value,
-        reason: 'validation_error',
-      });
-      return response(400, {
-        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
-        errors: patchValidation.errors,
-      });
-    }
-
-    const current = await sourceRegistryRepository.getById(sourceId.value);
-    if (!current || current.tenantId !== tenantId) {
-      logger.info('api.sources.update.not_found', {
-        correlationId,
-        statusCode: 404,
-        sourceId: sourceId.value,
-        tenantId,
-      });
-      return response(404, {
-        message: `Source "${sourceId.value}" was not found.`,
-        code: 'SOURCE_NOT_FOUND',
-      });
-    }
-
-    const nextUpdatedAt = now();
-    const nextSchedule = resolveSourceSchedule(current, patchValidation.value);
-    const shouldRecalculateNextRunAt = hasSourceScheduleChanged(current, nextSchedule);
-    const nextRunAt = shouldRecalculateNextRunAt
-      ? calculateNextRunAt(nextSchedule, nextUpdatedAt)
-      : {
-          success: true as const,
-          value: current.nextRunAt,
-        };
-    if (!nextRunAt.success) {
-      logger.info('api.sources.update.rejected', {
-        correlationId,
-        statusCode: 400,
-        sourceId: sourceId.value,
-        reason: 'invalid_schedule',
-      });
-      return response(400, {
-        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
-        errors: nextRunAt.errors,
-      });
-    }
-
-    const merged = mergeAndValidateSourcePatch(
-      current,
-      patchValidation.value,
-      nextUpdatedAt,
-      nextRunAt.value,
-    );
-    if (!merged.success) {
-      logger.info('api.sources.update.rejected', {
-        correlationId,
-        statusCode: 400,
-        sourceId: sourceId.value,
-        reason: 'merge_validation_error',
-      });
-      return response(400, {
-        message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
-        errors: merged.errors,
-      });
-    }
-
-    try {
-      await sourceRegistryRepository.update({
-        sourceId: current.sourceId,
-        source: merged.value,
-        expectedUpdatedAt: current.updatedAt,
-      });
-
-      logger.info('api.sources.update.succeeded', {
-        correlationId,
-        statusCode: 200,
-        sourceId: merged.value.sourceId,
-      });
-      return response(200, {
-        sourceId: merged.value.sourceId,
-        metadata: {
-          schemaVersion: merged.value.schemaVersion,
-          createdAt: merged.value.createdAt,
-          updatedAt: merged.value.updatedAt,
-          requestId: event.requestContext?.requestId ?? null,
-        },
-      });
-    } catch (error) {
-      if (error instanceof SourceVersionConflictError) {
-        logger.info('api.sources.update.conflict', {
+    return withTelemetrySpan({
+      component: 'api.sources.update',
+      spanName: 'api.sources.update',
+      attributes: buildTelemetryAttributes({
+        executionId: correlationId ?? undefined,
+      }),
+      run: async ({ span, traceContext, runInChildSpan }) => {
+        logger.info('api.sources.update.received', {
           correlationId,
-          statusCode: 409,
-          sourceId: current.sourceId,
         });
-        return response(409, {
-          message: error.message,
-          code: 'SOURCE_VERSION_CONFLICT',
+        logger.info('api.sources.update.trace_context', {
+          correlationId,
+          ...toTelemetryLogContext(traceContext),
         });
-      }
 
-      logger.info('api.sources.update.failed', {
-        correlationId,
-        statusCode: 500,
-        sourceId: current.sourceId,
-      });
-      return response(500, {
-        message: 'Failed to update source.',
-      });
-    }
+        const sourceId = parseSourceId(event.pathParameters?.id);
+        if (!sourceId.success) {
+          logger.info('api.sources.update.rejected', {
+            correlationId,
+            statusCode: sourceId.response.statusCode,
+            reason: 'missing_source_id',
+          });
+          return sourceId.response;
+        }
+        span.setAttribute('sourceId', sourceId.value);
+
+        const parsedBody = parseBody(event.body);
+        if (!parsedBody.success) {
+          logger.info('api.sources.update.rejected', {
+            correlationId,
+            statusCode: parsedBody.response.statusCode,
+            sourceId: sourceId.value,
+            reason: 'invalid_body',
+          });
+          return parsedBody.response;
+        }
+
+        const tenantId = resolveTenantIdFromJwtClaims(event);
+        if (!tenantId) {
+          logger.info('api.sources.update.rejected', {
+            correlationId,
+            statusCode: 401,
+            sourceId: sourceId.value,
+            reason: 'tenant_context_missing',
+          });
+          return response(401, {
+            message: 'Missing tenant context in JWT claims.',
+            code: 'TENANT_CONTEXT_MISSING',
+          });
+        }
+        span.setAttribute('tenantId', tenantId);
+
+        const patchValidation = validateSourcePatchPayload(parsedBody.value);
+        if (!patchValidation.success) {
+          logger.info('api.sources.update.rejected', {
+            correlationId,
+            statusCode: 400,
+            sourceId: sourceId.value,
+            reason: 'validation_error',
+          });
+          return response(400, {
+            message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+            errors: patchValidation.errors,
+          });
+        }
+
+        const current = await runInChildSpan(
+          {
+            spanName: 'api.sources.update.repository.get',
+            attributes: buildTelemetryAttributes({
+              sourceId: sourceId.value,
+              tenantId,
+              executionId: correlationId ?? undefined,
+            }),
+          },
+          async () => sourceRegistryRepository.getById(sourceId.value),
+        );
+        if (!current || current.tenantId !== tenantId) {
+          logger.info('api.sources.update.not_found', {
+            correlationId,
+            statusCode: 404,
+            sourceId: sourceId.value,
+            tenantId,
+          });
+          return response(404, {
+            message: `Source "${sourceId.value}" was not found.`,
+            code: 'SOURCE_NOT_FOUND',
+          });
+        }
+
+        const nextUpdatedAt = now();
+        const nextSchedule = resolveSourceSchedule(current, patchValidation.value);
+        const shouldRecalculateNextRunAt = hasSourceScheduleChanged(current, nextSchedule);
+        const nextRunAt = shouldRecalculateNextRunAt
+          ? calculateNextRunAt(nextSchedule, nextUpdatedAt)
+          : {
+              success: true as const,
+              value: current.nextRunAt,
+            };
+        if (!nextRunAt.success) {
+          logger.info('api.sources.update.rejected', {
+            correlationId,
+            statusCode: 400,
+            sourceId: sourceId.value,
+            reason: 'invalid_schedule',
+          });
+          return response(400, {
+            message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+            errors: nextRunAt.errors,
+          });
+        }
+
+        const merged = mergeAndValidateSourcePatch(
+          current,
+          patchValidation.value,
+          nextUpdatedAt,
+          nextRunAt.value,
+        );
+        if (!merged.success) {
+          logger.info('api.sources.update.rejected', {
+            correlationId,
+            statusCode: 400,
+            sourceId: sourceId.value,
+            reason: 'merge_validation_error',
+          });
+          return response(400, {
+            message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
+            errors: merged.errors,
+          });
+        }
+
+        try {
+          await runInChildSpan(
+            {
+              spanName: 'api.sources.update.repository.update',
+              attributes: buildTelemetryAttributes({
+                sourceId: current.sourceId,
+                tenantId,
+                executionId: correlationId ?? undefined,
+              }),
+            },
+            async () =>
+              sourceRegistryRepository.update({
+                sourceId: current.sourceId,
+                source: merged.value,
+                expectedUpdatedAt: current.updatedAt,
+              }),
+          );
+
+          logger.info('api.sources.update.succeeded', {
+            correlationId,
+            statusCode: 200,
+            sourceId: merged.value.sourceId,
+          });
+          return response(200, {
+            sourceId: merged.value.sourceId,
+            metadata: {
+              schemaVersion: merged.value.schemaVersion,
+              createdAt: merged.value.createdAt,
+              updatedAt: merged.value.updatedAt,
+              requestId: event.requestContext?.requestId ?? null,
+            },
+          });
+        } catch (error) {
+          if (error instanceof SourceVersionConflictError) {
+            logger.info('api.sources.update.conflict', {
+              correlationId,
+              statusCode: 409,
+              sourceId: current.sourceId,
+            });
+            return response(409, {
+              message: error.message,
+              code: 'SOURCE_VERSION_CONFLICT',
+            });
+          }
+
+          logger.info('api.sources.update.failed', {
+            correlationId,
+            statusCode: 500,
+            sourceId: current.sourceId,
+          });
+          return response(500, {
+            message: 'Failed to update source.',
+          });
+        }
+      },
+    });
   };
 
 export async function handler(event: UpdateSourceEvent): Promise<UpdateSourceResponse> {

--- a/src/shared/observability/open-telemetry.ts
+++ b/src/shared/observability/open-telemetry.ts
@@ -1,0 +1,311 @@
+import {
+  context,
+  SpanStatusCode,
+  trace,
+  type Attributes,
+  type Context,
+  type Span,
+  type SpanContext,
+  type TraceFlags,
+} from '@opentelemetry/api';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+
+const TRACEPARENT_REGEX = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})(?:-[0-9a-f]+)?$/i;
+const ZERO_TRACE_ID = '00000000000000000000000000000000';
+const ZERO_SPAN_ID = '0000000000000000';
+const DEFAULT_SERVICE_NAME = 'alert-orchestration-service';
+
+let providerInitialized = false;
+
+export interface TelemetryTraceContext {
+  traceparent: string;
+  traceId: string;
+  spanId: string;
+  traceFlags: string;
+}
+
+export interface TelemetryAttributesInput {
+  service?: string;
+  stage?: string;
+  sourceId?: string;
+  tenantId?: string;
+  executionId?: string;
+}
+
+export interface TelemetrySpanOptions {
+  component: string;
+  spanName: string;
+  parentTraceContext?: Partial<TelemetryTraceContext> | null;
+  attributes?: Attributes;
+}
+
+export interface ChildTelemetrySpanOptions {
+  spanName: string;
+  attributes?: Attributes;
+}
+
+export interface TelemetrySpanScope {
+  span: Span;
+  traceContext: TelemetryTraceContext;
+  runInChildSpan: <T>(
+    options: ChildTelemetrySpanOptions,
+    run: () => Promise<T> | T,
+  ) => Promise<T>;
+}
+
+export interface TelemetryLogContext {
+  trace_id: string;
+  span_id: string;
+  traceparent: string;
+}
+
+const normalizeHex = (value: string | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+};
+
+const ensureTracerProvider = (): void => {
+  if (providerInitialized) {
+    return;
+  }
+
+  trace.setGlobalTracerProvider(new BasicTracerProvider());
+  providerInitialized = true;
+};
+
+const resolveServiceName = (): string => {
+  const rawValue = process.env.OTEL_SERVICE_NAME ?? process.env.SERVICE_NAME;
+  if (!rawValue) {
+    return DEFAULT_SERVICE_NAME;
+  }
+
+  const normalized = rawValue.trim();
+  return normalized.length > 0 ? normalized : DEFAULT_SERVICE_NAME;
+};
+
+const buildTraceparent = (spanContext: SpanContext): string => {
+  const traceFlags = spanContext.traceFlags.toString(16).padStart(2, '0');
+  return `00-${spanContext.traceId}-${spanContext.spanId}-${traceFlags}`;
+};
+
+const toTelemetryTraceContext = (span: Span): TelemetryTraceContext => {
+  const spanContext = span.spanContext();
+  return {
+    traceparent: buildTraceparent(spanContext),
+    traceId: spanContext.traceId,
+    spanId: spanContext.spanId,
+    traceFlags: spanContext.traceFlags.toString(16).padStart(2, '0'),
+  };
+};
+
+const parseTraceFlags = (rawFlags: string | undefined): TraceFlags => {
+  const normalized = normalizeHex(rawFlags);
+  if (!normalized) {
+    return 1 as TraceFlags;
+  }
+
+  const parsed = Number.parseInt(normalized, 16);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 255) {
+    return 1 as TraceFlags;
+  }
+
+  return parsed as TraceFlags;
+};
+
+const toSpanContextFromFields = (
+  input: Partial<TelemetryTraceContext>,
+): SpanContext | null => {
+  const traceId = normalizeHex(input.traceId);
+  const spanId = normalizeHex(input.spanId);
+  if (!traceId || !spanId) {
+    return null;
+  }
+
+  const isValidTraceId = /^[0-9a-f]{32}$/.test(traceId) && traceId !== ZERO_TRACE_ID;
+  const isValidSpanId = /^[0-9a-f]{16}$/.test(spanId) && spanId !== ZERO_SPAN_ID;
+  if (!isValidTraceId || !isValidSpanId) {
+    return null;
+  }
+
+  return {
+    traceId,
+    spanId,
+    traceFlags: parseTraceFlags(input.traceFlags),
+    isRemote: true,
+  };
+};
+
+const toSpanContextFromTraceparent = (
+  rawTraceparent: string | undefined,
+): SpanContext | null => {
+  const normalized = normalizeHex(rawTraceparent);
+  if (!normalized) {
+    return null;
+  }
+
+  const match = TRACEPARENT_REGEX.exec(normalized);
+  if (!match) {
+    return null;
+  }
+
+  const traceId = match[2];
+  const spanId = match[3];
+  if (traceId === ZERO_TRACE_ID || spanId === ZERO_SPAN_ID) {
+    return null;
+  }
+
+  return {
+    traceId,
+    spanId,
+    traceFlags: parseTraceFlags(match[4]),
+    isRemote: true,
+  };
+};
+
+const resolveParentContext = (input: Partial<TelemetryTraceContext> | null | undefined): Context => {
+  if (!input) {
+    return context.active();
+  }
+
+  const parentSpanContext =
+    toSpanContextFromTraceparent(input.traceparent) ?? toSpanContextFromFields(input);
+  if (!parentSpanContext) {
+    return context.active();
+  }
+
+  return trace.setSpan(context.active(), trace.wrapSpanContext(parentSpanContext));
+};
+
+const normalizeAttributes = (attributes: Attributes | undefined): Attributes | undefined => {
+  if (!attributes) {
+    return undefined;
+  }
+
+  const entries = Object.entries(attributes).filter(([, value]) => value !== undefined && value !== null);
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries);
+};
+
+const markErrorOnSpan = (span: Span, error: unknown): void => {
+  if (error instanceof Error) {
+    span.recordException(error);
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error.message,
+    });
+    return;
+  }
+
+  span.setStatus({
+    code: SpanStatusCode.ERROR,
+    message: String(error),
+  });
+};
+
+const runWithTelemetryChildSpan = async <T>({
+  component,
+  parentContext,
+  options,
+  run,
+}: {
+  component: string;
+  parentContext: Context;
+  options: ChildTelemetrySpanOptions;
+  run: () => Promise<T> | T;
+}): Promise<T> => {
+  const tracer = trace.getTracer(resolveServiceName(), component);
+  const childSpan = tracer.startSpan(
+    options.spanName,
+    {
+      attributes: normalizeAttributes(options.attributes),
+    },
+    parentContext,
+  );
+
+  const childContext = trace.setSpan(parentContext, childSpan);
+  try {
+    return await context.with(childContext, async () => run());
+  } catch (error) {
+    markErrorOnSpan(childSpan, error);
+    throw error;
+  } finally {
+    childSpan.end();
+  }
+};
+
+export const withTelemetrySpan = async <T>({
+  component,
+  spanName,
+  parentTraceContext,
+  attributes,
+  run,
+}: TelemetrySpanOptions & {
+  run: (scope: TelemetrySpanScope) => Promise<T> | T;
+}): Promise<T> => {
+  ensureTracerProvider();
+
+  const tracer = trace.getTracer(resolveServiceName(), component);
+  const parentContext = resolveParentContext(parentTraceContext);
+  const rootSpan = tracer.startSpan(
+    spanName,
+    {
+      attributes: normalizeAttributes(attributes),
+    },
+    parentContext,
+  );
+  const rootSpanContext = trace.setSpan(parentContext, rootSpan);
+  const traceContext = toTelemetryTraceContext(rootSpan);
+
+  try {
+    return await context.with(rootSpanContext, async () =>
+      run({
+        span: rootSpan,
+        traceContext,
+        runInChildSpan: <ChildResult>(
+          options: ChildTelemetrySpanOptions,
+          childRun: () => Promise<ChildResult> | ChildResult,
+        ): Promise<ChildResult> =>
+          runWithTelemetryChildSpan({
+            component,
+            parentContext: rootSpanContext,
+            options,
+            run: childRun,
+          }),
+      }),
+    );
+  } catch (error) {
+    markErrorOnSpan(rootSpan, error);
+    throw error;
+  } finally {
+    rootSpan.end();
+  }
+};
+
+export const toTelemetryLogContext = (traceContext: TelemetryTraceContext): TelemetryLogContext => ({
+  trace_id: traceContext.traceId,
+  span_id: traceContext.spanId,
+  traceparent: traceContext.traceparent,
+});
+
+export const buildTelemetryAttributes = ({
+  service,
+  stage,
+  sourceId,
+  tenantId,
+  executionId,
+}: TelemetryAttributesInput): Attributes => {
+  return normalizeAttributes({
+    service: service?.trim() || process.env.SERVICE_NAME || DEFAULT_SERVICE_NAME,
+    stage: stage?.trim() || process.env.STAGE || 'unknown',
+    sourceId: sourceId?.trim() || undefined,
+    tenantId: tenantId?.trim() || undefined,
+    executionId: executionId?.trim() || undefined,
+  }) ?? {};
+};

--- a/state-machines/main-orchestration-v1.asl.json
+++ b/state-machines/main-orchestration-v1.asl.json
@@ -27,7 +27,8 @@
         "Fn::GetAtt": ["SchedulerLambdaFunction", "Arn"]
       },
       "Parameters": {
-        "now.$": "$.schedulerInput.now"
+        "now.$": "$.schedulerInput.now",
+        "meta.$": "$.meta"
       },
       "Retry": [
         {
@@ -65,7 +66,16 @@
       "Parameters": {
         "sourceId.$": "$$.Map.Item.Value.sourceId",
         "tenantId.$": "$$.Map.Item.Value.tenantId",
-        "meta.$": "$.meta"
+        "meta": {
+          "executionId.$": "$.meta.executionId",
+          "stateMachineId.$": "$.meta.stateMachineId",
+          "startedAt.$": "$.meta.startedAt",
+          "trigger.$": "$.meta.trigger",
+          "source.$": "$.meta.source",
+          "stage.$": "$.meta.stage",
+          "service.$": "$.meta.service",
+          "traceContext.$": "$.schedulerResult.traceContext"
+        }
       },
       "Iterator": {
         "StartAt": "InvokeCollector",

--- a/tests/unit/handlers/scheduler.test.ts
+++ b/tests/unit/handlers/scheduler.test.ts
@@ -344,6 +344,14 @@ describe('scheduler handler', () => {
       referenceNow: '2026-03-04T10:01:00.000Z',
       generatedAt: '2026-03-04T10:00:00.000Z',
       maxConcurrency: 5,
+      traceContext: {
+        traceId: expect.stringMatching(/^[0-9a-f]{32}$/),
+        spanId: expect.stringMatching(/^[0-9a-f]{16}$/),
+        traceFlags: expect.stringMatching(/^[0-9a-f]{2}$/),
+        traceparent: expect.stringMatching(
+          /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/,
+        ),
+      },
     });
     expect(logger.info).toHaveBeenCalledWith('scheduler.eligible_sources.filtered', {
       referenceNow: '2026-03-04T10:01:00.000Z',

--- a/tests/unit/shared/observability/open-telemetry.test.ts
+++ b/tests/unit/shared/observability/open-telemetry.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { trace, type Span, type SpanStatusCode } from '@opentelemetry/api';
+import {
+  buildTelemetryAttributes,
+  toTelemetryLogContext,
+  withTelemetrySpan,
+} from '../../../../src/shared/observability/open-telemetry';
+
+const createMockSpan = ({
+  traceId,
+  spanId,
+}: {
+  traceId: string;
+  spanId: string;
+}): {
+  span: Span;
+  end: ReturnType<typeof jest.fn>;
+  setStatus: ReturnType<typeof jest.fn>;
+  recordException: ReturnType<typeof jest.fn>;
+} => {
+  const end = jest.fn();
+  const setStatus = jest.fn();
+  const recordException = jest.fn();
+
+  return {
+    span: {
+      end,
+      setStatus,
+      recordException,
+      spanContext: () => ({
+        traceId,
+        spanId,
+        traceFlags: 1,
+      }),
+    } as unknown as Span,
+    end,
+    setStatus,
+    recordException,
+  };
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('open telemetry helpers', () => {
+  it('creates and closes root + child spans in successful execution', async () => {
+    const root = createMockSpan({
+      traceId: '11111111111111111111111111111111',
+      spanId: '1111111111111111',
+    });
+    const child = createMockSpan({
+      traceId: '11111111111111111111111111111111',
+      spanId: '2222222222222222',
+    });
+    const startSpan = jest.fn()
+      .mockReturnValueOnce(root.span)
+      .mockReturnValueOnce(child.span);
+    jest.spyOn(trace, 'getTracer').mockReturnValue({
+      startSpan,
+    } as unknown as ReturnType<typeof trace.getTracer>);
+
+    const result = await withTelemetrySpan({
+      component: 'scheduler',
+      spanName: 'scheduler.execute',
+      attributes: {
+        sourceId: 'source-1',
+      },
+      run: async ({ traceContext, runInChildSpan }) => {
+        const childResult = await runInChildSpan(
+          {
+            spanName: 'scheduler.list_sources',
+          },
+          () => 'child-ok',
+        );
+
+        expect(traceContext.traceId).toBe('11111111111111111111111111111111');
+        expect(traceContext.spanId).toBe('1111111111111111');
+        expect(traceContext.traceparent).toBe(
+          '00-11111111111111111111111111111111-1111111111111111-01',
+        );
+        return childResult;
+      },
+    });
+
+    expect(result).toBe('child-ok');
+    expect(startSpan).toHaveBeenCalledTimes(2);
+    expect(root.end).toHaveBeenCalledTimes(1);
+    expect(child.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('records exception and closes span when callback throws', async () => {
+    const root = createMockSpan({
+      traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      spanId: 'bbbbbbbbbbbbbbbb',
+    });
+    const startSpan = jest.fn().mockReturnValue(root.span);
+    jest.spyOn(trace, 'getTracer').mockReturnValue({
+      startSpan,
+    } as unknown as ReturnType<typeof trace.getTracer>);
+
+    await expect(
+      withTelemetrySpan({
+        component: 'collector',
+        spanName: 'collector.execute',
+        run: () => {
+          throw new Error('telemetry_failure');
+        },
+      }),
+    ).rejects.toThrow('telemetry_failure');
+
+    expect(root.recordException).toHaveBeenCalledTimes(1);
+    expect(root.setStatus).toHaveBeenCalledWith({
+      code: 2 as SpanStatusCode,
+      message: 'telemetry_failure',
+    });
+    expect(root.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('builds default attributes and serializes log context', () => {
+    process.env.SERVICE_NAME = 'alert-orchestration-service';
+    process.env.STAGE = 'stg';
+
+    const attributes = buildTelemetryAttributes({
+      sourceId: 'source-1',
+      tenantId: 'tenant-a',
+      executionId: 'exec-123',
+    });
+
+    expect(attributes).toEqual({
+      service: 'alert-orchestration-service',
+      stage: 'stg',
+      sourceId: 'source-1',
+      tenantId: 'tenant-a',
+      executionId: 'exec-123',
+    });
+
+    const logContext = toTelemetryLogContext({
+      traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      spanId: 'bbbbbbbbbbbbbbbb',
+      traceFlags: '01',
+      traceparent: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
+    });
+    expect(logContext).toEqual({
+      trace_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      span_id: 'bbbbbbbbbbbbbbbb',
+      traceparent: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
+    });
+  });
+});

--- a/tests/unit/state-machines/main-orchestration-v1.test.ts
+++ b/tests/unit/state-machines/main-orchestration-v1.test.ts
@@ -108,6 +108,7 @@ describe('main-orchestration-v1.asl.json', () => {
     expect(scheduler.Next).toBe('ProcessEligibleSources');
     const schedulerParameters = asObject(scheduler.Parameters);
     expect(schedulerParameters['now.$']).toBe('$.schedulerInput.now');
+    expect(schedulerParameters['meta.$']).toBe('$.meta');
     const schedulerRetry = scheduler.Retry as unknown[];
     expect(Array.isArray(schedulerRetry)).toBe(true);
     expect(schedulerRetry).toHaveLength(2);
@@ -144,7 +145,15 @@ describe('main-orchestration-v1.asl.json', () => {
     const processEligibleSourcesParameters = asObject(processEligibleSources.Parameters);
     expect(processEligibleSourcesParameters['sourceId.$']).toBe('$$.Map.Item.Value.sourceId');
     expect(processEligibleSourcesParameters['tenantId.$']).toBe('$$.Map.Item.Value.tenantId');
-    expect(processEligibleSourcesParameters['meta.$']).toBe('$.meta');
+    const processEligibleSourcesMeta = asObject(processEligibleSourcesParameters.meta);
+    expect(processEligibleSourcesMeta['executionId.$']).toBe('$.meta.executionId');
+    expect(processEligibleSourcesMeta['stateMachineId.$']).toBe('$.meta.stateMachineId');
+    expect(processEligibleSourcesMeta['startedAt.$']).toBe('$.meta.startedAt');
+    expect(processEligibleSourcesMeta['trigger.$']).toBe('$.meta.trigger');
+    expect(processEligibleSourcesMeta['source.$']).toBe('$.meta.source');
+    expect(processEligibleSourcesMeta['stage.$']).toBe('$.meta.stage');
+    expect(processEligibleSourcesMeta['service.$']).toBe('$.meta.service');
+    expect(processEligibleSourcesMeta['traceContext.$']).toBe('$.schedulerResult.traceContext');
     const iterator = asObject(processEligibleSources.Iterator);
     expect(iterator.StartAt).toBe('InvokeCollector');
     const iteratorStates = asObject(iterator.States);


### PR DESCRIPTION
Closes #183

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Estabelecer baseline de OpenTelemetry nas lambdas críticas com spans raiz/etapas, contexto de trace propagado no fluxo Scheduler -> Step Functions -> Collector e logs correlacionáveis por `trace_id`.

---

## 🧠 Decisão Técnica

Criado módulo compartilhado `src/shared/observability/open-telemetry.ts` com:
- criação de spans raiz/child spans;
- parse/serialização de `traceparent`;
- atributos padrão (`service`, `stage`, `sourceId`, `tenantId`, `executionId`).

Instrumentados `scheduler`, `collector` e CRUD de `/sources` com eventos de log `*.trace_context` contendo `trace_id`, `span_id` e `traceparent`.

A state machine passou a:
- enviar `meta` para o scheduler;
- propagar `schedulerResult.traceContext` para `meta.traceContext` de cada item do `Map`.

---

## 🧪 BDD Validado

Dado uma execução da orquestração
Quando o scheduler processa fontes elegíveis
Então ele retorna `traceContext` e esse contexto é propagado para o collector via `meta.traceContext`.

Dado handlers críticos instrumentados
Quando há execução com sucesso ou erro
Então spans são encerrados corretamente e logs incluem evento de contexto de trace.

---

## 🏗 Impacto Arquitetural

- [x] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [x] métricas
- [x] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

Comandos executados:
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`

---

## 🔥 Tipo de Release

- [ ] PATCH
- [x] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
