### PR TITLE
fix: propagar tenantId end-to-end nas consumidoras de integração

### DIFF
--- a/src/handlers/shared/create-integration-consumer-handler.ts
+++ b/src/handlers/shared/create-integration-consumer-handler.ts
@@ -39,6 +39,7 @@ export interface CreateIntegrationConsumerHandlerParams {
 export interface IntegrationConsumerPayload {
   eventType: 'customer.persisted';
   sourceId: string;
+  tenantId: string;
   correlationId: string;
   publishedAt: string;
   customer: Record<string, unknown>;
@@ -103,6 +104,7 @@ const parseConsumerPayload = (rawBody: string): IntegrationConsumerPayload => {
 
   const eventType = parsed.eventType;
   const sourceId = parsed.sourceId;
+  const tenantId = parsed.tenantId;
   const correlationId = parsed.correlationId;
   const publishedAt = parsed.publishedAt;
   const customer = parsed.customer;
@@ -112,6 +114,9 @@ const parseConsumerPayload = (rawBody: string): IntegrationConsumerPayload => {
   }
   if (!isNonEmptyString(sourceId)) {
     throw new Error('missing_source_id');
+  }
+  if (!isNonEmptyString(tenantId)) {
+    throw new Error('missing_tenant_id');
   }
   if (!isNonEmptyString(correlationId)) {
     throw new Error('missing_correlation_id');
@@ -126,6 +131,7 @@ const parseConsumerPayload = (rawBody: string): IntegrationConsumerPayload => {
   return {
     eventType,
     sourceId: sourceId.trim(),
+    tenantId: tenantId.trim(),
     correlationId: correlationId.trim(),
     publishedAt: publishedAt.trim(),
     customer,

--- a/src/infra/integrations/external-api-client.ts
+++ b/src/infra/integrations/external-api-client.ts
@@ -115,6 +115,7 @@ export const createIntegrationExternalApiClient = ({
         eventType: payload.eventType,
         integrationId: normalizedIntegrationName,
         sourceId: payload.sourceId,
+        tenantId: payload.tenantId,
         correlationId: payload.correlationId,
         occurredAt: payload.publishedAt,
         customer: payload.customer,

--- a/tests/unit/handlers/hubspot-consumer.test.ts
+++ b/tests/unit/handlers/hubspot-consumer.test.ts
@@ -60,7 +60,7 @@ describe('hubspot-consumer handler', () => {
         Records: [
           {
             messageId: 'msg-1',
-            body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+            body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
           },
         ],
       }),
@@ -100,7 +100,7 @@ describe('hubspot-consumer handler', () => {
         Records: [
           {
             messageId: 'msg-1',
-            body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+            body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
             attributes: {
               ApproximateReceiveCount: '1',
             },

--- a/tests/unit/handlers/salesforce-consumer.test.ts
+++ b/tests/unit/handlers/salesforce-consumer.test.ts
@@ -60,7 +60,7 @@ describe('salesforce-consumer handler', () => {
         Records: [
           {
             messageId: 'msg-1',
-            body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+            body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
           },
         ],
       }),
@@ -100,7 +100,7 @@ describe('salesforce-consumer handler', () => {
         Records: [
           {
             messageId: 'msg-1',
-            body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+            body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
             attributes: {
               ApproximateReceiveCount: '2',
             },

--- a/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
+++ b/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
@@ -84,7 +84,7 @@ describe('createIntegrationConsumerHandler', () => {
       Records: [
         {
           messageId: 'msg-1',
-          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
         },
       ],
     });
@@ -120,6 +120,7 @@ describe('createIntegrationConsumerHandler', () => {
         payload: {
           eventType: 'customer.persisted',
           sourceId: 'source-1',
+          tenantId: 'tenant-acme',
           correlationId: 'exec-1',
           publishedAt: '2026-03-04T10:00:00.000Z',
           customer: { id: 1 },
@@ -164,7 +165,7 @@ describe('createIntegrationConsumerHandler', () => {
       Records: [
         {
           messageId: 'msg-valid',
-          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
         },
         {
           messageId: 'msg-invalid-json',
@@ -172,7 +173,7 @@ describe('createIntegrationConsumerHandler', () => {
         },
         {
           messageId: 'msg-invalid-schema',
-          body: '{"eventType":"customer.persisted","sourceId":"","correlationId":"exec-2","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":2}}',
+          body: '{"eventType":"customer.persisted","sourceId":"","tenantId":"tenant-acme","correlationId":"exec-2","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":2}}',
         },
       ],
     });
@@ -211,14 +212,14 @@ describe('createIntegrationConsumerHandler', () => {
       Records: [
         {
           messageId: 'msg-permanent',
-          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
           attributes: {
             ApproximateReceiveCount: '3',
           },
         },
         {
           messageId: 'msg-transient',
-          body: '{"eventType":"customer.persisted","sourceId":"source-2","correlationId":"exec-2","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":2}}',
+          body: '{"eventType":"customer.persisted","sourceId":"source-2","tenantId":"tenant-acme","correlationId":"exec-2","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":2}}',
           attributes: {
             ApproximateReceiveCount: '1',
           },
@@ -249,7 +250,7 @@ describe('createIntegrationConsumerHandler', () => {
       Records: [
         {
           messageId: 'msg-redelivery',
-          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
         },
       ],
     });
@@ -300,7 +301,7 @@ describe('createIntegrationConsumerHandler', () => {
       Records: [
         {
           messageId: 'msg-1',
-          body: '{"eventType":"customer.persisted","sourceId":"source-1","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
           attributes: {
             ApproximateReceiveCount: '1',
           },

--- a/tests/unit/infra/integrations/external-api-client.test.ts
+++ b/tests/unit/infra/integrations/external-api-client.test.ts
@@ -56,6 +56,7 @@ describe('createIntegrationExternalApiClient', () => {
         payload: {
           eventType: 'customer.persisted',
           sourceId: 'source-1',
+          tenantId: 'tenant-acme',
           correlationId: 'exec-1',
           publishedAt: '2026-03-04T10:00:00.000Z',
           customer: { id: 1 },
@@ -76,6 +77,7 @@ describe('createIntegrationExternalApiClient', () => {
           eventType: 'customer.persisted',
           integrationId: 'salesforce',
           sourceId: 'source-1',
+          tenantId: 'tenant-acme',
           correlationId: 'exec-1',
           occurredAt: '2026-03-04T10:00:00.000Z',
           customer: { id: 1 },
@@ -123,6 +125,7 @@ describe('createIntegrationExternalApiClient', () => {
         payload: {
           eventType: 'customer.persisted',
           sourceId: 'source-1',
+          tenantId: 'tenant-acme',
           correlationId: 'exec-1',
           publishedAt: '2026-03-04T10:00:00.000Z',
           customer: { id: 1 },
@@ -149,6 +152,7 @@ describe('createIntegrationExternalApiClient', () => {
         payload: {
           eventType: 'customer.persisted',
           sourceId: 'source-1',
+          tenantId: 'tenant-acme',
           correlationId: 'exec-1',
           publishedAt: '2026-03-04T10:00:00.000Z',
           customer: { id: 1 },
@@ -176,6 +180,7 @@ describe('createIntegrationExternalApiClient', () => {
         payload: {
           eventType: 'customer.persisted',
           sourceId: 'source-1',
+          tenantId: 'tenant-acme',
           correlationId: 'exec-1',
           publishedAt: '2026-03-04T10:00:00.000Z',
           customer: { id: 1 },


### PR DESCRIPTION
Closes #187

## 🧪 BDD
- **Given** uma mensagem SNS/SQS de `customer.persisted` com `tenantId`
- **When** a consumidora de integração processa e chama a API externa
- **Then** o `tenantId` é validado no parser e propagado no payload de saída
- **And** mensagens sem `tenantId` passam a ser inválidas no consumer

## 🔥 Tipo de Release
- [x] `patch`
- [ ] `minor`
- [ ] `major`

## ✅ Checklist
- [x] Ajustado contrato `IntegrationConsumerPayload` para exigir `tenantId`
- [x] Ajustado parser para validar `missing_tenant_id`
- [x] Ajustado client externo para enviar `tenantId`
- [x] Atualizados testes unitários impactados
- [x] `npm test` (escopo alterado) e `npm run typecheck` executados com sucesso
