### PR TITLE
feat: consistencia de secretArn entre deploy e runtime

### DIFF
--- a/docs/deployment/stage-deploy-and-rollback.md
+++ b/docs/deployment/stage-deploy-and-rollback.md
@@ -17,6 +17,17 @@ Cada environment (`dev`, `stg`, `prod`) deve conter:
 - `AWS_DEPLOY_ROLE_ARN` (secret): role assumida por OIDC para deploy.
 - `SERVERLESS_ACCESS_KEY` (secret): autenticacao do Serverless Framework v4.
 - `AWS_REGION` (variable opcional): default `us-east-1`.
+- `SECRETS_ALLOWED_ACCOUNT_ID_<STAGE>` (variable): conta AWS permitida para `secretArn` de fontes.
+  - `SECRETS_ALLOWED_ACCOUNT_ID_DEV`
+  - `SECRETS_ALLOWED_ACCOUNT_ID_STG`
+  - `SECRETS_ALLOWED_ACCOUNT_ID_PROD`
+
+No runtime, a politica efetiva e exposta via:
+
+- `SECRETS_ALLOWED_REGION`
+- `SECRETS_ALLOWED_ACCOUNT_ID`
+
+Com isso, `POST/PATCH /sources` e `collector` rejeitam `secretArn` incompativel com stage.
 
 ## Fluxo de promocao recomendado
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,6 +21,8 @@ provider:
     STAGE: ${self:provider.stage}
     SERVICE_NAME: ${self:service}
     OTEL_SERVICE_NAME: ${env:OTEL_SERVICE_NAME, 'alert-orchestration-service'}
+    SECRETS_ALLOWED_REGION: ${self:custom.stages.${self:provider.stage}.secretsAllowedRegion}
+    SECRETS_ALLOWED_ACCOUNT_ID: ${self:custom.stages.${self:provider.stage}.secretsAllowedAccountId}
     SOURCES_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.sourcesTableName}
     CURSORS_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.cursorsTableName}
     IDEMPOTENCY_TABLE_NAME: ${self:custom.stages.${self:provider.stage}.idempotencyTableName}
@@ -103,6 +105,8 @@ custom:
   stages:
     dev:
       region: us-east-1
+      secretsAllowedRegion: us-east-1
+      secretsAllowedAccountId: ${env:SECRETS_ALLOWED_ACCOUNT_ID_DEV, ''}
       logRetentionInDays: 7
       tracing: false
       schedulerMemorySize: 256
@@ -148,6 +152,8 @@ custom:
       orchestrationScheduleExpression: cron(0/30 * * * ? *)
     stg:
       region: us-east-1
+      secretsAllowedRegion: us-east-1
+      secretsAllowedAccountId: ${env:SECRETS_ALLOWED_ACCOUNT_ID_STG, ''}
       logRetentionInDays: 14
       tracing: true
       schedulerMemorySize: 256
@@ -193,6 +199,8 @@ custom:
       orchestrationScheduleExpression: cron(0/15 * * * ? *)
     prod:
       region: us-east-1
+      secretsAllowedRegion: us-east-1
+      secretsAllowedAccountId: ${env:SECRETS_ALLOWED_ACCOUNT_ID_PROD, ''}
       logRetentionInDays: 30
       tracing: true
       schedulerMemorySize: 384

--- a/src/handlers/collector.ts
+++ b/src/handlers/collector.ts
@@ -58,6 +58,10 @@ import {
   withTelemetrySpan,
   type TelemetryTraceContext,
 } from '../shared/observability/open-telemetry';
+import {
+  resolveSecretArnStagePolicy,
+  validateSecretArnAgainstStagePolicy,
+} from '../shared/security/secret-arn-stage-policy';
 import { nowIso } from '../shared/time/now-iso';
 
 const COLLECTOR_SECRET_RETRY_MAX_ATTEMPTS_DEFAULT = 3;
@@ -799,6 +803,20 @@ export const createHandler =
           const tenantId = eventTenantId || sourceConfiguration.tenantId;
           resolvedTenantId = tenantId;
           span.setAttribute('tenantId', tenantId);
+          const secretArnPolicyValidation = validateSecretArnAgainstStagePolicy({
+            secretArn: sourceConfiguration.secretArn,
+            policy: resolveSecretArnStagePolicy(),
+          });
+          if (!secretArnPolicyValidation.success) {
+            logger.info('collector.secret_arn.rejected', {
+              sourceId,
+              tenantId,
+              reason: secretArnPolicyValidation.reason,
+            });
+            throw new Error(
+              `Secret ARN policy rejected source "${sourceId}": ${secretArnPolicyValidation.reason}`,
+            );
+          }
 
           const cursorSnapshot = await runInChildSpan(
             {

--- a/src/handlers/create-source.ts
+++ b/src/handlers/create-source.ts
@@ -18,6 +18,10 @@ import {
   toTelemetryLogContext,
   withTelemetrySpan,
 } from '../shared/observability/open-telemetry';
+import {
+  resolveSecretArnStagePolicy,
+  validateSecretArnAgainstStagePolicy,
+} from '../shared/security/secret-arn-stage-policy';
 import { nowIso } from '../shared/time/now-iso';
 
 const JSON_HEADERS = {
@@ -227,6 +231,22 @@ export const createHandler =
           updatedAt: createdAt,
         };
         span.setAttribute('sourceId', record.sourceId);
+        const secretArnPolicyValidation = validateSecretArnAgainstStagePolicy({
+          secretArn: record.secretArn,
+          policy: resolveSecretArnStagePolicy(),
+        });
+        if (!secretArnPolicyValidation.success) {
+          logger.info('api.sources.create.rejected', {
+            correlationId,
+            statusCode: 400,
+            sourceId: record.sourceId,
+            reason: 'secret_arn_stage_mismatch',
+          });
+          return response(400, {
+            message: secretArnPolicyValidation.reason,
+            code: 'SECRET_ARN_STAGE_MISMATCH',
+          });
+        }
 
         try {
           await runInChildSpan(

--- a/src/handlers/update-source.ts
+++ b/src/handlers/update-source.ts
@@ -19,6 +19,10 @@ import {
   toTelemetryLogContext,
   withTelemetrySpan,
 } from '../shared/observability/open-telemetry';
+import {
+  resolveSecretArnStagePolicy,
+  validateSecretArnAgainstStagePolicy,
+} from '../shared/security/secret-arn-stage-policy';
 import { nowIso } from '../shared/time/now-iso';
 
 const JSON_HEADERS = {
@@ -261,6 +265,22 @@ export const createHandler =
           return response(400, {
             message: SOURCE_PAYLOAD_VALIDATION_MESSAGE,
             errors: merged.errors,
+          });
+        }
+        const secretArnPolicyValidation = validateSecretArnAgainstStagePolicy({
+          secretArn: merged.value.secretArn,
+          policy: resolveSecretArnStagePolicy(),
+        });
+        if (!secretArnPolicyValidation.success) {
+          logger.info('api.sources.update.rejected', {
+            correlationId,
+            statusCode: 400,
+            sourceId: sourceId.value,
+            reason: 'secret_arn_stage_mismatch',
+          });
+          return response(400, {
+            message: secretArnPolicyValidation.reason,
+            code: 'SECRET_ARN_STAGE_MISMATCH',
           });
         }
 

--- a/src/shared/security/secret-arn-stage-policy.ts
+++ b/src/shared/security/secret-arn-stage-policy.ts
@@ -1,0 +1,109 @@
+const SECRET_ARN_REGEX =
+  /^arn:[^:\s]+:secretsmanager:([^:\s]+):(\d{12}):secret:[A-Za-z0-9/_+=.@-]+$/;
+
+const normalize = (value: string | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const parseSecretArn = (
+  secretArn: string,
+): { region: string; accountId: string } | null => {
+  const match = SECRET_ARN_REGEX.exec(secretArn.trim());
+  if (!match) {
+    return null;
+  }
+
+  return {
+    region: match[1],
+    accountId: match[2],
+  };
+};
+
+export interface SecretArnStagePolicy {
+  stage: string;
+  allowedRegion: string;
+  allowedAccountId?: string;
+}
+
+export interface SecretArnStageValidationResult {
+  success: true;
+}
+
+export interface SecretArnStageValidationFailure {
+  success: false;
+  reason: string;
+}
+
+export type SecretArnStageValidation =
+  | SecretArnStageValidationResult
+  | SecretArnStageValidationFailure;
+
+export const resolveSecretArnStagePolicy = ({
+  stage = process.env.STAGE,
+  allowedRegion = process.env.SECRETS_ALLOWED_REGION ??
+    process.env.AWS_REGION ??
+    process.env.AWS_DEFAULT_REGION ??
+    'us-east-1',
+  allowedAccountId = process.env.SECRETS_ALLOWED_ACCOUNT_ID,
+}: {
+  stage?: string;
+  allowedRegion?: string;
+  allowedAccountId?: string;
+} = {}): SecretArnStagePolicy => {
+  const normalizedStage = normalize(stage) ?? 'unknown';
+  const normalizedRegion = normalize(allowedRegion);
+  if (!normalizedRegion) {
+    throw new Error('SECRETS_ALLOWED_REGION is required.');
+  }
+
+  const normalizedAccountId = normalize(allowedAccountId);
+  if (normalizedAccountId && !/^\d{12}$/.test(normalizedAccountId)) {
+    throw new Error('SECRETS_ALLOWED_ACCOUNT_ID must be a 12-digit AWS account id.');
+  }
+
+  return {
+    stage: normalizedStage,
+    allowedRegion: normalizedRegion,
+    allowedAccountId: normalizedAccountId,
+  };
+};
+
+export const validateSecretArnAgainstStagePolicy = ({
+  secretArn,
+  policy,
+}: {
+  secretArn: string;
+  policy: SecretArnStagePolicy;
+}): SecretArnStageValidation => {
+  const normalizedArn = secretArn.trim();
+  const parsed = parseSecretArn(normalizedArn);
+  if (!parsed) {
+    return {
+      success: false,
+      reason: 'secretArn must be a valid AWS Secrets Manager ARN.',
+    };
+  }
+
+  if (parsed.region !== policy.allowedRegion) {
+    return {
+      success: false,
+      reason: `secretArn region "${parsed.region}" is incompatible with stage "${policy.stage}" (expected "${policy.allowedRegion}").`,
+    };
+  }
+
+  if (policy.allowedAccountId && parsed.accountId !== policy.allowedAccountId) {
+    return {
+      success: false,
+      reason: `secretArn account "${parsed.accountId}" is incompatible with stage "${policy.stage}" (expected "${policy.allowedAccountId}").`,
+    };
+  }
+
+  return {
+    success: true,
+  };
+};

--- a/tests/unit/handlers/collector.test.ts
+++ b/tests/unit/handlers/collector.test.ts
@@ -1269,6 +1269,64 @@ describe('collector handler', () => {
     expect(postgresFactory.queryCalls).toEqual([]);
   });
 
+  it('fails before Secrets Manager call when source secretArn is incompatible with stage policy', async () => {
+    const previousRegion = process.env.SECRETS_ALLOWED_REGION;
+    const previousAccount = process.env.SECRETS_ALLOWED_ACCOUNT_ID;
+    process.env.SECRETS_ALLOWED_REGION = 'us-east-1';
+    process.env.SECRETS_ALLOWED_ACCOUNT_ID = '123456789012';
+
+    try {
+      const sourceWithForeignSecretArn: SourceRegistryRecord = {
+        ...VALID_SOURCE,
+        sourceId: 'source-foreign-secret',
+        secretArn: 'arn:aws:secretsmanager:us-west-2:123456789012:secret:acme/source-db',
+      };
+      const repository = new SpySourceRegistryRepository(
+        new Map<string, SourceRegistryRecord>([
+          [sourceWithForeignSecretArn.sourceId, sourceWithForeignSecretArn],
+        ]),
+      );
+      const secrets = new SpySecretRepository(
+        new Map<string, string | null>([
+          [
+            sourceWithForeignSecretArn.secretArn,
+            JSON.stringify({
+              host: 'db.internal',
+              port: 5432,
+              database: 'crm',
+              username: 'collector_user',
+              password: 'collector_password',
+            }),
+          ],
+        ]),
+      );
+      const postgresFactory = new SpyPostgresQueryExecutorFactory([]);
+      const handler = createCollectorHandler({
+        sourceRegistryRepository: repository,
+        secretRepository: secrets,
+        postgresQueryExecutorFactory: postgresFactory,
+      });
+
+      await expect(handler({ sourceId: sourceWithForeignSecretArn.sourceId })).rejects.toThrow(
+        'Secret ARN policy rejected source "source-foreign-secret": secretArn region "us-west-2" is incompatible with stage "unknown" (expected "us-east-1").',
+      );
+      expect(secrets.getSecretValueCalls).toEqual([]);
+      expect(postgresFactory.queryCalls).toEqual([]);
+    } finally {
+      if (previousRegion === undefined) {
+        delete process.env.SECRETS_ALLOWED_REGION;
+      } else {
+        process.env.SECRETS_ALLOWED_REGION = previousRegion;
+      }
+
+      if (previousAccount === undefined) {
+        delete process.env.SECRETS_ALLOWED_ACCOUNT_ID;
+      } else {
+        process.env.SECRETS_ALLOWED_ACCOUNT_ID = previousAccount;
+      }
+    }
+  });
+
   it('throws controlled error when secret does not exist in Secrets Manager', async () => {
     const repository = new SpySourceRegistryRepository(
       new Map<string, SourceRegistryRecord>([[VALID_SOURCE.sourceId, VALID_SOURCE]]),

--- a/tests/unit/handlers/create-source.test.ts
+++ b/tests/unit/handlers/create-source.test.ts
@@ -145,6 +145,49 @@ describe('create-source handler', () => {
     expect(repository.created).toHaveLength(0);
   });
 
+  it('returns 400 when secretArn is incompatible with stage policy', async () => {
+    const previousRegion = process.env.SECRETS_ALLOWED_REGION;
+    const previousAccount = process.env.SECRETS_ALLOWED_ACCOUNT_ID;
+    process.env.SECRETS_ALLOWED_REGION = 'us-east-1';
+    process.env.SECRETS_ALLOWED_ACCOUNT_ID = '123456789012';
+
+    try {
+      const repository = new SpySourceRegistryRepository();
+      const handler = createHandler({
+        sourceRegistryRepository: repository,
+        now: () => '2026-03-03T12:00:00.000Z',
+      });
+
+      const result = await handler({
+        body: JSON.stringify({
+          ...VALID_INTERVAL_SOURCE,
+          secretArn: 'arn:aws:secretsmanager:us-west-2:123456789012:secret:acme/source-db',
+        }),
+        requestContext: tenantRequestContext(),
+      });
+
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body)).toEqual({
+        message:
+          'secretArn region "us-west-2" is incompatible with stage "unknown" (expected "us-east-1").',
+        code: 'SECRET_ARN_STAGE_MISMATCH',
+      });
+      expect(repository.created).toHaveLength(0);
+    } finally {
+      if (previousRegion === undefined) {
+        delete process.env.SECRETS_ALLOWED_REGION;
+      } else {
+        process.env.SECRETS_ALLOWED_REGION = previousRegion;
+      }
+
+      if (previousAccount === undefined) {
+        delete process.env.SECRETS_ALLOWED_ACCOUNT_ID;
+      } else {
+        process.env.SECRETS_ALLOWED_ACCOUNT_ID = previousAccount;
+      }
+    }
+  });
+
   it('returns 400 when body is invalid json', async () => {
     const handler = createHandler({
       sourceRegistryRepository: new SpySourceRegistryRepository(),

--- a/tests/unit/handlers/update-source.test.ts
+++ b/tests/unit/handlers/update-source.test.ts
@@ -203,6 +203,47 @@ describe('update-source handler', () => {
     expect(parsed.errors.some((entry) => entry.field === 'sourceId')).toBe(true);
   });
 
+  it('returns 400 when merged secretArn is incompatible with stage policy', async () => {
+    const previousRegion = process.env.SECRETS_ALLOWED_REGION;
+    const previousAccount = process.env.SECRETS_ALLOWED_ACCOUNT_ID;
+    process.env.SECRETS_ALLOWED_REGION = 'us-east-1';
+    process.env.SECRETS_ALLOWED_ACCOUNT_ID = '123456789012';
+
+    try {
+      const handler = createHandler({
+        sourceRegistryRepository: new SpySourceRegistryRepository([EXISTING_SOURCE]),
+        now: () => '2026-03-03T12:00:00.000Z',
+      });
+
+      const result = await handler({
+        pathParameters: { id: EXISTING_SOURCE.sourceId },
+        body: JSON.stringify({
+          secretArn: 'arn:aws:secretsmanager:us-west-2:123456789012:secret:acme/source-db',
+        }),
+        requestContext: tenantRequestContext(),
+      });
+
+      expect(result.statusCode).toBe(400);
+      expect(JSON.parse(result.body)).toEqual({
+        message:
+          'secretArn region "us-west-2" is incompatible with stage "unknown" (expected "us-east-1").',
+        code: 'SECRET_ARN_STAGE_MISMATCH',
+      });
+    } finally {
+      if (previousRegion === undefined) {
+        delete process.env.SECRETS_ALLOWED_REGION;
+      } else {
+        process.env.SECRETS_ALLOWED_REGION = previousRegion;
+      }
+
+      if (previousAccount === undefined) {
+        delete process.env.SECRETS_ALLOWED_ACCOUNT_ID;
+      } else {
+        process.env.SECRETS_ALLOWED_ACCOUNT_ID = previousAccount;
+      }
+    }
+  });
+
   it('returns 400 when payload tries to update nextRunAt directly', async () => {
     const handler = createHandler({
       sourceRegistryRepository: new SpySourceRegistryRepository([EXISTING_SOURCE]),

--- a/tests/unit/shared/security/secret-arn-stage-policy.test.ts
+++ b/tests/unit/shared/security/secret-arn-stage-policy.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  resolveSecretArnStagePolicy,
+  validateSecretArnAgainstStagePolicy,
+} from '../../../../src/shared/security/secret-arn-stage-policy';
+
+describe('secret arn stage policy', () => {
+  it('validates compatible secret arn for stage policy', () => {
+    const policy = resolveSecretArnStagePolicy({
+      stage: 'dev',
+      allowedRegion: 'us-east-1',
+      allowedAccountId: '123456789012',
+    });
+
+    const result = validateSecretArnAgainstStagePolicy({
+      secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:acme/source-db',
+      policy,
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it('rejects secret arn when region does not match stage policy', () => {
+    const policy = resolveSecretArnStagePolicy({
+      stage: 'stg',
+      allowedRegion: 'us-east-1',
+      allowedAccountId: '123456789012',
+    });
+
+    const result = validateSecretArnAgainstStagePolicy({
+      secretArn: 'arn:aws:secretsmanager:us-west-2:123456789012:secret:acme/source-db',
+      policy,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      reason:
+        'secretArn region "us-west-2" is incompatible with stage "stg" (expected "us-east-1").',
+    });
+  });
+
+  it('rejects secret arn when account does not match stage policy', () => {
+    const policy = resolveSecretArnStagePolicy({
+      stage: 'prod',
+      allowedRegion: 'us-east-1',
+      allowedAccountId: '123456789012',
+    });
+
+    const result = validateSecretArnAgainstStagePolicy({
+      secretArn: 'arn:aws:secretsmanager:us-east-1:999999999999:secret:acme/source-db',
+      policy,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      reason:
+        'secretArn account "999999999999" is incompatible with stage "prod" (expected "123456789012").',
+    });
+  });
+
+  it('allows account-agnostic policy when allowedAccountId is omitted', () => {
+    const policy = resolveSecretArnStagePolicy({
+      stage: 'dev',
+      allowedRegion: 'us-east-1',
+    });
+
+    const result = validateSecretArnAgainstStagePolicy({
+      secretArn: 'arn:aws:secretsmanager:us-east-1:999999999999:secret:acme/source-db',
+      policy,
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+});


### PR DESCRIPTION
Closes #182

> Obrigatório: substitua `<issue_number>` por uma issue real (ex.: `Closes #93`).
> Também são aceitos `Fixes #<issue>` e `Resolves #<issue>`.

---

## 🎯 Objetivo

Garantir consistência de segredos entre deploy e runtime por stage, validando `secretArn` em cadastro/edição e no collector antes de chamar Secrets Manager.

---

## 🧠 Decisão Técnica

Criado módulo compartilhado `secret-arn-stage-policy` para:
- resolver política por stage (`SECRETS_ALLOWED_REGION`, `SECRETS_ALLOWED_ACCOUNT_ID`);
- validar `secretArn` contra região/conta permitidas;
- produzir motivo explícito para rejeição.

Aplicado em:
- `POST /sources` (`create-source`): rejeita `secretArn` incompatível com `SECRET_ARN_STAGE_MISMATCH`.
- `PATCH /sources/{id}` (`update-source`): valida estado final merged antes de persistir.
- `collector`: valida em runtime antes de consultar Secrets Manager; em incompatibilidade falha com erro rastreável e sem chamada ao Secrets Manager.

`serverless.yml` atualizado para unificar contrato deploy/runtime com envs:
- `SECRETS_ALLOWED_REGION`
- `SECRETS_ALLOWED_ACCOUNT_ID`

---

## 🧪 BDD Validado

Dado uma política de stage (`us-east-1` / conta esperada)
Quando uma fonte é criada/atualizada com `secretArn` incompatível
Então a API retorna `400` com `SECRET_ARN_STAGE_MISMATCH` e mensagem clara.

Dado um `secretArn` incompatível salvo na fonte
Quando o collector executa
Então ele falha antes do Secrets Manager e não realiza leitura de segredo.

---

## 🏗 Impacto Arquitetural

- [ ] Domain
- [ ] Application
- [x] Infrastructure
- [x] Interfaces
- [ ] Read Model
- [x] Worker
- [ ] Frontend

---

## 🔍 Observabilidade

- [ ] correlationId propagado
- [x] logs estruturados
- [ ] métricas
- [ ] traces

---

## 🧪 Testes

- [x] Unit
- [ ] Integration
- [ ] E2E

Comandos executados:
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`

---

## 🔥 Tipo de Release

- [ ] PATCH
- [x] MINOR
- [ ] MAJOR

---

## ✔ Checklist

- [x] Segue DDD
- [x] Segue SOLID
- [x] Não mistura camadas
- [x] Sem código morto
