### PR TITLE
refactor: consumidoras SQS usam dedup apenas por correlationId

### DIFF
--- a/.codex/runs/platform_architect-issue-189.md
+++ b/.codex/runs/platform_architect-issue-189.md
@@ -1,0 +1,28 @@
+## Issue #189 — [EPIC 6] Ajustar consumidoras SQS para usar apenas correlationId
+
+### Objetivo
+Eliminar a deduplicação persistida por repositório de idempotência nas consumidoras SQS e adotar deduplicação orientada exclusivamente por `correlationId` no fluxo de consumo.
+
+### Decisões arquiteturais
+1. **Remoção do acoplamento com `CollectorIdempotencyRepository` nas consumidoras**
+- `createIntegrationConsumerHandler` deixa de receber `idempotencyRepository`/TTL.
+- `salesforce-consumer` e `hubspot-consumer` deixam de instanciar repositório DynamoDB para dedup.
+
+2. **Deduplicação no escopo do lote usando apenas `correlationId`**
+- No processamento de cada batch SQS, manter conjunto de `correlationId` já entregues com sucesso.
+- Mensagem com `correlationId` repetido no mesmo batch é descartada como deduplicada.
+- `tenantId` e `sourceId` deixam de participar de qualquer chave de dedup do consumer.
+
+3. **IAM mínimo alinhado ao novo comportamento**
+- Remover permissões `dynamodb:PutItem`/`dynamodb:UpdateItem` das roles das consumidoras, já que não haverá mais gravação de claims de idempotência por elas.
+
+4. **Cobertura de testes orientada ao novo contrato**
+- Atualizar testes unitários do handler compartilhado para dedup por `correlationId`.
+- Atualizar testes das consumidoras para não mockar `dynamodb-collector-idempotency-repository`.
+- Garantir cenário em que mesmo `tenantId` com `correlationId` diferente continua processando.
+
+### Critérios técnicos de aceite
+- Consumidoras processam mensagens sem depender de `idempotencyRepository`.
+- Deduplicação do consumer usa somente `correlationId`.
+- Testes refletem ausência de mocks do repositório de idempotência no fluxo das consumidoras.
+- Documentação operacional explicita o comportamento de dedup por `correlationId`.

--- a/.codex/runs/qa-issue-189.md
+++ b/.codex/runs/qa-issue-189.md
@@ -1,0 +1,23 @@
+**QA — Issue #189 (Ajustar consumidoras SQS para usar apenas correlationId)**
+
+**Achados por severidade**
+
+1. Crítico: nenhum.
+2. Alto: nenhum bloqueante.
+3. Médio: nenhum.
+4. Baixo: logs de testes exibem `runtime.metrics.publish_failed` em ambiente de teste por ausência de callback de import dinâmico de VM; não afeta status funcional do escopo.
+
+**Checklist de aceite da issue**
+
+- [x] Consumidoras deduplicam mensagens equivalentes por `correlationId`.
+- [x] `tenantId`/`sourceId` não participam da chave de dedup das consumidoras.
+- [x] Mensagens com `correlationId` distinto continuam sendo processadas, mesmo com `tenantId` igual.
+- [x] Testes das consumidoras e handler compartilhado não dependem de mocks de `idempotencyRepository`.
+- [x] Documentação atualizada com comportamento de dedup por `correlationId`.
+
+**Evidências de validação**
+
+- `npm run lint` ✅
+- `npm run test` ✅
+
+**Status final**: **APPROVED**

--- a/.codex/runs/worker-issue-189.md
+++ b/.codex/runs/worker-issue-189.md
@@ -1,0 +1,40 @@
+**Status de execução — Issue #189**
+
+**Escopo implementado**
+
+- Remoção da dependência de `CollectorIdempotencyRepository` no consumer compartilhado:
+  - `src/handlers/shared/create-integration-consumer-handler.ts`
+  - deduplicação agora ocorre no lote SQS apenas por `correlationId`;
+  - removidos parâmetros `idempotencyRepository` e `idempotencyTtlSeconds`.
+- Simplificação dos handlers de integração:
+  - `src/handlers/salesforce-consumer.ts`
+  - `src/handlers/hubspot-consumer.ts`
+  - removidos imports/validação/env bootstrap de idempotência persistida.
+- Ajuste de IAM mínimo para consumidoras:
+  - `serverless.yml`
+  - removidos statements de `dynamodb:PutItem`/`dynamodb:UpdateItem` das roles `SalesforceConsumerExecutionRole` e `HubspotConsumerExecutionRole`;
+  - removida env global `CONSUMER_IDEMPOTENCY_TTL_SECONDS` (não utilizada após mudança).
+- Documentação atualizada:
+  - `README.md`
+  - fluxo de ingestão passa a explicitar dedup das consumidoras por `correlationId`.
+
+**Testes atualizados**
+
+- `tests/unit/handlers/shared/create-integration-consumer-handler.test.ts`
+  - removida dependência de spy/mocks de idempotency repository;
+  - adicionado cenário de dedup por `correlationId` independente de `tenantId/sourceId`;
+  - adicionado cenário de `tenantId` duplicado com `correlationId` distinto (processa ambos).
+- `tests/unit/handlers/salesforce-consumer.test.ts`
+- `tests/unit/handlers/hubspot-consumer.test.ts`
+  - removidos mocks de `dynamodb-collector-idempotency-repository`;
+  - setup deixa de depender de `IDEMPOTENCY_TABLE_NAME`.
+
+**Validações executadas**
+
+- `npm ci` ✅
+- `npm run lint` ✅
+- `npm run test` ✅ (35 suites, 173 testes)
+
+**Resultado**
+
+Issue #189 implementada com consumidoras SQS usando deduplicação apenas por `correlationId`, sem repositório de idempotência persistido no fluxo de consumo.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Componentes-chave:
 4. Coletora carrega configuração/segredo, executa query incremental e normaliza para modelo canônico.
 5. Lote válido é enviado para API oficial (`upsert-batch`) com idempotência por `sourceId + cursor + recordId`.
 6. Registros persistidos geram evento `customer.persisted` no SNS.
-7. Filas SQS por integração recebem fan-out; consumidores entregam para APIs externas.
+7. Filas SQS por integração recebem fan-out; consumidores deduplicam no lote por `correlationId` e entregam para APIs externas.
 8. Falhas de entrega excedentes são roteadas para DLQ, com alarmes e reprocessamento manual.
 
 ## Variáveis de ambiente essenciais

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,7 +42,6 @@ provider:
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_BASE_DELAY_MS, '200'}
     OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE: ${env:OFFICIAL_CUSTOMERS_UPSERT_RETRY_BACKOFF_RATE, '2'}
     COLLECTOR_IDEMPOTENCY_TTL_SECONDS: ${env:COLLECTOR_IDEMPOTENCY_TTL_SECONDS, '604800'}
-    CONSUMER_IDEMPOTENCY_TTL_SECONDS: ${env:CONSUMER_IDEMPOTENCY_TTL_SECONDS, '604800'}
     INTEGRATION_API_TIMEOUT_MS: ${env:INTEGRATION_API_TIMEOUT_MS, '5000'}
     METRICS_NAMESPACE: ${env:METRICS_NAMESPACE, 'AlertOrchestrationService/Runtime'}
     INTEGRATION_TARGETS: ${env:INTEGRATION_TARGETS, 'salesforce|hubspot'}
@@ -688,15 +687,6 @@ resources:
                     - logs:PutLogEvents
                   Resource:
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.salesforceConsumerFunctionName}:*
-                - Sid: WriteSalesforceConsumerIdempotencyClaims
-                  Effect: Allow
-                  Action:
-                    - dynamodb:PutItem
-                    - dynamodb:UpdateItem
-                  Resource:
-                    - Fn::GetAtt:
-                        - IdempotencyTable
-                        - Arn
                 - Sid: ReadSalesforceOutboundAuthSecret
                   Effect: Allow
                   Action:
@@ -747,15 +737,6 @@ resources:
                     - logs:PutLogEvents
                   Resource:
                     - Fn::Sub: arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${self:custom.naming.hubspotConsumerFunctionName}:*
-                - Sid: WriteHubspotConsumerIdempotencyClaims
-                  Effect: Allow
-                  Action:
-                    - dynamodb:PutItem
-                    - dynamodb:UpdateItem
-                  Resource:
-                    - Fn::GetAtt:
-                        - IdempotencyTable
-                        - Arn
                 - Sid: ReadHubspotOutboundAuthSecret
                   Effect: Allow
                   Action:

--- a/src/handlers/hubspot-consumer.ts
+++ b/src/handlers/hubspot-consumer.ts
@@ -9,7 +9,6 @@ import {
   IntegrationExternalApiTransientError,
   createIntegrationExternalApiClient,
 } from '../infra/integrations/external-api-client';
-import { createDynamoDbCollectorIdempotencyRepository } from '../infra/idempotency/dynamodb-collector-idempotency-repository';
 import { createFetchIntegrationHttpClient } from '../infra/integrations/fetch-integration-http-client';
 import { createCloudWatchMetricsPublisher } from '../infra/observability/cloudwatch-metrics-publisher';
 import { createIntegrationDeliveryMetricsPublisher } from '../infra/observability/integration-delivery-metrics-publisher';
@@ -19,8 +18,6 @@ import { createSecretsManagerOutboundAuthHeadersResolver } from '../infra/securi
 const HUBSPOT_INTEGRATION_NAME = 'hubspot';
 const HUBSPOT_TARGET_BASE_URL_ENV = 'HUBSPOT_INTEGRATION_TARGET_BASE_URL';
 const INTEGRATION_API_TIMEOUT_MS_ENV = 'INTEGRATION_API_TIMEOUT_MS';
-const IDEMPOTENCY_TABLE_NAME_ENV = 'IDEMPOTENCY_TABLE_NAME';
-const CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV = 'CONSUMER_IDEMPOTENCY_TTL_SECONDS';
 const HUBSPOT_AUTH_SECRET_ARN_ENV = 'HUBSPOT_INTEGRATION_AUTH_SECRET_ARN';
 const METRICS_NAMESPACE_ENV = 'METRICS_NAMESPACE';
 const METRICS_NAMESPACE_DEFAULT = 'AlertOrchestrationService/Runtime';
@@ -29,9 +26,6 @@ const SERVICE_NAME_ENV = 'SERVICE_NAME';
 const INTEGRATION_API_TIMEOUT_MS_DEFAULT = 5000;
 const INTEGRATION_API_TIMEOUT_MS_MIN = 100;
 const INTEGRATION_API_TIMEOUT_MS_MAX = 60000;
-const CONSUMER_IDEMPOTENCY_TTL_SECONDS_DEFAULT = 604_800;
-const CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN = 60;
-const CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX = 2_592_000;
 
 let cachedHandler:
   | ((event: IntegrationConsumerSqsEvent) => Promise<IntegrationConsumerSqsResult>)
@@ -58,26 +52,6 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     ) {
       throw new Error(
         `${INTEGRATION_API_TIMEOUT_MS_ENV} must be an integer between ${INTEGRATION_API_TIMEOUT_MS_MIN} and ${INTEGRATION_API_TIMEOUT_MS_MAX}.`,
-      );
-    }
-  }
-
-  const idempotencyTableName = process.env[IDEMPOTENCY_TABLE_NAME_ENV];
-  if (!idempotencyTableName || idempotencyTableName.trim().length === 0) {
-    throw new Error(`${IDEMPOTENCY_TABLE_NAME_ENV} is required.`);
-  }
-
-  let idempotencyTtlSeconds = CONSUMER_IDEMPOTENCY_TTL_SECONDS_DEFAULT;
-  const idempotencyTtlRawValue = process.env[CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV];
-  if (idempotencyTtlRawValue) {
-    idempotencyTtlSeconds = Number.parseInt(idempotencyTtlRawValue, 10);
-    if (
-      !Number.isInteger(idempotencyTtlSeconds) ||
-      idempotencyTtlSeconds < CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN ||
-      idempotencyTtlSeconds > CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX
-    ) {
-      throw new Error(
-        `${CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV} must be an integer between ${CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN} and ${CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX}.`,
       );
     }
   }
@@ -110,10 +84,6 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
   cachedHandler = createIntegrationConsumerHandler({
     integrationName: HUBSPOT_INTEGRATION_NAME,
     targetBaseUrl,
-    idempotencyRepository: createDynamoDbCollectorIdempotencyRepository({
-      tableName: idempotencyTableName,
-    }),
-    idempotencyTtlSeconds,
     processRecord: ({ messageId, payload }) => sendCustomerEvent({ messageId, payload }),
     classifyError: (error) => {
       if (error instanceof IntegrationExternalApiAuthError) {

--- a/src/handlers/salesforce-consumer.ts
+++ b/src/handlers/salesforce-consumer.ts
@@ -9,7 +9,6 @@ import {
   IntegrationExternalApiTransientError,
   createIntegrationExternalApiClient,
 } from '../infra/integrations/external-api-client';
-import { createDynamoDbCollectorIdempotencyRepository } from '../infra/idempotency/dynamodb-collector-idempotency-repository';
 import { createFetchIntegrationHttpClient } from '../infra/integrations/fetch-integration-http-client';
 import { createCloudWatchMetricsPublisher } from '../infra/observability/cloudwatch-metrics-publisher';
 import { createIntegrationDeliveryMetricsPublisher } from '../infra/observability/integration-delivery-metrics-publisher';
@@ -19,8 +18,6 @@ import { createSecretsManagerOutboundAuthHeadersResolver } from '../infra/securi
 const SALESFORCE_INTEGRATION_NAME = 'salesforce';
 const SALESFORCE_TARGET_BASE_URL_ENV = 'SALESFORCE_INTEGRATION_TARGET_BASE_URL';
 const INTEGRATION_API_TIMEOUT_MS_ENV = 'INTEGRATION_API_TIMEOUT_MS';
-const IDEMPOTENCY_TABLE_NAME_ENV = 'IDEMPOTENCY_TABLE_NAME';
-const CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV = 'CONSUMER_IDEMPOTENCY_TTL_SECONDS';
 const SALESFORCE_AUTH_SECRET_ARN_ENV = 'SALESFORCE_INTEGRATION_AUTH_SECRET_ARN';
 const METRICS_NAMESPACE_ENV = 'METRICS_NAMESPACE';
 const METRICS_NAMESPACE_DEFAULT = 'AlertOrchestrationService/Runtime';
@@ -29,9 +26,6 @@ const SERVICE_NAME_ENV = 'SERVICE_NAME';
 const INTEGRATION_API_TIMEOUT_MS_DEFAULT = 5000;
 const INTEGRATION_API_TIMEOUT_MS_MIN = 100;
 const INTEGRATION_API_TIMEOUT_MS_MAX = 60000;
-const CONSUMER_IDEMPOTENCY_TTL_SECONDS_DEFAULT = 604_800;
-const CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN = 60;
-const CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX = 2_592_000;
 
 let cachedHandler:
   | ((event: IntegrationConsumerSqsEvent) => Promise<IntegrationConsumerSqsResult>)
@@ -58,26 +52,6 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
     ) {
       throw new Error(
         `${INTEGRATION_API_TIMEOUT_MS_ENV} must be an integer between ${INTEGRATION_API_TIMEOUT_MS_MIN} and ${INTEGRATION_API_TIMEOUT_MS_MAX}.`,
-      );
-    }
-  }
-
-  const idempotencyTableName = process.env[IDEMPOTENCY_TABLE_NAME_ENV];
-  if (!idempotencyTableName || idempotencyTableName.trim().length === 0) {
-    throw new Error(`${IDEMPOTENCY_TABLE_NAME_ENV} is required.`);
-  }
-
-  let idempotencyTtlSeconds = CONSUMER_IDEMPOTENCY_TTL_SECONDS_DEFAULT;
-  const idempotencyTtlRawValue = process.env[CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV];
-  if (idempotencyTtlRawValue) {
-    idempotencyTtlSeconds = Number.parseInt(idempotencyTtlRawValue, 10);
-    if (
-      !Number.isInteger(idempotencyTtlSeconds) ||
-      idempotencyTtlSeconds < CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN ||
-      idempotencyTtlSeconds > CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX
-    ) {
-      throw new Error(
-        `${CONSUMER_IDEMPOTENCY_TTL_SECONDS_ENV} must be an integer between ${CONSUMER_IDEMPOTENCY_TTL_SECONDS_MIN} and ${CONSUMER_IDEMPOTENCY_TTL_SECONDS_MAX}.`,
       );
     }
   }
@@ -110,10 +84,6 @@ const getHandler = (): ((event: IntegrationConsumerSqsEvent) => Promise<Integrat
   cachedHandler = createIntegrationConsumerHandler({
     integrationName: SALESFORCE_INTEGRATION_NAME,
     targetBaseUrl,
-    idempotencyRepository: createDynamoDbCollectorIdempotencyRepository({
-      tableName: idempotencyTableName,
-    }),
-    idempotencyTtlSeconds,
     processRecord: ({ messageId, payload }) => sendCustomerEvent({ messageId, payload }),
     classifyError: (error) => {
       if (error instanceof IntegrationExternalApiAuthError) {

--- a/src/handlers/shared/create-integration-consumer-handler.ts
+++ b/src/handlers/shared/create-integration-consumer-handler.ts
@@ -1,5 +1,4 @@
 import { createStructuredLogger } from '../../shared/logging/structured-logger';
-import type { CollectorIdempotencyRepository } from '../../domain/collector/collector-idempotency-repository';
 
 export interface IntegrationConsumerSqsRecord {
   messageId: string;
@@ -22,10 +21,6 @@ export interface IntegrationConsumerSqsResult {
 export interface CreateIntegrationConsumerHandlerParams {
   integrationName: string;
   targetBaseUrl: string;
-  idempotencyRepository?: CollectorIdempotencyRepository;
-  idempotencyTtlSeconds?: number;
-  now?: () => string;
-  nowMs?: () => number;
   processRecord?: (record: {
     messageId: string;
     payload: IntegrationConsumerPayload;
@@ -51,44 +46,11 @@ const isNonEmptyString = (value: unknown): value is string =>
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const DEFAULT_IDEMPOTENCY_TTL_SECONDS = 604_800;
-
-const noopIdempotencyRepository: CollectorIdempotencyRepository = {
-  tryClaim: () => Promise.resolve(true),
-  markCompleted: () => Promise.resolve(),
-};
-
-const resolveDeduplicationRecordId = ({
-  messageId,
-  payload,
-}: {
-  messageId: string;
-  payload: IntegrationConsumerPayload;
-}): string => {
-  const customerId = payload.customer.id;
-  if (typeof customerId === 'string') {
-    const normalizedCustomerId = customerId.trim();
-    if (normalizedCustomerId.length > 0) {
-      return normalizedCustomerId;
-    }
-  }
-
-  if (typeof customerId === 'number' && Number.isFinite(customerId)) {
-    return String(customerId);
-  }
-
-  return messageId.trim();
-};
-
 const buildDeduplicationKey = ({
-  integrationName,
   correlationId,
-  recordId,
 }: {
-  integrationName: string;
   correlationId: string;
-  recordId: string;
-}): string => `consumer:${integrationName}:${correlationId}:${recordId}`;
+}): string => correlationId;
 
 const parseConsumerPayload = (rawBody: string): IntegrationConsumerPayload => {
   let parsed: unknown;
@@ -141,10 +103,6 @@ const parseConsumerPayload = (rawBody: string): IntegrationConsumerPayload => {
 export const createIntegrationConsumerHandler = ({
   integrationName,
   targetBaseUrl,
-  idempotencyRepository = noopIdempotencyRepository,
-  idempotencyTtlSeconds = DEFAULT_IDEMPOTENCY_TTL_SECONDS,
-  now = () => new Date().toISOString(),
-  nowMs = Date.now,
   processRecord = () => Promise.resolve(),
   classifyError = () => 'transient',
   logger = createStructuredLogger({
@@ -162,9 +120,6 @@ export const createIntegrationConsumerHandler = ({
       `targetBaseUrl is required for integration consumer "${normalizedIntegrationName}".`,
     );
   }
-  if (!Number.isInteger(idempotencyTtlSeconds) || idempotencyTtlSeconds <= 0) {
-    throw new Error('idempotencyTtlSeconds must be a positive integer.');
-  }
 
   return async (event: IntegrationConsumerSqsEvent): Promise<IntegrationConsumerSqsResult> => {
     const records = event.Records ?? [];
@@ -180,33 +135,17 @@ export const createIntegrationConsumerHandler = ({
     let retriedCount = 0;
     let deduplicatedCount = 0;
     let discardedCount = 0;
+    const deliveredCorrelationIds = new Set<string>();
+
     for (const record of records) {
       let payload: IntegrationConsumerPayload | null = null;
       try {
         payload = parseConsumerPayload(record.body);
-        const deduplicationRecordId = resolveDeduplicationRecordId({
-          messageId: record.messageId,
-          payload,
-        });
         const deduplicationKey = buildDeduplicationKey({
-          integrationName: normalizedIntegrationName,
           correlationId: payload.correlationId,
-          recordId: deduplicationRecordId,
         });
-        const claimCreatedAt = now();
-        const claimExpiration = Math.floor(nowMs() / 1000) + idempotencyTtlSeconds;
-        const claimed = await idempotencyRepository.tryClaim({
-          deduplicationKey,
-          scope: 'consumer',
-          status: 'PENDING',
-          sourceId: payload.sourceId,
-          recordId: deduplicationRecordId,
-          cursor: payload.publishedAt,
-          correlationId: payload.correlationId,
-          createdAt: claimCreatedAt,
-          expiresAtEpochSeconds: claimExpiration,
-        });
-        if (!claimed) {
+
+        if (deliveredCorrelationIds.has(deduplicationKey)) {
           deduplicatedCount += 1;
           logger.info('integration.consumer.deduplicated', {
             integrationName: normalizedIntegrationName,
@@ -223,11 +162,7 @@ export const createIntegrationConsumerHandler = ({
           integrationName: normalizedIntegrationName,
           targetBaseUrl: normalizedTargetBaseUrl,
         });
-        await idempotencyRepository.markCompleted({
-          deduplicationKey,
-          completedAt: now(),
-          expiresAtEpochSeconds: claimExpiration,
-        });
+        deliveredCorrelationIds.add(deduplicationKey);
         processedCount += 1;
       } catch (error) {
         const classification = classifyError(error);

--- a/tests/unit/handlers/hubspot-consumer.test.ts
+++ b/tests/unit/handlers/hubspot-consumer.test.ts
@@ -3,10 +3,6 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 describe('hubspot-consumer handler', () => {
   const originalEnv = process.env;
   const originalFetch = global.fetch;
-  const mockIdempotencyRepositoryFactory = () => ({
-    tryClaim: jest.fn(() => Promise.resolve(true)),
-    markCompleted: jest.fn(() => Promise.resolve()),
-  });
 
   afterEach(() => {
     process.env = { ...originalEnv };
@@ -16,10 +12,6 @@ describe('hubspot-consumer handler', () => {
 
   it('fails when target URL env var is missing', async () => {
     jest.resetModules();
-    const idempotencyRepository = mockIdempotencyRepositoryFactory();
-    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
-      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
-    }));
     process.env = { ...originalEnv };
     delete process.env.HUBSPOT_INTEGRATION_TARGET_BASE_URL;
 
@@ -31,10 +23,6 @@ describe('hubspot-consumer handler', () => {
 
   it('initializes with integration-specific configuration', async () => {
     jest.resetModules();
-    const idempotencyRepository = mockIdempotencyRepositoryFactory();
-    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
-      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
-    }));
     jest.doMock('../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver', () => ({
       createSecretsManagerOutboundAuthHeadersResolver: () => () =>
         Promise.resolve({
@@ -44,7 +32,6 @@ describe('hubspot-consumer handler', () => {
     process.env = {
       ...originalEnv,
       HUBSPOT_INTEGRATION_TARGET_BASE_URL: 'https://hubspot.internal',
-      IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
       HUBSPOT_INTEGRATION_AUTH_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123:secret:hubspot',
     };
     global.fetch = jest.fn(() =>
@@ -71,10 +58,6 @@ describe('hubspot-consumer handler', () => {
 
   it('retries transient 5xx external errors by returning batch item failure', async () => {
     jest.resetModules();
-    const idempotencyRepository = mockIdempotencyRepositoryFactory();
-    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
-      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
-    }));
     jest.doMock('../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver', () => ({
       createSecretsManagerOutboundAuthHeadersResolver: () => () =>
         Promise.resolve({
@@ -84,7 +67,6 @@ describe('hubspot-consumer handler', () => {
     process.env = {
       ...originalEnv,
       HUBSPOT_INTEGRATION_TARGET_BASE_URL: 'https://hubspot.internal',
-      IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
       HUBSPOT_INTEGRATION_AUTH_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123:secret:hubspot',
     };
     global.fetch = jest.fn(() =>

--- a/tests/unit/handlers/salesforce-consumer.test.ts
+++ b/tests/unit/handlers/salesforce-consumer.test.ts
@@ -3,10 +3,6 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 describe('salesforce-consumer handler', () => {
   const originalEnv = process.env;
   const originalFetch = global.fetch;
-  const mockIdempotencyRepositoryFactory = () => ({
-    tryClaim: jest.fn(() => Promise.resolve(true)),
-    markCompleted: jest.fn(() => Promise.resolve()),
-  });
 
   afterEach(() => {
     process.env = { ...originalEnv };
@@ -16,10 +12,6 @@ describe('salesforce-consumer handler', () => {
 
   it('fails when target URL env var is missing', async () => {
     jest.resetModules();
-    const idempotencyRepository = mockIdempotencyRepositoryFactory();
-    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
-      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
-    }));
     process.env = { ...originalEnv };
     delete process.env.SALESFORCE_INTEGRATION_TARGET_BASE_URL;
 
@@ -31,10 +23,6 @@ describe('salesforce-consumer handler', () => {
 
   it('initializes with integration-specific configuration', async () => {
     jest.resetModules();
-    const idempotencyRepository = mockIdempotencyRepositoryFactory();
-    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
-      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
-    }));
     jest.doMock('../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver', () => ({
       createSecretsManagerOutboundAuthHeadersResolver: () => () =>
         Promise.resolve({
@@ -44,7 +32,6 @@ describe('salesforce-consumer handler', () => {
     process.env = {
       ...originalEnv,
       SALESFORCE_INTEGRATION_TARGET_BASE_URL: 'https://salesforce.internal',
-      IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
       SALESFORCE_INTEGRATION_AUTH_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123:secret:salesforce',
     };
     global.fetch = jest.fn(() =>
@@ -71,10 +58,6 @@ describe('salesforce-consumer handler', () => {
 
   it('discards permanent 4xx external errors without retrying the SQS message', async () => {
     jest.resetModules();
-    const idempotencyRepository = mockIdempotencyRepositoryFactory();
-    jest.doMock('../../../src/infra/idempotency/dynamodb-collector-idempotency-repository', () => ({
-      createDynamoDbCollectorIdempotencyRepository: () => idempotencyRepository,
-    }));
     jest.doMock('../../../src/infra/security/secrets-manager-outbound-auth-headers-resolver', () => ({
       createSecretsManagerOutboundAuthHeadersResolver: () => () =>
         Promise.resolve({
@@ -84,7 +67,6 @@ describe('salesforce-consumer handler', () => {
     process.env = {
       ...originalEnv,
       SALESFORCE_INTEGRATION_TARGET_BASE_URL: 'https://salesforce.internal',
-      IDEMPOTENCY_TABLE_NAME: 'idempotency-table',
       SALESFORCE_INTEGRATION_AUTH_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123:secret:salesforce',
     };
     global.fetch = jest.fn(() =>

--- a/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
+++ b/tests/unit/handlers/shared/create-integration-consumer-handler.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
 
-import type {
-  CollectorIdempotencyClaim,
-  CollectorIdempotencyCompletion,
-} from '../../../../src/domain/collector/collector-idempotency-repository';
 import {
   createIntegrationConsumerHandler,
   type IntegrationConsumerPayload,
@@ -36,48 +32,15 @@ class SpyRecordProcessor {
   };
 }
 
-class SpyIntegrationConsumerIdempotencyRepository {
-  public readonly tryClaimCalls: CollectorIdempotencyClaim[] = [];
-  public readonly markCompletedCalls: CollectorIdempotencyCompletion[] = [];
-  private readonly statusByKey = new Map<string, 'PENDING' | 'COMPLETED'>();
-
-  constructor(preCompletedKeys: string[] = []) {
-    for (const key of preCompletedKeys) {
-      this.statusByKey.set(key, 'COMPLETED');
-    }
-  }
-
-  tryClaim = (claim: CollectorIdempotencyClaim): Promise<boolean> => {
-    this.tryClaimCalls.push(claim);
-    const currentStatus = this.statusByKey.get(claim.deduplicationKey);
-    if (currentStatus === 'COMPLETED') {
-      return Promise.resolve(false);
-    }
-
-    this.statusByKey.set(claim.deduplicationKey, claim.status ?? 'COMPLETED');
-    return Promise.resolve(true);
-  };
-
-  markCompleted = (params: CollectorIdempotencyCompletion): Promise<void> => {
-    this.markCompletedCalls.push(params);
-    this.statusByKey.set(params.deduplicationKey, 'COMPLETED');
-    return Promise.resolve();
-  };
-}
-
 describe('createIntegrationConsumerHandler', () => {
   it('creates reusable consumer handler and returns no batch item failures', async () => {
     const logger = new SpyLogger();
     const recordProcessor = new SpyRecordProcessor();
-    const idempotencyRepository = new SpyIntegrationConsumerIdempotencyRepository();
     const handler = createIntegrationConsumerHandler({
       integrationName: 'salesforce',
       targetBaseUrl: 'https://salesforce.internal',
-      idempotencyRepository,
       processRecord: recordProcessor.invoke,
       logger,
-      now: () => '2026-03-04T11:00:00.000Z',
-      nowMs: () => 1000,
     });
 
     const result = await handler({
@@ -127,26 +90,6 @@ describe('createIntegrationConsumerHandler', () => {
         },
         integrationName: 'salesforce',
         targetBaseUrl: 'https://salesforce.internal',
-      },
-    ]);
-    expect(idempotencyRepository.tryClaimCalls).toEqual([
-      {
-        deduplicationKey: 'consumer:salesforce:exec-1:1',
-        scope: 'consumer',
-        status: 'PENDING',
-        sourceId: 'source-1',
-        recordId: '1',
-        cursor: '2026-03-04T10:00:00.000Z',
-        correlationId: 'exec-1',
-        createdAt: '2026-03-04T11:00:00.000Z',
-        expiresAtEpochSeconds: 604801,
-      },
-    ]);
-    expect(idempotencyRepository.markCompletedCalls).toEqual([
-      {
-        deduplicationKey: 'consumer:salesforce:exec-1:1',
-        completedAt: '2026-03-04T11:00:00.000Z',
-        expiresAtEpochSeconds: 604801,
       },
     ]);
   });
@@ -232,16 +175,12 @@ describe('createIntegrationConsumerHandler', () => {
     });
   });
 
-  it('deduplicates redelivered message already completed for the same customer event', async () => {
+  it('deduplicates by correlationId only, independent of tenantId/sourceId', async () => {
     const logger = new SpyLogger();
     const recordProcessor = new SpyRecordProcessor();
-    const idempotencyRepository = new SpyIntegrationConsumerIdempotencyRepository([
-      'consumer:hubspot:exec-1:1',
-    ]);
     const handler = createIntegrationConsumerHandler({
       integrationName: 'hubspot',
       targetBaseUrl: 'https://hubspot.internal',
-      idempotencyRepository,
       processRecord: recordProcessor.invoke,
       logger,
     });
@@ -249,8 +188,12 @@ describe('createIntegrationConsumerHandler', () => {
     const result = await handler({
       Records: [
         {
-          messageId: 'msg-redelivery',
-          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+          messageId: 'msg-first',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-shared","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+        },
+        {
+          messageId: 'msg-duplicate-correlation',
+          body: '{"eventType":"customer.persisted","sourceId":"source-2","tenantId":"tenant-other","correlationId":"exec-shared","publishedAt":"2026-03-04T10:01:00.000Z","customer":{"id":2}}',
         },
       ],
     });
@@ -258,7 +201,7 @@ describe('createIntegrationConsumerHandler', () => {
     expect(result).toEqual({
       batchItemFailures: [],
     });
-    expect(recordProcessor.calls).toEqual([]);
+    expect(recordProcessor.calls).toHaveLength(1);
     expect(
       logger.infoCalls.some(([eventName]) => eventName === 'integration.consumer.deduplicated'),
     ).toBe(true);
@@ -267,8 +210,8 @@ describe('createIntegrationConsumerHandler', () => {
         'integration.consumer.batch_summary',
         {
           integrationName: 'hubspot',
-          recordsCount: 1,
-          processedCount: 0,
+          recordsCount: 2,
+          processedCount: 1,
           retriedCount: 0,
           deduplicatedCount: 1,
           discardedCount: 0,
@@ -277,15 +220,40 @@ describe('createIntegrationConsumerHandler', () => {
     ]));
   });
 
-  it('keeps failed delivery pending and retries successfully on next attempt', async () => {
+  it('processes duplicated tenantId when correlationId is different', async () => {
+    const recordProcessor = new SpyRecordProcessor();
+    const handler = createIntegrationConsumerHandler({
+      integrationName: 'salesforce',
+      targetBaseUrl: 'https://salesforce.internal',
+      processRecord: recordProcessor.invoke,
+    });
+
+    const result = await handler({
+      Records: [
+        {
+          messageId: 'msg-1',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-1","publishedAt":"2026-03-04T10:00:00.000Z","customer":{"id":1}}',
+        },
+        {
+          messageId: 'msg-2',
+          body: '{"eventType":"customer.persisted","sourceId":"source-1","tenantId":"tenant-acme","correlationId":"exec-2","publishedAt":"2026-03-04T10:00:30.000Z","customer":{"id":2}}',
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      batchItemFailures: [],
+    });
+    expect(recordProcessor.calls).toHaveLength(2);
+  });
+
+  it('keeps failed delivery retryable and succeeds on the next attempt', async () => {
     class TransientError extends Error {}
 
-    const idempotencyRepository = new SpyIntegrationConsumerIdempotencyRepository();
     let shouldFail = true;
     const handler = createIntegrationConsumerHandler({
       integrationName: 'salesforce',
       targetBaseUrl: 'https://salesforce.internal',
-      idempotencyRepository,
       processRecord: () => {
         if (shouldFail) {
           shouldFail = false;
@@ -317,15 +285,6 @@ describe('createIntegrationConsumerHandler', () => {
     });
     expect(secondAttempt).toEqual({
       batchItemFailures: [],
-    });
-    expect(
-      idempotencyRepository.tryClaimCalls
-        .filter((claim) => claim.scope === 'consumer')
-        .map((claim) => claim.status),
-    ).toEqual(['PENDING', 'PENDING']);
-    expect(idempotencyRepository.markCompletedCalls).toHaveLength(1);
-    expect(idempotencyRepository.markCompletedCalls[0]).toMatchObject({
-      deduplicationKey: 'consumer:salesforce:exec-1:1',
     });
   });
 });


### PR DESCRIPTION
## Resumo
- remove o uso de `idempotencyRepository` em `createIntegrationConsumerHandler`
- aplica deduplicação no batch SQS usando somente `correlationId`
- simplifica `salesforce-consumer` e `hubspot-consumer` removendo bootstrap de idempotência persistida
- remove permissões IAM de escrita na tabela de idempotência das consumidoras
- atualiza testes unitários das consumidoras/handler compartilhado e documentação no README

## 🧪 BDD
- **Given** um evento `customer.persisted` publicado no SNS com `tenantId` e `correlationId`
- **When** a Lambda consumidora processa o record e envia para a API externa
- **Then** o `correlationId` segue único como chave de deduplicação e `tenantId` permanece apenas para observabilidade
- **And** múltiplos eventos com o mesmo `correlationId` são descartados mesmo que venham de tenants diferentes

## 🔥 Tipo de Release
- [x] `patch`
- [ ] `minor`
- [ ] `major`

## ✅ Checklist
- [x] `createIntegrationConsumerHandler` não chama mais `idempotencyRepository`
- [x] consumers na feature branch usam apenas `correlationId`
- [x] testes e README atualizados
- [x] `npm run lint && npm run test` executados localmente

## Validação
- npm run lint
- npm run test

Closes #189